### PR TITLE
Create a single instance of MetricGroupId for SSE

### DIFF
--- a/mantis-client/src/main/java/io/mantisrx/client/SseSinkConnectionFunction.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SseSinkConnectionFunction.java
@@ -16,6 +16,8 @@
 
 package io.mantisrx.client;
 
+import static com.mantisrx.common.utils.MantisMetricStringConstants.DROP_OPERATOR_INCOMING_METRIC_GROUP;
+
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -44,6 +46,7 @@ public class SseSinkConnectionFunction implements SinkConnectionFunc<MantisServe
     private static final String DEFAULT_BUFFER_SIZE_STR = "0";
     private static final Logger logger = LoggerFactory.getLogger(SseSinkConnectionFunction.class);
     private static final CopyOnWriteArraySet<MetricGroupId> metricsSet = new CopyOnWriteArraySet<>();
+    private static final MetricGroupId metricGroupId;
     private static final Action1<Throwable> defaultConxResetHandler = new Action1<Throwable>() {
         @Override
         public void call(Throwable throwable) {
@@ -59,7 +62,8 @@ public class SseSinkConnectionFunction implements SinkConnectionFunc<MantisServe
         // Use single netty thread
         NettyUtils.setNettyThreads();
 
-
+        metricGroupId = new MetricGroupId(DROP_OPERATOR_INCOMING_METRIC_GROUP + "_Sse" + "Sink" + "ConnectionFunction_withBuffer");
+        metricsSet.add(metricGroupId);
         logger.info("SETTING UP METRICS PRINTER THREAD");
         new ScheduledThreadPoolExecutor(1).scheduleWithFixedDelay(new Runnable() {
             @Override
@@ -124,7 +128,7 @@ public class SseSinkConnectionFunction implements SinkConnectionFunc<MantisServe
             private final SseWorkerConnection workerConn =
                     new SseWorkerConnection("Sink", hostname, port, updateConxStatus, updateDataRecvngStatus,
                             connectionResetHandler, dataRecvTimeoutSecs, reconnectUponConnectionRest, metricsSet,
-                            bufferSize, sinkParameters, disablePingFiltering);
+                            bufferSize, sinkParameters, disablePingFiltering,metricGroupId);
 
             @Override
             public String getName() {

--- a/mantis-client/src/main/java/io/mantisrx/client/SseSinkConnectionFunction.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SseSinkConnectionFunction.java
@@ -62,7 +62,7 @@ public class SseSinkConnectionFunction implements SinkConnectionFunc<MantisServe
         // Use single netty thread
         NettyUtils.setNettyThreads();
 
-        metricGroupId = new MetricGroupId(DROP_OPERATOR_INCOMING_METRIC_GROUP + "_Sse" + "Sink" + "ConnectionFunction_withBuffer");
+        metricGroupId = new MetricGroupId(DROP_OPERATOR_INCOMING_METRIC_GROUP + "_SseSinkConnectionFunction_withBuffer");
         metricsSet.add(metricGroupId);
         logger.info("SETTING UP METRICS PRINTER THREAD");
         new ScheduledThreadPoolExecutor(1).scheduleWithFixedDelay(new Runnable() {

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnection.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnection.java
@@ -141,7 +141,7 @@ public class SseWorkerConnection {
         this.hostname = hostname;
         this.port = port;
 
-        this.metricGroupId = metricGroupId;//new MetricGroupId(DROP_OPERATOR_INCOMING_METRIC_GROUP + "_Sse" + connectionType + "ConnectionFunction_withBuffer");
+        this.metricGroupId = metricGroupId;
         final MetricGroupId connHealthMetricGroup = new MetricGroupId("ConnectionHealth");
         Metrics m = new Metrics.Builder()
                 .id(connHealthMetricGroup)
@@ -177,7 +177,6 @@ public class SseWorkerConnection {
     }
 
     public synchronized void close() throws Exception {
-       // metricsSet.remove(metricGroupId);
         if (isShutdown)
             return;
         logger.info("Closing sse connection to " + hostname + ":" + port);
@@ -190,7 +189,6 @@ public class SseWorkerConnection {
     public synchronized Observable<MantisServerSentEvent> call() {
         if (isShutdown)
             return Observable.empty();
-       // metricsSet.add(metricGroupId);
         client =
                 RxNetty.<ByteBuf, ServerSentEvent>newHttpClientBuilder(hostname, port)
                         .pipelineConfigurator(PipelineConfigurators.<ByteBuf>clientSseConfigurator())

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnection.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnection.java
@@ -118,9 +118,11 @@ public class SseWorkerConnection {
                                final boolean reconnectUponConnectionReset,
                                final CopyOnWriteArraySet<MetricGroupId> metricsSet,
                                final int bufferSize,
-                               final SinkParameters sinkParameters) {
+                               final SinkParameters sinkParameters,
+                               final MetricGroupId metricGroupId) {
         this(connectionType, hostname, port, updateConxStatus, updateDataRecvngStatus, connectionResetHandler,
-                dataRecvTimeoutSecs, reconnectUponConnectionReset, metricsSet, bufferSize, sinkParameters, false);
+                dataRecvTimeoutSecs, reconnectUponConnectionReset, metricsSet, bufferSize, sinkParameters, false,
+                metricGroupId);
     }
     public SseWorkerConnection(final String connectionType,
                                final String hostname,
@@ -133,12 +135,13 @@ public class SseWorkerConnection {
                                final CopyOnWriteArraySet<MetricGroupId> metricsSet,
                                final int bufferSize,
                                final SinkParameters sinkParameters,
-                               final boolean disablePingFiltering) {
+                               final boolean disablePingFiltering,
+                               final MetricGroupId metricGroupId) {
         this.connectionType = connectionType;
         this.hostname = hostname;
         this.port = port;
 
-        this.metricGroupId = new MetricGroupId(DROP_OPERATOR_INCOMING_METRIC_GROUP + "_Sse" + connectionType + "ConnectionFunction_withBuffer");
+        this.metricGroupId = metricGroupId;//new MetricGroupId(DROP_OPERATOR_INCOMING_METRIC_GROUP + "_Sse" + connectionType + "ConnectionFunction_withBuffer");
         final MetricGroupId connHealthMetricGroup = new MetricGroupId("ConnectionHealth");
         Metrics m = new Metrics.Builder()
                 .id(connHealthMetricGroup)
@@ -174,7 +177,7 @@ public class SseWorkerConnection {
     }
 
     public synchronized void close() throws Exception {
-        metricsSet.remove(metricGroupId);
+       // metricsSet.remove(metricGroupId);
         if (isShutdown)
             return;
         logger.info("Closing sse connection to " + hostname + ":" + port);
@@ -187,7 +190,7 @@ public class SseWorkerConnection {
     public synchronized Observable<MantisServerSentEvent> call() {
         if (isShutdown)
             return Observable.empty();
-        metricsSet.add(metricGroupId);
+       // metricsSet.add(metricGroupId);
         client =
                 RxNetty.<ByteBuf, ServerSentEvent>newHttpClientBuilder(hostname, port)
                         .pipelineConfigurator(PipelineConfigurators.<ByteBuf>clientSseConfigurator())

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnectionFunction.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnectionFunction.java
@@ -59,7 +59,7 @@ public class SseWorkerConnectionFunction implements WorkerConnectionFunc<MantisS
         // Use single netty thread
         NettyUtils.setNettyThreads();
 
-        metricGroupId = new MetricGroupId(DROP_OPERATOR_INCOMING_METRIC_GROUP + "_Sse" + "WorkerMetrics" + "ConnectionFunction_withBuffer");
+        metricGroupId = new MetricGroupId(DROP_OPERATOR_INCOMING_METRIC_GROUP + "_SseWorkerMetricsConnectionFunction_withBuffer");
         metricsSet.add(metricGroupId);
         logger.info("SETTING UP METRICS PRINTER THREAD");
         new ScheduledThreadPoolExecutor(1).scheduleWithFixedDelay(new Runnable() {

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnectionFunction.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnectionFunction.java
@@ -16,6 +16,8 @@
 
 package io.mantisrx.server.worker.client;
 
+import static com.mantisrx.common.utils.MantisMetricStringConstants.DROP_OPERATOR_INCOMING_METRIC_GROUP;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -42,6 +44,7 @@ public class SseWorkerConnectionFunction implements WorkerConnectionFunc<MantisS
     private static final String DEFAULT_BUFFER_SIZE_STR = "0";
     private static final Logger logger = LoggerFactory.getLogger(SseWorkerConnectionFunction.class);
     private static final CopyOnWriteArraySet<MetricGroupId> metricsSet = new CopyOnWriteArraySet<>();
+    private static final MetricGroupId metricGroupId;
     private static final Action1<Throwable> defaultConxResetHandler = new Action1<Throwable>() {
         @Override
         public void call(Throwable throwable) {
@@ -56,7 +59,8 @@ public class SseWorkerConnectionFunction implements WorkerConnectionFunc<MantisS
         // Use single netty thread
         NettyUtils.setNettyThreads();
 
-
+        metricGroupId = new MetricGroupId(DROP_OPERATOR_INCOMING_METRIC_GROUP + "_Sse" + "WorkerMetrics" + "ConnectionFunction_withBuffer");
+        metricsSet.add(metricGroupId);
         logger.info("SETTING UP METRICS PRINTER THREAD");
         new ScheduledThreadPoolExecutor(1).scheduleWithFixedDelay(new Runnable() {
             @Override
@@ -119,7 +123,7 @@ public class SseWorkerConnectionFunction implements WorkerConnectionFunc<MantisS
             private final SseWorkerConnection workerConn =
                     new SseWorkerConnection("WorkerMetrics", hostname, port, updateConxStatus, updateDataRecvngStatus,
                             connectionResetHandler, dataRecvTimeoutSecs, reconnectUponConnectionRest, metricsSet,
-                            bufferSize, sinkParameters);
+                            bufferSize, sinkParameters,metricGroupId);
 
             @Override
             public String getName() {


### PR DESCRIPTION
### Context

Instead of creating a new metric group per connection, do it only once.

### Checklist

- [ x] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
