### PR TITLE
Bump Mesos version for agents.

### DIFF
--- a/mantis-server/mantis-server-worker/build.gradle
+++ b/mantis-server/mantis-server-worker/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'eu.appsatori.fatjar'
 ext {
     mantisControlPlaneVersion = '1.2.+'
     mantisRxControlVersion = '1.3.14'
-    mesosVersion = '1.3.2'
+    mesosVersion = '1.7.2'
     httpComponentsVersion = '4.5.6'
 }
 


### PR DESCRIPTION
### Context

Bumps the Mesos version for agents to match control plane.

Should be a noop. Seems the only related change is in https://github.com/apache/mesos/commit/2caff4036264301de767203f8ac8fd7ebf4017ee.

Diff doesn't have any other Java library changes https://github.com/apache/mesos/compare/1.7.2...1.3.2.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
