### PR TITLE
Added RPS metric for autoscaler.

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageScalingPolicy.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageScalingPolicy.java
@@ -177,7 +177,8 @@ public class StageScalingPolicy {
         UserDefined,
         KafkaProcessed,
         Clutch,
-        ClutchExperimental
+        ClutchExperimental,
+        RPS
     }
 
     public static class RollingCount {

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/jobmaster/WorkerMetrics.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/jobmaster/WorkerMetrics.java
@@ -22,6 +22,7 @@ import static io.mantisrx.server.core.stats.MetricStringConstants.DROP_PERCENT;
 import static io.mantisrx.server.core.stats.MetricStringConstants.ON_NEXT_COUNT;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,8 +48,14 @@ public class WorkerMetrics {
                 final double totalCount = dropCount + onNextCount;
                 if (totalCount > 0.0) {
                     final double dropPercent = (dropCount * 100.0) / totalCount;
-                    return new GaugeData(data.getWhen(), Collections.singletonMap(DROP_PERCENT, dropPercent));
+
+                    Map<String, Double> newGauges = new HashMap<>(2);
+                    newGauges.put(DROP_PERCENT, dropPercent);
+                    newGauges.put(ON_NEXT_COUNT, gauges.get(ON_NEXT_COUNT));
+                    return new GaugeData(data.getWhen(), newGauges);
                 }
+            } else if (gauges.containsKey(ON_NEXT_COUNT)) {
+                return new GaugeData(data.getWhen(), Collections.singletonMap(ON_NEXT_COUNT, gauges.get(ON_NEXT_COUNT)));
             }
             return new GaugeData(data.getWhen(), Collections.emptyMap());
         }


### PR DESCRIPTION
RPS is a measure of onNext / metricsInterval. This provides a measure of
work which can be used to autoscale via Clutch.

### Context

We need an abstract measure of "work" being done by a Mantis job. In the past RPS has been useful for this, and the first iteration of clutch actually used RPS. Our issue there was correctly selecting an RPS value was tricky and it was only present for Kafka jobs. We've since learned;

- How to select setpoints by recording sketches and using percentiles.
- How Lag/Drops can be incorporated into RPS in a manner that a PID understands.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
