### PR TITLE
Travis CI: Update environment, OpenJDK and CPU platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: java
-dist: bionic
-jdk: openjdk13
-arch:
- - amd64
- - arm64
+
+jobs:
+  include:
+    - jdk: openjdk8
+    - jdk: openjdk8
+      arch: arm64
+    - jdk: openjdk13
 
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: java
 dist: bionic
 jdk: openjdk13
+arch:
+ - amd64
+ - arm64
+
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
-jdk: openjdk8
+dist: bionic
+jdk: openjdk13
 install: "./installViaTravis.sh"
 script: "./buildViaTravis.sh"
 cache:


### PR DESCRIPTION
### Context

Update the Travis CI configuration:
 - Update build environment to Ubuntu 18.04 Bionic
 - Update OpenJDK version to 13.x (currently 13.0.1)
 - Add a job executed on ARMv8 CPU.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] `./gradlew test` passes all tests
