### PR TITLE
Init calls on multisink and other sink wrappers

### DIFF
--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/sink/Sinks.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/sink/Sinks.java
@@ -42,6 +42,11 @@ public class Sinks {
                 o.subscribe();
                 sink.call(c, p, o);
             }
+
+            @Override
+            public void init(Context t) {
+                sink.init(t);
+            }
         };
     }
 
@@ -61,6 +66,11 @@ public class Sinks {
             public Metadata metadata() {
                 return sink.metadata();
             }
+
+            @Override
+            public void init(Context t) {
+                sink.init(t);
+            }
         };
     }
 
@@ -79,6 +89,12 @@ public class Sinks {
             public void call(Context t1, PortRequest t2, Observable<T> t3) {
                 for (Sink<T> sink : many) {
                     sink.call(t1, t2, t3);
+                }
+            }
+            @Override
+            public void init(Context t) {
+                for(Sink<T> sink : many) {
+                    sink.init(t);
                 }
             }
         };


### PR DESCRIPTION
### Context

Init call was not forwarded in wrapper sinks like multisink etc


### Checklist

- [ x] `./gradlew build` compiles code correctly
- [ x] Added new tests where applicable
- [ x] `./gradlew test` passes all tests
- [ x] Extended README or added javadocs where applicable
- [ x] Added copyright headers for new files from `CONTRIBUTING.md`
