### PR TITLE
block till mesos scheduler driver is initialized

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -55,7 +55,7 @@ public interface MasterConfiguration extends CoreConfiguration {
     String getMasterIP();
 
     @Config("mesos.scheduler.driver.init.timeout.sec")
-    @Default("5")
+    @Default("2")
     int getMesosSchedulerDriverInitTimeoutSec();
 
     @Config("mesos.scheduler.driver.init.num.retries")

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -54,6 +54,10 @@ public interface MasterConfiguration extends CoreConfiguration {
     @DefaultNull
     String getMasterIP();
 
+    @Config("mesos.scheduler.driver.init.timeout.sec")
+    @Default("5")
+    int getMesosSchedulerDriverInitTimeoutSec();
+
     @Config("mesos.worker.timeoutSecondsToReportStart")
     @Default("10")
     int getTimeoutSecondsToReportStart();

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -58,6 +58,10 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("5")
     int getMesosSchedulerDriverInitTimeoutSec();
 
+    @Config("mesos.scheduler.driver.init.num.retries")
+    @Default("3")
+    int getMesosSchedulerDriverInitNumRetries();
+
     @Config("mesos.worker.timeoutSecondsToReportStart")
     @Default("10")
     int getTimeoutSecondsToReportStart();

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/mesos/MesosDriverSupplier.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/mesos/MesosDriverSupplier.java
@@ -113,16 +113,13 @@ public class MesosDriverSupplier implements Supplier<MesosSchedulerDriver> {
             logger.info("initialized mesos scheduler driver {}", result);
         } else {
             // block till mesosDriver is not null
-            while (true) {
-                if (mesosDriverRef.get() == null) {
-                    try {
-                        Thread.sleep(100);
-                    } catch (InterruptedException e) {
-                        logger.warn("thread interrupted during sleep", e);
-                        Thread.currentThread().interrupt();
-                    }
-                } else {
-                    break;
+            while (mesosDriverRef.get() == null) {
+                try {
+                    logger.info("mesos scheduler driver null, sleep for 1 sec awaiting init");
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    logger.warn("thread interrupted during sleep", e);
+                    Thread.currentThread().interrupt();
                 }
             }
         }


### PR DESCRIPTION
### Context

Block till scheduler driver is initialized, retry when failed to initialize driver within 5 seconds

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
