### PR TITLE
Add validator for `WorkerPorts`.

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/WorkerPorts.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/WorkerPorts.java
@@ -17,7 +17,9 @@
 package io.mantisrx.common;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -35,8 +37,8 @@ public class WorkerPorts {
     private List<Integer> ports;
 
     public WorkerPorts(final List<Integer> assignedPorts) {
-        if (!(assignedPorts.size() >= 4)) {
-            throw new IllegalArgumentException("assignedPorts should be >= 4");
+        if (assignedPorts.size() < 4) {
+            throw new IllegalArgumentException("assignedPorts should have at least 4 ports");
         }
         this.metricsPort = assignedPorts.get(0);
         this.debugPort = assignedPorts.get(1);
@@ -117,6 +119,20 @@ public class WorkerPorts {
 
     public List<Integer> getPorts() {
         return ports;
+    }
+
+    /**
+     * Validates that this object has 5 valid ports and all of them are unique.
+     */
+    public boolean isValid() {
+        Set<Integer> uniquePorts = new HashSet<>();
+        uniquePorts.add(metricsPort);
+        uniquePorts.add(consolePort);
+        uniquePorts.add(debugPort);
+        uniquePorts.add(customPort);
+        uniquePorts.add(sinkPort);
+        return metricsPort > 0 && consolePort > 0 && debugPort > 0 && customPort > 0 && sinkPort > 0
+                && uniquePorts.size() == 5;
     }
 
     @Override

--- a/mantis-common/src/test/java/io/mantisrx/common/WorkerPortsTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/common/WorkerPortsTest.java
@@ -1,0 +1,47 @@
+package io.mantisrx.common;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class WorkerPortsTest {
+
+    /**
+     * Uses legacy constructor {@link WorkerPorts#WorkerPorts(List)} which expects
+     * at least 4 ports: metrics, debug, console, custom.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotConstructWorkerPorts() {
+        new WorkerPorts(Arrays.asList(1, 1, 1));
+    }
+
+    /**
+     * Uses legacy constructor {@link WorkerPorts#WorkerPorts(List)} which can construct
+     * a WorkerPorts object, but is technically invalid because a worker needs a sink
+     * to be useful. Otherwise, other workers can't connect to it.
+     */
+    @Test
+    public void shouldConstructInvalidWorkerPorts() {
+        // Not enough ports.
+        WorkerPorts workerPorts = new WorkerPorts(Arrays.asList(1, 1, 1, 1));
+        assertFalse(workerPorts.isValid());
+
+        // Enough ports, but has duplicate ports.
+        workerPorts = new WorkerPorts(Arrays.asList(1, 1, 1, 1, 1));
+        assertFalse(workerPorts.isValid());
+    }
+
+    /**
+     * Uses legacy constructor {@link WorkerPorts#WorkerPorts(List)}.
+     */
+    @Test
+    public void shouldConstructValidWorkerPorts() {
+        WorkerPorts workerPorts = new WorkerPorts(Arrays.asList(1, 2, 3, 4, 5));
+        assertTrue(workerPorts.isValid());
+    }
+}


### PR DESCRIPTION
Mantis Master uses the legacy constructor. This is now tested and
documented right in the test.

Intent is to add validation to this class so we can validate it from the
Master side when it goes to initialize running workers. If validation
fails, this is considered a precondition which the Master will fail out
the worker. All invalid workers will be resubmitted together after the
launch sequence so they can try to get new port allocations.

### Context

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
