### PR TITLE
Use `compile` vs `api`.

### DIFF
--- a/mantis-server/mantis-server-worker/build.gradle
+++ b/mantis-server/mantis-server-worker/build.gradle
@@ -17,29 +17,28 @@
 apply plugin: 'eu.appsatori.fatjar'
 
 ext {
-    mantisControlPlaneVersion = '1.+'
+    mantisControlPlaneVersion = '1.2.+'
     mesosVersion = '1.0.1'
     httpComponentsVersion = '4.5.6'
 }
 
 dependencies {
-    api project(':mantis-runtime')
-    api "io.mantisrx:mantis-control-plane-core:$mantisControlPlaneVersion"
-    api "io.mantisrx:mantis-control-plane-client:$mantisControlPlaneVersion"
-    api project(':mantis-server:mantis-server-worker-client')
+    compile project(':mantis-runtime')
+    compile "io.mantisrx:mantis-control-plane-core:$mantisControlPlaneVersion"
+    compile "io.mantisrx:mantis-control-plane-client:$mantisControlPlaneVersion"
+    compile project(':mantis-server:mantis-server-worker-client')
 
-    api "org.apache.mesos:mesos:$mesosVersion"
-    api "org.slf4j:slf4j-api:$slf4jVersion"
-    implementation "org.slf4j:slf4j-log4j12:$slf4jVersion"
-    implementation 'io.vavr:vavr:0.9.2'
-    implementation 'io.vavr:vavr-jackson:0.9.2'
-    implementation('nz.ac.waikato.cms.moa:moa:2017.06') {
+    compile "org.apache.mesos:mesos:$mesosVersion"
+    compile "org.slf4j:slf4j-api:$slf4jVersion"
+    compile "org.slf4j:slf4j-log4j12:$slf4jVersion"
+    compile 'io.vavr:vavr:0.9.2'
+    compile 'io.vavr:vavr-jackson:0.9.2'
+    compile('nz.ac.waikato.cms.moa:moa:2017.06') {
         exclude group: 'com.github.spullara.cli-parser', module: 'cli-parser'
         exclude group: 'org.pentaho.pentaho-commons', module: 'pentaho-package-manager'
     }
-    api "org.apache.httpcomponents:httpclient:$httpComponentsVersion"
-    api 'io.mantisrx:mantis-rxcontrol:1.+'
-
+    compile "org.apache.httpcomponents:httpclient:$httpComponentsVersion"
+    compile 'io.mantisrx:mantis-rxcontrol:1.+'
 
     testImplementation "junit:junit-dep:$junitVersion"
     testImplementation "org.mockito:mockito-all:$mockitoVersion"


### PR DESCRIPTION
### Context

The `api` feature isn't compatible with this version of fatJar. This
causes problems when mantis workers try to load the
`io.mantisrx.server.worker.MantisWorker` class since it extends
`BaseService` which won't exist in the fatJar without `compile`.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
