### PR TITLE
Shade curator and zookeeper.

### DIFF
--- a/mantis-connectors/mantis-connector-job/src/main/java/io/mantisrx/connector/job/source/JobSource.java
+++ b/mantis-connectors/mantis-connector-job/src/main/java/io/mantisrx/connector/job/source/JobSource.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 
-import com.google.common.collect.Lists;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -41,6 +40,7 @@ import io.mantisrx.runtime.parameter.type.StringParameter;
 import io.mantisrx.runtime.parameter.validator.Validators;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
+import io.mantisrx.shaded.com.google.common.collect.Lists;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import org.slf4j.Logger;

--- a/mantis-connectors/mantis-connector-publish/build.gradle
+++ b/mantis-connectors/mantis-connector-publish/build.gradle
@@ -16,6 +16,7 @@
 
 ext {
     junitVersion = '5.3.+'
+    nettyVersion = '4.1.34.Final'
 }
 
 dependencies {
@@ -24,6 +25,8 @@ dependencies {
 
     api project(":mantis-control-plane:mantis-control-plane-core")
     api project(":mantis-publish:mantis-publish-core")
+
+    implementation "io.netty:netty-all:$nettyVersion"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/mantis-control-plane/mantis-control-plane-core/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-core/build.gradle
@@ -15,10 +15,8 @@
  */
 
 ext {
-
     cliParserVersion = '1.1.1'
     configMagicVersion = '0.11'
-    curatorVersion = '2.11.0'
     hdrHistogramVersion = '2.+'
     jodaTimeVersion = '2.+'
     jsonVersion = '20180813'
@@ -27,7 +25,6 @@ ext {
 }
 
 dependencies {
-
     api project(":mantis-common")
 
     api "org.skife.config:config-magic:$configMagicVersion"
@@ -36,8 +33,6 @@ dependencies {
     api "org.json:json:$jsonVersion"
     api "org.hdrhistogram:HdrHistogram:$hdrHistogramVersion"
     api "com.github.spullara.cli-parser:cli-parser:$cliParserVersion"
-    api "org.apache.curator:curator-framework:$curatorVersion"
-    api "org.apache.curator:curator-recipes:$curatorVersion"
     api "joda-time:joda-time:$jodaTimeVersion"
 
 

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/master/ZookeeperMasterMonitor.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/master/ZookeeperMasterMonitor.java
@@ -20,11 +20,11 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.mantisrx.server.core.json.DefaultObjectMapper;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.api.BackgroundCallback;
-import org.apache.curator.framework.api.CuratorEvent;
-import org.apache.curator.framework.recipes.cache.NodeCache;
-import org.apache.curator.framework.recipes.cache.NodeCacheListener;
+import io.mantisrx.shaded.org.apache.curator.framework.CuratorFramework;
+import io.mantisrx.shaded.org.apache.curator.framework.api.BackgroundCallback;
+import io.mantisrx.shaded.org.apache.curator.framework.api.CuratorEvent;
+import io.mantisrx.shaded.org.apache.curator.framework.recipes.cache.NodeCache;
+import io.mantisrx.shaded.org.apache.curator.framework.recipes.cache.NodeCacheListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/zookeeper/CuratorService.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/zookeeper/CuratorService.java
@@ -26,19 +26,19 @@ import io.mantisrx.server.core.Service;
 import io.mantisrx.server.core.master.MasterDescription;
 import io.mantisrx.server.core.master.MasterMonitor;
 import io.mantisrx.server.core.master.ZookeeperMasterMonitor;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.framework.imps.GzipCompressionProvider;
-import org.apache.curator.framework.state.ConnectionState;
-import org.apache.curator.framework.state.ConnectionStateListener;
-import org.apache.curator.retry.ExponentialBackoffRetry;
-import org.apache.curator.utils.ZKPaths;
+import io.mantisrx.shaded.org.apache.curator.framework.CuratorFramework;
+import io.mantisrx.shaded.org.apache.curator.framework.CuratorFrameworkFactory;
+import io.mantisrx.shaded.org.apache.curator.framework.imps.GzipCompressionProvider;
+import io.mantisrx.shaded.org.apache.curator.framework.state.ConnectionState;
+import io.mantisrx.shaded.org.apache.curator.framework.state.ConnectionStateListener;
+import io.mantisrx.shaded.org.apache.curator.retry.ExponentialBackoffRetry;
+import io.mantisrx.shaded.org.apache.curator.utils.ZKPaths;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 /**
- * This {@link Service} implementation is responsible for managing the lifecycle of a {@link org.apache.curator.framework.CuratorFramework}
+ * This {@link Service} implementation is responsible for managing the lifecycle of a {@link io.mantisrx.shaded.org.apache.curator.framework.CuratorFramework}
  * instance.
  */
 public class CuratorService extends BaseService {

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -23,7 +23,6 @@ ext {
     cliParserVersion = '1.1.1'
     configMagicVersion = '0.11'
     rxJavaReactiveStreamsVersion = '1.+'
-    curatorVersion = '2.11.0'
     testngVersion = '6.+'
 }
 
@@ -42,8 +41,6 @@ dependencies {
     api "com.netflix.fenzo:fenzo-core:$fenzoVersion"
     api "com.netflix.fenzo:fenzo-triggers:$fenzoVersion"
     api "com.github.spullara.cli-parser:cli-parser:$cliParserVersion"
-    api "org.apache.curator:curator-framework:$curatorVersion"
-    api "org.apache.curator:curator-recipes:$curatorVersion"
     api "org.skife.config:config-magic:$configMagicVersion"
 
     testCompile "com.typesafe.akka:akka-testkit_2.13:$akkaVersion"

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/zk/LeaderElector.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/zk/LeaderElector.java
@@ -16,22 +16,22 @@
 
 package io.mantisrx.master.zk;
 
-import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
-import io.mantisrx.server.core.BaseService;
-import io.mantisrx.server.master.ILeadershipManager;
-import io.netty.util.concurrent.DefaultThreadFactory;
-import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.leader.LeaderLatch;
-import org.apache.curator.framework.recipes.leader.LeaderLatchListener;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.data.Stat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static io.mantisrx.shaded.org.apache.zookeeper.KeeperException.Code.OK;
 
 import java.io.IOException;
 import java.util.concurrent.Executors;
 
-import static org.apache.zookeeper.KeeperException.Code.*;
+import io.mantisrx.server.core.BaseService;
+import io.mantisrx.server.master.ILeadershipManager;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import io.mantisrx.shaded.org.apache.curator.framework.CuratorFramework;
+import io.mantisrx.shaded.org.apache.curator.framework.recipes.leader.LeaderLatch;
+import io.mantisrx.shaded.org.apache.curator.framework.recipes.leader.LeaderLatchListener;
+import io.mantisrx.shaded.org.apache.zookeeper.CreateMode;
+import io.mantisrx.shaded.org.apache.zookeeper.data.Stat;
+import io.netty.util.concurrent.DefaultThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LeaderElector extends BaseService {
     private static final Logger logger = LoggerFactory.getLogger(LeaderElector.class);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -78,7 +78,7 @@ import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.MantisStorageProviderAdapter;
 import io.mantisrx.server.master.scheduler.JobMessageRouter;
 import io.mantisrx.server.master.scheduler.WorkerRegistry;
-import org.apache.curator.utils.ZKPaths;
+import io.mantisrx.shaded.org.apache.curator.utils.ZKPaths;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-server/mantis-server-worker/build.gradle
+++ b/mantis-server/mantis-server-worker/build.gradle
@@ -20,7 +20,6 @@ ext {
     mantisRxControlVersion = '1.3.14'
     mesosVersion = '1.7.2'
     httpComponentsVersion = '4.5.6'
-    curatorVersion = '2.11.0'
 }
 
 dependencies {
@@ -29,8 +28,6 @@ dependencies {
     compile project(":mantis-control-plane:mantis-control-plane-core")
     compile project(":mantis-server:mantis-server-worker-client")
 
-    api "org.apache.curator:curator-framework:$curatorVersion"
-    api "org.apache.curator:curator-recipes:$curatorVersion"
     compile "org.apache.mesos:mesos:$mesosVersion"
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     compile "org.slf4j:slf4j-log4j12:$slf4jVersion"

--- a/mantis-shaded/build.gradle
+++ b/mantis-shaded/build.gradle
@@ -19,6 +19,8 @@ apply plugin: 'com.github.johnrengelman.shadow'
 ext {
     jacksonVersion = '2.10.+'
     guavaVersion = '18.+'
+    curatorVersion = '2.11.0'       // For mantis-control-plane.
+    zookeeperVersion = '3.4.6'      // For mantis-control-plane.
 }
 
 configurations {
@@ -36,8 +38,15 @@ dependencies {
     shaded "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
     shaded "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
     shaded "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:$jacksonVersion"
+
     shaded "io.vavr:vavr-jackson:$vavrVersion"
+
     shaded "com.google.guava:guava:$guavaVersion"
+
+    shaded "org.apache.curator:curator-framework:$curatorVersion"
+    shaded "org.apache.curator:curator-recipes:$curatorVersion"
+    shaded "org.apache.curator:curator-client:$curatorVersion"
+    shaded "org.apache.zookeeper:zookeeper:$zookeeperVersion"
 
     implementation "io.vavr:vavr:$vavrVersion"
 }
@@ -46,8 +55,10 @@ shadowJar {
     classifier = null
     configurations = [project.configurations.shaded]
     relocate 'com.fasterxml', 'io.mantisrx.shaded.com.fasterxml'
-    relocate 'io.vavr.jackson.datatype', 'io.mantisrx.shaded.io.vavr.jackson.datatype'
     relocate 'com.google.common', 'io.mantisrx.shaded.com.google.common'
+    relocate 'io.vavr.jackson.datatype', 'io.mantisrx.shaded.io.vavr.jackson.datatype'
+    relocate 'org.apache.curator', 'io.mantisrx.shaded.org.apache.curator'
+    relocate 'org.apache.zookeeper', 'io.mantisrx.shaded.org.apache.zookeeper'
 
     mergeServiceFiles()
 }


### PR DESCRIPTION
### Context

Curator brings in Zookeeper which transitively pulls in Netty 3.x (which we don't use). This currently breaks Mantis Jobs at runtime because some of the `io.reactivex.netty` classes end up getting Netty 3.x and run into classpath issues:

```
2020-10-07 21:14:29 WARN  AbstractChannelHandlerContext:146 - An exception 'java.lang.NoSuchMethodError: mantis.io.reactivex.netty.protocol.http.client.HttpClientResponse.getStatus()Lio/netty/handler/codec/http/HttpResponseStatus;' [enable DEBUG level for full stacktrace] was thrown by a user handler's exceptionCaught() method while handling the following exception:
java.lang.NoSuchMethodError: mantis.io.reactivex.netty.protocol.http.client.HttpClientResponse.getStatus()Lio/netty/handler/codec/http/HttpResponseStatus;
	at com.netflix.mantis.common.properties.MantisFastPropertiesLoader$1.call(MantisFastPropertiesLoader.java:79)
	at com.netflix.mantis.common.properties.MantisFastPropertiesLoader$1.call(MantisFastPropertiesLoader.java:76)
	at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:69)
	at rx.internal.operators.OperatorDoAfterTerminate$1.onNext(OperatorDoAfterTerminate.java:50)
	at rx.internal.operators.OperatorTake$1.onNext(OperatorTake.java:79)
	at rx.observers.SafeSubscriber.onNext(SafeSubscriber.java:134)
	at rx.internal.operators.OnSubscribeDoOnEach$DoOnEachSubscriber.onNext(OnSubscribeDoOnEach.java:101)
	at rx.internal.operators.OnSubscribeDoOnEach$DoOnEachSubscriber.onNext(OnSubscribeDoOnEach.java:101)
	at rx.subjects.PublishSubject$PublishSubjectProducer.onNext(PublishSubject.java:304)
	at rx.subjects.PublishSubject$PublishSubjectState.onNext(PublishSubject.java:219)
	at rx.subjects.PublishSubject.onNext(PublishSubject.java:72)
	at mantis.io.reactivex.netty.pipeline.ObservableAdapter.channelRead(ObservableAdapter.java:50)
```

This PR adds shaded Curator and Zookeeper which excludes Netty 3.x as a dependency. 4.x is mostly compatible.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
