### PR TITLE
Update Mesos to 1.1.3.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
   # Start mesos-master
   mesos-master:
-    image: mesosphere/mesos-master:1.0.1-2.0.93.ubuntu1404
+    image: mesosphere/mesos-master:1.1.3
     ports:
       - "5050:5050"
     command: mesos-master --zk=zk://zookeeper:2181/mantis/mesos/nmahilani --work_dir=/tmp/master --log_dir=/var/log/mesos --logging_level=INFO --quorum=1

--- a/mantis-server/mantis-server-worker/Dockerfile
+++ b/mantis-server/mantis-server-worker/Dockerfile
@@ -1,6 +1,10 @@
-FROM mesosphere/mesos-slave-dind:0.2.4_mesos-1.0.1_docker-1.12.1_ubuntu-14.04.5
+FROM mesosphere/mesos-slave:1.1.3
 
 MAINTAINER Mantis Developers <mantisd-oss-dev@netflix.com>
+
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
+
+ENV MESOS_SYSTEMD_ENABLE_SUPPORT false
 
 # Setup mantis-agent environment
 RUN mkdir -p /mnt/local/mantisWorkerInstall/bin/
@@ -11,19 +15,17 @@ RUN mkdir -p /mnt/local/mantisWorkerInstall/jobs/
 COPY ./src/main/resources/startup_docker.sh /mnt/local/mantisWorkerInstall/bin/
 COPY ./build/libs/mantis-server-worker*.jar /mnt/local/mantisWorkerInstall/libs/
 COPY worker-docker.properties /mnt/local/mantisWorkerInstall/jobs/
-# Set up Java 8
-#ENV DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
-#ENV CODENAME=$(lsb_release -cs)
 
-RUN sudo apt-get update
-RUN sudo apt-get install -y --no-install-recommends software-properties-common
-RUN sudo apt-get install -y python-software-properties debconf-utils
-RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
-RUN sudo apt-add-repository "deb http://repos.azulsystems.com/ubuntu stable main"
-RUN sudo apt-get install -y unzip
-RUN sudo apt-get install wget
-RUN sudo apt-get update
-RUN sudo apt-get install -y zulu-8
+# Set up Java 8
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends software-properties-common
+RUN apt-get install -y python3-software-properties debconf-utils
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9
+RUN apt-add-repository "deb http://repos.azulsystems.com/ubuntu stable main"
+RUN apt-get install -y unzip
+RUN apt-get install wget
+RUN apt-get update
+RUN apt-get install -y zulu-8
 
 
 # Make it look like we're running in VPC to test networking

--- a/mantis-server/mantis-server-worker/build.gradle
+++ b/mantis-server/mantis-server-worker/build.gradle
@@ -18,7 +18,7 @@ apply plugin: 'eu.appsatori.fatjar'
 
 ext {
     mantisControlPlaneVersion = '1.2.+'
-    mesosVersion = '1.0.4'
+    mesosVersion = '1.1.3'
     httpComponentsVersion = '4.5.6'
 }
 

--- a/mantis-server/mantis-server-worker/buildDockerImage.sh
+++ b/mantis-server/mantis-server-worker/buildDockerImage.sh
@@ -4,6 +4,6 @@
 ../../gradlew clean fatJar
 
 # build the Docker image that packages the mantis-server-worker along with a running mesos-slave
-docker build -t dev/mantisagent .
+docker build -t netflixoss/mantisagent .
 
-echo "Created Docker image 'dev/mantisagent'"
+echo "Created Docker image 'netflixoss/mantisagent'"


### PR DESCRIPTION
### Context

Includes updating Dockerfile Mesos refs to 1.1.3 and updating the JDK
image to Azul JDK 8 and fixing migration bugs along the way.

The JDK 8 image runs Ubuntu Xenial (which is more in line with our testing infrastructure) as opposed to an older version on Debian.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
