### PR TITLE
bound max time to wait for scheduler driver init

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -333,6 +333,7 @@ public class MasterMain implements Service {
         if (shutdownInitiated.compareAndSet(false, true)) {
             logger.info("Shutting down Mantis Master");
             mantisServices.shutdown();
+            logger.info("mantis services shutdown complete");
             boolean shutdownCuratorEnabled = ConfigurationProvider.getConfig().getShutdownCuratorServiceEnabled();
             if (curatorService != null && shutdownCuratorEnabled) {
                 logger.info("Shutting down Curator Service");
@@ -341,6 +342,7 @@ public class MasterMain implements Service {
                 logger.info("not shutting down curator service {} shutdownEnabled? {}", curatorService, shutdownCuratorEnabled);
             }
             blockUntilShutdown.countDown();
+            logger.info("Mantis Master shutdown done");
         } else
             logger.info("Shutdown already initiated, not starting again");
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -58,9 +58,9 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("2")
     int getMesosSchedulerDriverInitTimeoutSec();
 
-    @Config("mesos.scheduler.driver.init.num.retries")
+    @Config("mesos.scheduler.driver.init.max.attempts")
     @Default("3")
-    int getMesosSchedulerDriverInitNumRetries();
+    int getMesosSchedulerDriverInitMaxAttempts();
 
     @Config("mesos.worker.timeoutSecondsToReportStart")
     @Default("10")

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/mesos/VirtualMachineMasterServiceMesosImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/mesos/VirtualMachineMasterServiceMesosImpl.java
@@ -66,7 +66,7 @@ public class VirtualMachineMasterServiceMesosImpl extends BaseService implements
 
     private static final Logger logger = LoggerFactory.getLogger(VirtualMachineMasterServiceMesosImpl.class);
     private final String masterDescriptionJson;
-    private final Supplier<MesosSchedulerDriver> mesosDriver;
+    private final MesosDriverSupplier mesosDriver;
     private final AtomicBoolean initializationDone = new AtomicBoolean(false);
     private volatile int workerJvmMemoryScaleBackPct;
     private MasterConfiguration masterConfig;
@@ -76,7 +76,7 @@ public class VirtualMachineMasterServiceMesosImpl extends BaseService implements
     public VirtualMachineMasterServiceMesosImpl(
             final MasterConfiguration masterConfig,
             final String masterDescriptionJson,
-            final Supplier<MesosSchedulerDriver> mesosSchedulerDriverSupplier) {
+            final MesosDriverSupplier mesosSchedulerDriverSupplier) {
         super(true);
         this.masterConfig = masterConfig;
         this.masterDescriptionJson = masterDescriptionJson;
@@ -441,7 +441,7 @@ public class VirtualMachineMasterServiceMesosImpl extends BaseService implements
     @Override
     public void shutdown() {
         logger.info("Unregistering Mantis Framework with Mesos");
-        mesosDriver.get().stop(true);
+        mesosDriver.shutdown();
         executor.shutdown();
     }
 


### PR DESCRIPTION
### Context

bound max time to wait for scheduler driver init
### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
- [X] Added copyright headers for new files from `CONTRIBUTING.md`
