### PR TITLE
Add `LocationProvider` for table location support.

### DIFF
--- a/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
+++ b/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
@@ -112,7 +113,8 @@ public class IcebergWriterStage implements ScalarComputation<Record, DataFile> {
         Table table = catalog.loadTable(id);
         WorkerInfo workerInfo = context.getWorkerInfo();
 
-        IcebergWriter writer = new DefaultIcebergWriter(config, workerInfo, table);
+        LocationProvider locationProvider = context.getServiceLocator().service(LocationProvider.class);
+        IcebergWriter writer = new DefaultIcebergWriter(config, workerInfo, table, locationProvider);
         WriterMetrics metrics = new WriterMetrics();
         PartitionerFactory partitionerFactory = context.getServiceLocator().service(PartitionerFactory.class);
         Partitioner partitioner = partitionerFactory.getPartitioner(table);


### PR DESCRIPTION
### Context

We can use Iceberg's `LocationProvider` interface and implement the
ability for users to provide different table locations. This is useful
in a cluster island-model setup, for example in AWS east/west/eu. Each
of these clusters might have table locations with different paths such
as `s3n://prod-data` (main, r/w), `s3n://prod-west-replica1-data`, and
`s3n://prod-eu-replica2-data`. If we had only one table location, eu and
west would write `DataFile`s cross-region over to the east location. By
specifying different locations, each region can write to their local
location, then, some other service can asynchronously replicate over to
the main (east) region in a separate runtime path.

This way, we can reduce/mostly avoid huge cross-regional latencies when
writing DataFiles.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
