### PR TITLE
Use Netflix Docker Hub container image registry.

### DIFF
--- a/mantis-control-plane/Dockerfile
+++ b/mantis-control-plane/Dockerfile
@@ -1,4 +1,4 @@
-FROM azul/zulu-openjdk:8u172-8.30.0.1
+FROM docker-hub.netflix.net/azul/zulu-openjdk:8u172-8.30.0.1
 
 MAINTAINER Mantis Developers <mantis-oss-dev@netflix.com>
 
@@ -9,10 +9,10 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
     apt-get install -y mesos=1.3.2-2.0.1 && \
     apt-get clean
 
-COPY ./server/build/install/mantis-control-plane-server/bin/* /apps/mantis/mantis-control-plane-server/bin/
-COPY ./server/build/install/mantis-control-plane-server/lib/* /apps/mantis/mantis-control-plane-server/lib/
+COPY ./mantis-control-plane-server/build/install/mantis-control-plane-server/bin/* /apps/mantis/mantis-control-plane-server/bin/
+COPY ./mantis-control-plane-server/build/install/mantis-control-plane-server/lib/* /apps/mantis/mantis-control-plane-server/lib/
 
-COPY ./server/src/main/resources/master-docker.properties /apps/mantis/mantis-control-plane-server/conf/
+COPY ./mantis-control-plane-server/src/main/resources/master-docker.properties /apps/mantis/mantis-control-plane-server/conf/
 
 RUN mkdir -p /apps/mantis/mantis-control-plane-server/src/main/webapp
 RUN mkdir -p /apps/mantis/mantis-control-plane-server/logs

--- a/mantis-control-plane/buildDockerImage.sh
+++ b/mantis-control-plane/buildDockerImage.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # build the mantis-master-akka executable
-./gradlew clean installDist
+../gradlew clean installDist
 
 # build the Docker image that packages mantis-control-plane
 docker build -t netflixoss/mantiscontrolplaneserver .

--- a/mantis-examples/mantis-examples-mantis-publish-sample/Dockerfile
+++ b/mantis-examples/mantis-examples-mantis-publish-sample/Dockerfile
@@ -1,5 +1,5 @@
 # Alpine Linux with OpenJDK JRE
-FROM openjdk:8-jre-alpine
+FROM docker-hub.netflix.net/openjdk:8-jre-alpine
 # copy WAR into image
 
 RUN mkdir -p /mnt/local/mantispublish

--- a/mantis-examples/mantis-examples-mantis-publish-web-sample/Dockerfile
+++ b/mantis-examples/mantis-examples-mantis-publish-web-sample/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0-alpine
+FROM docker-hub.netflix.net/tomcat:9.0-alpine
 
 LABEL maintainer="mantis-oss-dev@netflix.com"
 

--- a/mantis-server/mantis-server-worker/Dockerfile
+++ b/mantis-server/mantis-server-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mesosphere/mesos-slave:1.3.2
+FROM docker-hub.netflix.net/mesosphere/mesos-slave:1.3.2
 
 MAINTAINER Mantis Developers <mantisd-oss-dev@netflix.com>
 


### PR DESCRIPTION
### Context

Adds a caching layer to reduce rate limit behavior from the public
Docker Hub; goes into effect November 01, 2020. See
https://docs.docker.com/docker-hub/download-rate-limit/ for more info.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
