### PR TITLE
Minor: Fail construction of `WorkerPorts` if not enough ports.

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/WorkerPorts.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/WorkerPorts.java
@@ -37,8 +37,8 @@ public class WorkerPorts {
     private List<Integer> ports;
 
     public WorkerPorts(final List<Integer> assignedPorts) {
-        if (assignedPorts.size() < 4) {
-            throw new IllegalArgumentException("assignedPorts should have at least 4 ports");
+        if (assignedPorts.size() < 5) {
+            throw new IllegalArgumentException("assignedPorts should have at least 5 ports");
         }
         this.metricsPort = assignedPorts.get(0);
         this.debugPort = assignedPorts.get(1);
@@ -50,6 +50,10 @@ public class WorkerPorts {
 
             sinkPort = assignedPorts.get(idx);
             break;
+        }
+
+        if (!isValid()) {
+            throw new IllegalStateException("worker validation failed on port allocation");
         }
     }
 
@@ -122,7 +126,7 @@ public class WorkerPorts {
     }
 
     /**
-     * Validates that this object has 5 valid ports and all of them are unique.
+     * Validates that this object has at least 5 valid ports and all of them are unique.
      */
     public boolean isValid() {
         Set<Integer> uniquePorts = new HashSet<>();
@@ -131,8 +135,21 @@ public class WorkerPorts {
         uniquePorts.add(debugPort);
         uniquePorts.add(customPort);
         uniquePorts.add(sinkPort);
-        return metricsPort > 0 && consolePort > 0 && debugPort > 0 && customPort > 0 && sinkPort > 0
-                && uniquePorts.size() == 5;
+
+        return uniquePorts.size() >= 5
+                && isValidPort(metricsPort)
+                && isValidPort(consolePort)
+                && isValidPort(debugPort)
+                && isValidPort(customPort)
+                && isValidPort(sinkPort);
+    }
+
+    /**
+     * A port with 0 is technically correct, but we disallow it because there would be an inconsistency between
+     * what unused port the OS selects (some port number) and what this object's metadata holds (0).
+     */
+    private boolean isValidPort(int port) {
+        return port > 0 && port <= 65535;
     }
 
     @Override

--- a/mantis-common/src/test/java/io/mantisrx/common/WorkerPortsTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/common/WorkerPortsTest.java
@@ -1,11 +1,10 @@
 package io.mantisrx.common;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Before;
 import org.junit.Test;
 
 
@@ -13,27 +12,33 @@ public class WorkerPortsTest {
 
     /**
      * Uses legacy constructor {@link WorkerPorts#WorkerPorts(List)} which expects
-     * at least 4 ports: metrics, debug, console, custom.
+     * at least 5 ports: metrics, debug, console, custom.
      */
     @Test(expected = IllegalArgumentException.class)
     public void shouldNotConstructWorkerPorts() {
-        new WorkerPorts(Arrays.asList(1, 1, 1));
+        // Not enough ports.
+        new WorkerPorts(Arrays.asList(1, 1, 1, 1));
     }
 
     /**
-     * Uses legacy constructor {@link WorkerPorts#WorkerPorts(List)} which can construct
-     * a WorkerPorts object, but is technically invalid because a worker needs a sink
-     * to be useful. Otherwise, other workers can't connect to it.
+     * Uses legacy constructor {@link WorkerPorts#WorkerPorts(List)} which cannot construct
+     * a WorkerPorts object, because a worker needs a sink to be useful.
+     * Otherwise, other workers can't connect to it.
      */
-    @Test
-    public void shouldConstructInvalidWorkerPorts() {
-        // Not enough ports.
-        WorkerPorts workerPorts = new WorkerPorts(Arrays.asList(1, 1, 1, 1));
-        assertFalse(workerPorts.isValid());
-
+    @Test(expected = IllegalStateException.class)
+    public void shouldNotConstructWorkerPortsWithDuplicatePorts() {
         // Enough ports, but has duplicate ports.
-        workerPorts = new WorkerPorts(Arrays.asList(1, 1, 1, 1, 1));
-        assertFalse(workerPorts.isValid());
+        new WorkerPorts(Arrays.asList(1, 1, 1, 1, 1));
+    }
+
+    /**
+     * Uses legacy constructor {@link WorkerPorts#WorkerPorts(List)} but was given a port
+     * out of range.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void shouldNotConstructWorkerPortsWithInvalidPortRange() {
+        // Enough ports, but given an invalid port range
+        new WorkerPorts(Arrays.asList(1, 1, 1, 1, 65536));
     }
 
     /**


### PR DESCRIPTION
### Context

Need at least 5 ports.

Mantis Master calls `WorkerPorts#new(List)` from
`SchedulingService#launchTasks`. If Mesos doesn't give it enough ports,
it will mark the launch as a failure and unschedule the worker
(`SchedulingService#unscheduleWorker`) right at that moment.

Keeping the `isValid` function in case a caller wants to use it.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
