### PR TITLE
Replace jcenter with maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }
@@ -64,7 +64,21 @@ subprojects {
     }
 
     repositories {
-        jcenter()
+        mavenCentral()
+        /**
+         * This repository locates artifacts that don't exist in maven central but we had to backup from jcenter
+         * The exclusiveContent 
+         */
+        exclusiveContent {
+            forRepository {
+                maven {
+                    url "https://artifactory-oss.prod.netflix.net/artifactory/required-jcenter-modules-backup"
+                }
+            }
+            filter {
+                includeGroupByRegex "net\\.andreinc.*"
+            }
+        }
     }
 
     tasks.withType(Javadoc).all {

--- a/mantis-examples/mantis-examples-mantis-publish-sample/build.gradle
+++ b/mantis-examples/mantis-examples-mantis-publish-sample/build.gradle
@@ -19,9 +19,10 @@ apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 repositories {
     maven {
-        url "https://dl.bintray.com/netflixoss/maven"
+        url "https://artifactory-oss.prod.netflix.net/artifactory/maven-oss-releases"
     }
 }
+
 
 if (project.hasProperty('useMavenLocal')) {
     repositories {
@@ -31,7 +32,10 @@ if (project.hasProperty('useMavenLocal')) {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:6.1.0'

--- a/mantis-examples/mantis-examples-mantis-publish-web-sample/build.gradle
+++ b/mantis-examples/mantis-examples-mantis-publish-web-sample/build.gradle
@@ -17,9 +17,9 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
-            url "https://dl.bintray.com/netflixoss/maven"
+            url "https://artifactory-oss.prod.netflix.net/artifactory/maven-oss-releases"
         }
     }
 }


### PR DESCRIPTION
This replaces jcenter with maven central

Also noticed that artifacts from `net.andreinc.*` are in use for some mantis samples and those are in jcenter only. I went ahead and create a backup in our own repos so when jcenter goes away, we will be fine