### PR TITLE
Update the way we set Netty low and high water marks

### DIFF
--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/LegacyTcpPushServer.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/LegacyTcpPushServer.java
@@ -28,6 +28,7 @@ import io.mantisrx.common.metrics.Metrics;
 import io.mantisrx.common.metrics.MetricsRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.codec.compression.JdkZlibDecoder;
@@ -166,8 +167,7 @@ public class LegacyTcpPushServer<T> extends PushServer<T, RemoteRxEvent> {
 
                             }
                         }, new LegacyTcpPipelineConfigurator(name)))
-                .channelOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 5 * 1024 * 1024)
-                .channelOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 1024 * 1024)
+                .channelOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(1024 * 1024, 5 * 1024 * 1024))
 
                 .build();
         return server;

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServerSse.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServerSse.java
@@ -27,6 +27,7 @@ import io.mantisrx.mql.shaded.clojure.java.api.Clojure;
 import io.mantisrx.mql.shaded.clojure.lang.IFn;
 import com.netflix.spectator.api.BasicTag;
 import io.mantisrx.mql.jvm.core.Query;
+import io.netty.channel.WriteBufferWaterMark;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -313,9 +314,8 @@ public class PushServerSse<T, S> extends PushServer<T, ServerSentEvent> {
                     }
                 })
                 .pipelineConfigurator(PipelineConfigurators.serveSseConfigurator())
+                .channelOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(1024 * 1024, 5 * 1024 * 1024))
 
-                .channelOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 5 * 1024 * 1024)
-                .channelOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 1024 * 1024)
                 .build();
         return server;
     }

--- a/mantis-remote-observable/src/main/java/io/reactivex/mantis/remote/observable/RemoteRxServer.java
+++ b/mantis-remote-observable/src/main/java/io/reactivex/mantis/remote/observable/RemoteRxServer.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import io.mantisrx.server.core.ServiceRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.codec.compression.JdkZlibDecoder;
@@ -104,8 +105,8 @@ public class RemoteRxServer {
 
                             }
                         }, new BatchedRxEventPipelineConfigurator()))
-                .channelOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 5 * 1024 * 1024)
-                .channelOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 1024 * 1024)
+                .channelOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(1024 * 1024, 5 * 1024 * 1024))
+
                 .build();
 
         this.server = server;

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/TestSseServerFactory.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/TestSseServerFactory.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.WriteBufferWaterMark;
 import mantis.io.reactivex.netty.RxNetty;
 import mantis.io.reactivex.netty.pipeline.PipelineConfigurators;
 import mantis.io.reactivex.netty.protocol.http.server.HttpServer;
@@ -61,8 +62,8 @@ public class TestSseServerFactory {
                     }
                 })
                 .pipelineConfigurator(PipelineConfigurators.<String>serveSseConfigurator())
-                .channelOption(ChannelOption.WRITE_BUFFER_HIGH_WATER_MARK, 5 * 1024 * 1024)
-                .channelOption(ChannelOption.WRITE_BUFFER_LOW_WATER_MARK, 1024 * 1024)
+                .channelOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(1024 * 1024, 5 * 1024 * 1024))
+                
                 .build();
         server.start();
         synchronized (servers) {


### PR DESCRIPTION
### Context

Replace the deprecated way of setting netty low and high water marks.

### Checklist

- [ x] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
