### PR TITLE
Change meaning of resubmission limit to take time duration into account

### DIFF
--- a/mantis-network/src/test/java/io/reactivex/mantis/network/push/TimedChunkerTest.java
+++ b/mantis-network/src/test/java/io/reactivex/mantis/network/push/TimedChunkerTest.java
@@ -47,7 +47,15 @@ public class TimedChunkerTest {
 
     @Test
     public void testProcessData() throws Exception {
+<<<<<<< HEAD
+<<<<<<< HEAD
         TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 100, 500, processor, null);
+=======
+        TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 100, 1000, processor, null);
+>>>>>>> 1d9ec46... Refactor TimedChunker to fix data drop due to race condition
+=======
+        TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 100, 500, processor, null);
+>>>>>>> 41790fe... fix metric name
 
         List<Integer> expected = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
@@ -76,7 +84,15 @@ public class TimedChunkerTest {
 
     @Test
     public void testBufferLength() throws Exception {
+<<<<<<< HEAD
+<<<<<<< HEAD
         TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 5, 500, processor, null);
+=======
+        TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 5, 1000, processor, null);
+>>>>>>> 1d9ec46... Refactor TimedChunker to fix data drop due to race condition
+=======
+        TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 5, 500, processor, null);
+>>>>>>> 41790fe... fix metric name
 
         List<Integer> expected = new ArrayList<>();
         for (int i = 0; i < 50; i++) {

--- a/mantis-network/src/test/java/io/reactivex/mantis/network/push/TimedChunkerTest.java
+++ b/mantis-network/src/test/java/io/reactivex/mantis/network/push/TimedChunkerTest.java
@@ -47,15 +47,7 @@ public class TimedChunkerTest {
 
     @Test
     public void testProcessData() throws Exception {
-<<<<<<< HEAD
-<<<<<<< HEAD
         TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 100, 500, processor, null);
-=======
-        TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 100, 1000, processor, null);
->>>>>>> 1d9ec46... Refactor TimedChunker to fix data drop due to race condition
-=======
-        TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 100, 500, processor, null);
->>>>>>> 41790fe... fix metric name
 
         List<Integer> expected = new ArrayList<>();
         for (int i = 0; i < 50; i++) {
@@ -84,15 +76,7 @@ public class TimedChunkerTest {
 
     @Test
     public void testBufferLength() throws Exception {
-<<<<<<< HEAD
-<<<<<<< HEAD
         TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 5, 500, processor, null);
-=======
-        TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 5, 1000, processor, null);
->>>>>>> 1d9ec46... Refactor TimedChunker to fix data drop due to race condition
-=======
-        TimedChunker<Integer> timedChunker = new TimedChunker<>(monitoredQueue, 5, 500, processor, null);
->>>>>>> 41790fe... fix metric name
 
         List<Integer> expected = new ArrayList<>();
         for (int i = 0; i < 50; i++) {

--- a/mantis-publish/mantis-publish-core/build.gradle
+++ b/mantis-publish/mantis-publish-core/build.gradle
@@ -18,7 +18,7 @@ ext {
     junitVersion = '5.3.+'
     mockitoVersion = '2.18.+'
     mqlVersion = '3.2.2'
-    spectatorVersion = 'latest.release'
+    spectatorVersion = '0.134.0'
 }
 
 dependencies {


### PR DESCRIPTION
### Context

Change meaning of resubmission limit to take time duration into account. For long running jobs that may run for months or years, worker resubmissions will eventually reach the limit. We don't want to penalize such jobs. We should only terminate jobs where workers are resubmitted constantly. That may be due to bad code or external dependency failures.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
