### PR TITLE
Download job artifacts from mantis api in docker setup.

### DIFF
--- a/mantis-server/mantis-server-worker/Dockerfile
+++ b/mantis-server/mantis-server-worker/Dockerfile
@@ -19,6 +19,8 @@ RUN sudo apt-get install -y --no-install-recommends software-properties-common
 RUN sudo apt-get install -y python-software-properties debconf-utils
 RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
 RUN sudo apt-add-repository "deb http://repos.azulsystems.com/ubuntu stable main"
+RUN sudo apt-get install -y unzip
+RUN sudo apt-get install wget
 RUN sudo apt-get update
 RUN sudo apt-get install -y zulu-8
 


### PR DESCRIPTION
### Context

Update the mantisagent in docker to download the mantis artifacts from mantisui. This allows us to create multiple different job clusters.

### Checklist

- [x ] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
