### PR TITLE
Use older mkdocs pages vs nav.

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Mantis
-nav:
+pages:
   - 'Welcome': 'index.md'
   - User Guides:
     - Writing Mantis Jobs:


### PR DESCRIPTION
We can move to nav once we upgrade. For now, keep syntax consistent with
older version of mkdoc.

### Context

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
