### PR TITLE
Allowing the sink subscriber to specify a delimiter via queryParameters.

### DIFF
--- a/mantis-common/src/main/java/com/mantisrx/common/utils/MantisSSEConstants.java
+++ b/mantis-common/src/main/java/com/mantisrx/common/utils/MantisSSEConstants.java
@@ -42,5 +42,5 @@ public class MantisSSEConstants {
 
     public static final String MQL = "mql";
 
-
+    public static final String DELIMITER = "delimiter";
 }

--- a/mantis-common/src/main/java/io/mantisrx/common/compression/CompressionUtils.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/compression/CompressionUtils.java
@@ -41,14 +41,17 @@ public class CompressionUtils {
     public static final byte[] MANTIS_SSE_DELIMITER_BINARY = MANTIS_SSE_DELIMITER.getBytes();
     private static Logger logger = LoggerFactory.getLogger(CompressionUtils.class);
 
-
     public static String compressAndBase64Encode(List<String> events, boolean useSnappy) {
+        return compressAndBase64Encode(events, useSnappy, MANTIS_SSE_DELIMITER_BINARY);
+    }
+
+    public static String compressAndBase64Encode(List<String> events, boolean useSnappy, byte[] delimiter) {
         if (!events.isEmpty()) {
 
             StringBuilder sb = new StringBuilder();
             for (String event : events) {
                 sb.append(event);
-                sb.append(MANTIS_SSE_DELIMITER);
+                sb.append(delimiter);
             }
             try {
                 byte[] compressedBytes;
@@ -78,14 +81,18 @@ public class CompressionUtils {
     }
 
     public static byte[] compressAndBase64EncodeBytes(List<List<byte[]>> nestedEvents, boolean useSnappy) {
+        return compressAndBase64EncodeBytes(nestedEvents, useSnappy, MANTIS_SSE_DELIMITER_BINARY);
+    }
+
+    public static byte[] compressAndBase64EncodeBytes(List<List<byte[]>> nestedEvents, boolean useSnappy, byte[] delimiter) {
         if (!nestedEvents.isEmpty()) {
 
-            ByteBuffer buffer = ByteBuffer.allocate(getTotalByteSize(nestedEvents));
+            ByteBuffer buffer = ByteBuffer.allocate(getTotalByteSize(nestedEvents, delimiter));
 
             for (List<byte[]> outerList : nestedEvents) {
                 for (byte[] event : outerList) {
                     buffer.put(event);
-                    buffer.put(MANTIS_SSE_DELIMITER_BINARY);
+                    buffer.put(delimiter);
                 }
             }
 
@@ -115,7 +122,8 @@ public class CompressionUtils {
     public static byte[] compressAndBase64EncodeBytes(List<List<byte[]>> nestedEvents) {
         if (!nestedEvents.isEmpty()) {
 
-            ByteBuffer buffer = ByteBuffer.allocate(getTotalByteSize(nestedEvents));
+            ByteBuffer buffer = ByteBuffer.allocate(getTotalByteSize(nestedEvents, MANTIS_SSE_DELIMITER_BINARY));
+
 
             for (List<byte[]> outerList : nestedEvents) {
                 for (byte[] event : outerList) {
@@ -142,7 +150,8 @@ public class CompressionUtils {
         return null;
     }
 
-    private static int getTotalByteSize(List<List<byte[]>> nestedEvents) {
+
+    private static int getTotalByteSize(List<List<byte[]>> nestedEvents, byte[] delimiter) {
         int size = 0;
         int count = 0;
         for (List<byte[]> outerList : nestedEvents) {
@@ -152,7 +161,7 @@ public class CompressionUtils {
             }
         }
 
-        return size + count * MANTIS_SSE_DELIMITER_BINARY.length;
+        return size + count * delimiter.length;
 
     }
 

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServerSse.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServerSse.java
@@ -156,6 +156,8 @@ public class PushServerSse<T, S> extends PushServer<T, ServerSentEvent> {
                             predicateFunction = predicate.call(queryParameters);
                         }
 
+                        byte[] delimiter = "$$$".getBytes();
+
                         if (queryParameters != null && !queryParameters.isEmpty()) {
 
                             if (queryParameters.containsKey(MantisSSEConstants.ID)) {
@@ -179,13 +181,11 @@ public class PushServerSse<T, S> extends PushServer<T, ServerSentEvent> {
                                 enableHeartbeats = true;
                             }
                             if (queryParameters != null && queryParameters.containsKey(MantisSSEConstants.MANTIS_ENABLE_COMPRESSION)) {
-
                                 String enableBinaryOutputStr = queryParameters.get(MantisSSEConstants.MANTIS_ENABLE_COMPRESSION).get(0);
                                 if ("true".equalsIgnoreCase(enableBinaryOutputStr)) {
                                     logger.info("Binary compression requested");
                                     enableBinaryOutput = true;
                                 }
-
                             }
                             if (queryParameters.containsKey(MantisSSEConstants.ENABLE_PINGS)) {
                                 String enablePings = queryParameters.get(MantisSSEConstants.ENABLE_PINGS).get(0);
@@ -222,6 +222,13 @@ public class PushServerSse<T, S> extends PushServer<T, ServerSentEvent> {
                                     throw new IllegalArgumentException("Sampling rate too low: " + samplingTimeMsec);
                                 }
                                 enableSampling = true;
+                            }
+
+                            if (queryParameters.containsKey(MantisSSEConstants.DELIMITER)) {
+                                String rawDelimiter = queryParameters.get(MantisSSEConstants.DELIMITER).get(0);
+                                if (rawDelimiter != null && !rawDelimiter.isEmpty()) {
+                                    delimiter = rawDelimiter.getBytes();
+                                }
                             }
 
                             if (queryParameters.containsKey(MantisSSEConstants.MQL)) {
@@ -310,7 +317,7 @@ public class PushServerSse<T, S> extends PushServer<T, ServerSentEvent> {
                                 enableHeartbeats, heartbeatSubscription, enableSampling, samplingTimeMsec, metaMsgSubject, metaMsgSubscription,
                                 predicateFunction, connectionClosedCallback, sseProcessedCounter,
                                 sseDroppedCounter,
-                                new SubscribeCallback(), enableBinaryOutput, true);
+                                new SubscribeCallback(), enableBinaryOutput, true, delimiter);
                     }
                 })
                 .pipelineConfigurator(PipelineConfigurators.serveSseConfigurator())


### PR DESCRIPTION
Previously compressed output, which is implicitly batched, used a fixed
delimiter of '$$$' to delimit the events in the batch. This causes
problems when the delimiter string naturally occurs in the events. The
proposed solution is to allow users to allow subscribers to specify a
delimiter.

### Context

This is a proposed solution to #47.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
