### PR TITLE
pin mantis-rxcontrol to pick latest patch version

### DIFF
--- a/mantis-server/mantis-server-worker/build.gradle
+++ b/mantis-server/mantis-server-worker/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: 'eu.appsatori.fatjar'
 
 ext {
-    mantisRxControlVersion = '1.3.14'
+    mantisRxControlVersion = '1.3.+'
     mesosVersion = '1.7.2'
     httpComponentsVersion = '4.5.6'
     curatorVersion = '2.11.0'


### PR DESCRIPTION
### Context

bump mantis-rxcontrol version to pick up stream double consume fix in ClutchConfigurator
### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
