### PR TITLE
Added a local docker compose file that uses locally build docker images.

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -1,0 +1,116 @@
+# Compose file that brings up ZK, Mesos, Mantis Agent, and Mantis Master in their own containers.
+# Each container is using "host" networking to ensure they can communicate.
+
+# The ZK and Mesos images are currently pulled from Docker Hub.
+# The Mantis Master and Mantis Agent images are expected to exist
+# locally, built from the Dockerfile in their Stash repos so that
+# the local developer's control which version is being built.
+
+version: '3'
+services:
+
+  zookeeper:
+    image: jplock/zookeeper:3.4.6
+    ports:
+      - "2181:2181"
+    networks:
+      mantis_net:
+        ipv4_address: 172.16.186.3
+
+  # Start mesos-master
+  mesos-master:
+    image: mesosphere/mesos-master:1.0.1-2.0.93.ubuntu1404
+    ports:
+      - "5050:5050"
+    command: mesos-master --zk=zk://zookeeper:2181/mantis/mesos/nmahilani --work_dir=/tmp/master --log_dir=/var/log/mesos --logging_level=INFO --quorum=1
+    depends_on:
+      - zookeeper
+    networks:
+      mantis_net:
+        ipv4_address: 172.16.186.4
+
+  # MantisMaster local build
+  mantismaster:
+    image: dev/mantiscontrolplaneserver
+    ports:
+      - "8100:8100"
+      - "5005:5005"
+    depends_on:
+      - mesos-master
+    environment:
+      JAVA_OPTS: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Dmantis.zookeeper.connectString=zookeeper:2181 -Dmesos.master.location=mesos-master:5050 -Dmantis.master.exit.on.losing.leader=false"
+    volumes:
+      - ./localdev/conf/:/apps/mantis/mantis-control-plane-server/localconf/
+    networks:
+      mantis_net:
+        ipv4_address: 172.16.186.5
+
+  # Start Mantis executor
+  mantisagent:
+    image: dev/mantisagent
+    ports:
+      - "5051:5051"
+    privileged: true
+    command:
+      mesos-slave \
+      --master=zk://zookeeper:2181/mantis/mesos/nmahilani \
+      --log_dir=/var/log/mesos/                            \
+      --work_dir=/tmp/mesos_workdir                        \
+      --logging_level=INFO                                 \
+      --hostname=mantisagent                                \
+      --resources="ports:[7150-7400];ephemeral_ports:[32768-57344];network:1000"                           \
+      --attributes="region:laptop;asg:mantisagent-laptop-v001;stack:laptop;zone:laptopd;itype:macbook.pro;cluster:mantisagent-laptop;id:l-deadbeef;res:ResourceSet-ENIs-7-29"
+    depends_on:
+      - zookeeper
+    volumes:
+      - ./localdev/conf/:/mnt/local/mantisWorkerInstall/jobs/
+    #      - ./mantis-server/mantis-server-worker/src/main/resources/startup_docker.sh:/mnt/local/mantisWorkerInstall/bin/startup_docker.sh
+    networks:
+      mantis_net:
+        ipv4_address: 172.16.186.6
+  #
+  mantisapi:
+    image: dev/mantisapi
+    ports:
+      - "7101:7101"
+      - "5006:5006"
+    environment:
+      JAVA_OPTS: "-Dmantis.zookeeper.connectString=zookeeper:2181 -Dmantissapi.master.host=mantismaster -Dmantisapi.master.ip=172.16.186.5 -Dmantisapi.master.port=8100"
+      NETFLIX_ENVIRONMENT: test
+      NETFLIX_ACCOUNT: test
+      NETFLIX_STACK: desktop
+    depends_on:
+      - mantismaster
+    networks:
+      mantis_net:
+        ipv4_address: 172.16.186.7
+
+   #
+  mantispublishweb:
+    image: dev/mantispublishweb
+    ports:
+      - "80:8080"
+    depends_on:
+      - mantisapi
+    networks:
+      mantis_net:
+        ipv4_address: 172.16.186.8
+
+  mantispublish:
+    image: dev/mantispublish
+    ports:
+      - "81:8180"
+    depends_on:
+      - mantisapi
+    networks:
+      mantis_net:
+        ipv4_address: 172.16.186.9
+
+networks:
+  mantis_net:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        -
+          subnet: 172.16.186.0/24

--- a/mantis-server/mantis-server-worker/buildDockerImage.sh
+++ b/mantis-server/mantis-server-worker/buildDockerImage.sh
@@ -4,6 +4,6 @@
 ../../gradlew clean fatJar
 
 # build the Docker image that packages the mantis-server-worker along with a running mesos-slave
-docker build -t netflixoss/mantisagent .
+docker build -t dev/mantisagent .
 
-echo "Created Docker image 'netflixoss/mantisagent'"
+echo "Created Docker image 'dev/mantisagent'"


### PR DESCRIPTION
### Context

A local docker compose file to be used while building docker images locally

### Checklist

- [x ] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
