### PR TITLE
ignore all exceptions during master init for autoscale rules setup

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/SchedulingService.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/SchedulingService.java
@@ -238,8 +238,8 @@ public class SchedulingService extends BaseService implements MantisScheduler {
                 } else
                     logger.warn("No auto scale rules setup");
             }
-        } catch (IllegalStateException e) {
-            logger.warn("Ignoring: " + e.getMessage());
+        } catch (Exception e) {
+            logger.error("Ignoring exception during autoscale rules setup", e);
         }
         schedulerBuilder = schedulerBuilder.withMaxOffersToReject(Math.max(1, minMinIdle));
         final TaskScheduler scheduler = schedulerBuilder.build();


### PR DESCRIPTION
### Context

Failure to load autoscale rules due to other exceptions could fail SchedulingService init which in turn prevents master from starting during bootstrap
### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
