### PR TITLE
set jacksonversion to 2.10.+ series

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,20 +1,6 @@
-#
-# Copyright 2019 Netflix, Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+#Thu Mar 26 09:45:11 PDT 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/mantis-common/build.gradle
+++ b/mantis-common/build.gradle
@@ -15,7 +15,7 @@
  */
 
 ext {
-    jacksonVersion = '2.+'
+    jacksonVersion = '2.10.+'
     jctoolsVersion = '1.+'
     nettyVersion = '4.1.17.Final'
     numerusVersion = '1.+'

--- a/mantis-discovery-proto/build.gradle
+++ b/mantis-discovery-proto/build.gradle
@@ -15,7 +15,7 @@
  */
 
 ext {
-    jacksonVersion = '2.+'
+    jacksonVersion = '2.10.+'
 }
 
 dependencies {


### PR DESCRIPTION
### Context

switching jacksonVersion from 2.+ to 2.10.+ so we don't pull in higher versions like 2.11.0.rc1 etc which is incompatible with scala 2.13

### Checklist

- [ x] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
