### PR TITLE
Additional documentation fixes

### DIFF
--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -9,7 +9,7 @@ You can install the Mantis CLI locally in your development environment by follow
 on the [Mantis CLI Readme](https://github.com/netflix/mantis-cli#getting-started).
 
 Additionally, you can install the Mantis CLI onto your system as a package by following instructions
-on the [Mantis CLI Release](https://github.com/netflix/mantis-cli#releasing) section of the readme.
+on the [Mantis CLI Releasing](https://github.com/netflix/mantis-cli#releasing) section of the readme.
 
 ## Mantis Commands
 
@@ -69,10 +69,10 @@ To do this issue the following command:
 
 By default, the Mantis CLI bootstrap command is interactive and will prompt you for provisioning choices. Additionally, you can pass the following command-line parameters to skip some of the prompts from the `mantis aws:bootstrap` command:
 
-| prompt                           | parameter                        | valid inputs |
-| -------------------------------- | -------------------------------- | ------------ |
-| **select a region**              | [`-r`\|`--region`] *`region`*    | us-east-1, us-east-2, us-west-2  |
-| **confirm**                      | -y                               | n/a |
+| prompt                 | parameter                        | valid inputs |
+| ---------------------- | -------------------------------- | ------------ |
+| **select a region**    | [`-r`\|`--region`] *`region`*    | `us-east-1`, `us-east-2`, `us-west-2` |
+| **confirm**            | `-y`                             | n/a |
 
 After you have finished executing the `mantis aws:bootstrap` command, you can submit [Jobs] into the
 Mantis cluster that it creates.

--- a/docs/docs/mantisapi/index.md
+++ b/docs/docs/mantisapi/index.md
@@ -1,4 +1,4 @@
-In addition to the [Mantis UI](mantisui), there is a REST API with which you can maintain
+In addition to the Mantis UI, there is a REST API with which you can maintain
 [Mantis Jobs] and [Job Clusters]. This page describes the open source version of the Mantis REST
 API.
 

--- a/docs/docs/writingjobs/index.md
+++ b/docs/docs/writingjobs/index.md
@@ -4,11 +4,11 @@ another Observable stream.
 
 [RxJava] Observables can be visualized by using “marble diagrams”:
 
-![RxJava Observables can be represented by “marble diagrams”](/images/observables.svg)
+![RxJava Observables can be represented by “marble diagrams”](/mantis/images/observables.svg)
 
 You can combine multiple RxJava operators to transform an Observable stream of items in many ways:
 
-![An incoming stream is processed by a Mantis Job composed of the operators map and merge, to compose an output stream](/images/complex.svg)
+![An incoming stream is processed by a Mantis Job composed of the operators map and merge, to compose an output stream](/mantis/images/complex.svg)
 
 The above diagram shows a Mantis Job composed of two operators that process an input stream to
 compose an output stream. The first operator, `map`, emits a new Observable for each item emitted by
@@ -22,7 +22,7 @@ If the volume of data to be processed is too large for a single [worker] to hand
 and conquer” by grouping and dividing the operators across various [processing stages], as in the
 following diagram:
 
-![An incoming stream is processed by a Mantis Job composed of three stages, one composed of the groupBy operator, the second by the window and reduce operators, and the third composed of the merge operator, together resulting in an output stream](/images/stages.svg)
+![An incoming stream is processed by a Mantis Job composed of three stages, one composed of the groupBy operator, the second by the window and reduce operators, and the third composed of the merge operator, together resulting in an output stream](/mantis/images/stages.svg)
 
 ## Mantis Job Clusters
 
@@ -48,7 +48,7 @@ documentation:
 
 1. [**Sink**](sink) — Pushes the resulting Observable out in the form of a fresh stream.
 
-![A Mantis Job is composed of three components: the “Source” fetches data in a streaming, non-blocking, back-pressure-aware manner; the “Stage” transforms the incoming stream by applying high-level functions such as map, scan, reduce, et cetera; the “Sink” pushes the results of the transformation in a non-blocking, asynchronous manner.](/images/job-components.svg)
+![A Mantis Job is composed of three components: the “Source” fetches data in a streaming, non-blocking, back-pressure-aware manner; the “Stage” transforms the incoming stream by applying high-level functions such as map, scan, reduce, et cetera; the “Sink” pushes the results of the transformation in a non-blocking, asynchronous manner.](/mantis/images/job-components.svg)
 
 ## Directory Structure of a Mantis Job
 

--- a/docs/docs/writingjobs/source.md
+++ b/docs/docs/writingjobs/source.md
@@ -20,7 +20,7 @@ You can string Mantis Jobs together by using the output of one Mantis Job as the
 This is useful if you want to break up your processing into multiple, reusable components and to
 take advantage of code and data reuse.
 
-In such a case, you do not have access to the complete set of [Mantis Query Language (MQL)](/MQL)
+In such a case, you do not have access to the complete set of [Mantis Query Language (MQL)](/mantis/MQL)
 capabilities that you do in the case of a Source Job, but you can use MQL in client mode.
 
 #### Connecting to a Mantis Job
@@ -61,7 +61,7 @@ There are two advantages to this approach:
 
 1. Source Jobs handle all of the implementation details around interacting with the native data
    source.
-1. Source Jobs come with a simple query interface based on the [Mantis Query Language (MQL)](/MQL),
+1. Source Jobs come with a simple query interface based on the [Mantis Query Language (MQL)](/mantis/MQL),
    which allows you to filter the data from the source before processing it. In the case of source
    jobs that fetch data from application servers directly, this filter gets pushed all the way to
    those target servers so that no data flows unless someone is asking for it.
@@ -86,7 +86,7 @@ The difference is that you should pass in additional parameters:
 
 1. `sourceJobName` *(required)* — the name of the source Job Cluster you want to connect to
 1. `sample` *(required)* — use this if you want to [sample] the output `sample` times per second, or set this to `-1` to disable sampling
-1. `criterion` *(required)* — a query expression in [MQL](/MQL) to filter the source
+1. `criterion` *(required)* — a query expression in [MQL](/mantis/MQL) to filter the source
 1. `clientId` *(optional)* — by default, the `jobId` of the client Job; the Source Job uses this to distribute data between all the subscriptions of the client Job
 1. `enableMetaMessages` *(optional)* — the source job may occasionally inject [meta messages] (with the prefix `mantis.meta.`) that indicate things like data drops on the Source Job side.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,27 +1,26 @@
 site_name: Mantis
 nav:
   - 'Welcome': 'index.md'
-  - User Guides:
-    - Writing Mantis Jobs:
-      - 'Introduction': 'writingjobs/index.md'
-      - 'The Source Component': 'writingjobs/source.md'
-      - 'The Processing Stage Component': 'writingjobs/stage.md'
-      - 'The Sink Component': 'writingjobs/sink.md'
-    - MQL:
-      - 'Introduction': 'MQL/index.md'
-      - 'Operators': 'MQL/operators.md'
-      - 'Sampling': 'MQL/sampling.md'
-      - 'Scaling Limits': 'MQL/aggregation-scaling-limits.md'
-    - 'Mantis Job Autoscaling': 'autoscaling.md'
-    - 'Publishing Events to Mantis': 'internals/mre.md'
-    - The Mantis API:
-        - 'API Reference': 'mantisapi/index.md'
-        - 'Mantis Websocket API': 'mantisapi/websocket.md'
-    - 'The Mantis CLI': 'cli.md'
-    - Mantis Internals:
-        - 'Mantis Source Jobs': 'internals/sourcejobs.md'
-        - 'Mantis Runtime': 'internals/runtime.md'
-    - 'Mantis Job Capacity Planning & Sizing': 'capacity.md'
+  - Writing Mantis Jobs:
+    - 'Introduction': 'writingjobs/index.md'
+    - 'The Source Component': 'writingjobs/source.md'
+    - 'The Processing Stage Component': 'writingjobs/stage.md'
+    - 'The Sink Component': 'writingjobs/sink.md'
+  - MQL:
+    - 'Introduction': 'MQL/index.md'
+    - 'Operators': 'MQL/operators.md'
+    - 'Sampling': 'MQL/sampling.md'
+    - 'Scaling Limits': 'MQL/aggregation-scaling-limits.md'
+  - 'Mantis Job Autoscaling': 'autoscaling.md'
+  - 'Publishing Events to Mantis': 'internals/mre.md'
+  - The Mantis API:
+      - 'API Reference': 'mantisapi/index.md'
+      - 'Mantis Websocket API': 'mantisapi/websocket.md'
+  - 'The Mantis CLI': 'cli.md'
+  - Mantis Internals:
+      - 'Mantis Source Jobs': 'internals/sourcejobs.md'
+      - 'Mantis Runtime': 'internals/runtime.md'
+  - 'Mantis Job Capacity Planning & Sizing': 'capacity.md'
   - 'FAQ': 'faq.md'
   - 'Glossary': 'glossary.md'
 theme:


### PR DESCRIPTION
Documentation-only changes: Fix internal links to account for "mantis/" subdirectory. Squish TOC hierarchy.