### PR TITLE
applying formatting to all subprojects under mantis-server

### DIFF
--- a/baseline.gradle
+++ b/baseline.gradle
@@ -25,7 +25,7 @@ subprojects {
     // to be applied to ALL projects. And we are not prepared to address all of the build errors that
     // occur as a result at this time.
 
-    if (project.name in ['mantis-server-worker']) {
+    if (project.name in ['mantis-server-worker', 'mantis-server-agent', 'mantis-server-worker-client']) {
         apply plugin: 'com.palantir.baseline-exact-dependencies'
         apply plugin: 'com.palantir.baseline-format'
     }

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/MantisAgent.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/MantisAgent.java
@@ -16,9 +16,8 @@
 
 package io.mantisrx.server.agent;
 
-import java.util.concurrent.CountDownLatch;
-
 import io.mantisrx.server.core.Service;
+import java.util.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/MetricsClient.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/MetricsClient.java
@@ -27,4 +27,3 @@ public interface MetricsClient<T> {
 
     Observable<Observable<T>> getResults();
 }
-

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/MetricsClientImpl.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/MetricsClientImpl.java
@@ -16,11 +16,6 @@
 
 package io.mantisrx.server.worker.client;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import io.mantisrx.common.metrics.Gauge;
 import io.mantisrx.common.metrics.Metrics;
 import io.mantisrx.common.metrics.MetricsRegistry;
@@ -28,6 +23,10 @@ import io.mantisrx.common.network.WorkerEndpoint;
 import io.mantisrx.server.master.client.MasterClientWrapper;
 import io.reactivex.mantis.remote.observable.EndpointChange;
 import io.reactivx.mantis.operators.DropOperator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnection.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnection.java
@@ -18,13 +18,6 @@ package io.mantisrx.server.worker.client;
 
 import static com.mantisrx.common.utils.MantisMetricStringConstants.DROP_OPERATOR_INCOMING_METRIC_GROUP;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
-
 import com.mantisrx.common.utils.MantisSSEConstants;
 import io.mantisrx.common.MantisServerSentEvent;
 import io.mantisrx.common.compression.CompressionUtils;
@@ -36,6 +29,12 @@ import io.mantisrx.runtime.parameter.SinkParameter;
 import io.mantisrx.runtime.parameter.SinkParameters;
 import io.netty.buffer.ByteBuf;
 import io.reactivx.mantis.operators.DropOperator;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import mantis.io.reactivex.netty.RxNetty;
 import mantis.io.reactivex.netty.pipeline.PipelineConfigurators;
 import mantis.io.reactivex.netty.protocol.http.client.HttpClient;

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnectionFunction.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnectionFunction.java
@@ -18,12 +18,6 @@ package io.mantisrx.server.worker.client;
 
 import static com.mantisrx.common.utils.MantisMetricStringConstants.DROP_OPERATOR_INCOMING_METRIC_GROUP;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
 import com.mantisrx.common.utils.NettyUtils;
 import io.mantisrx.common.MantisServerSentEvent;
 import io.mantisrx.common.metrics.Counter;
@@ -33,6 +27,11 @@ import io.mantisrx.common.metrics.spectator.MetricGroupId;
 import io.mantisrx.runtime.parameter.SinkParameters;
 import io.mantisrx.server.core.ServiceRegistry;
 import io.reactivx.mantis.operators.DropOperator;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/WorkerMetricsClient.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/WorkerMetricsClient.java
@@ -16,12 +16,11 @@
 
 package io.mantisrx.server.worker.client;
 
-import java.util.Properties;
-
 import io.mantisrx.server.master.client.MantisMasterClientApi;
 import io.mantisrx.server.master.client.MasterClientWrapper;
 import io.mantisrx.server.master.client.config.ConfigurationFactory;
 import io.reactivex.mantis.remote.observable.EndpointChange;
+import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/example/SampleClient.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/example/SampleClient.java
@@ -16,21 +16,20 @@
 
 package io.mantisrx.server.worker.client.example;
 
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicReference;
-
-import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
-import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import com.sampullara.cli.Args;
 import com.sampullara.cli.Argument;
 import io.mantisrx.common.MantisServerSentEvent;
 import io.mantisrx.server.worker.client.MetricsClient;
 import io.mantisrx.server.worker.client.SseWorkerConnectionFunction;
 import io.mantisrx.server.worker.client.WorkerMetricsClient;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/TestSseServerFactory.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/TestSseServerFactory.java
@@ -16,14 +16,13 @@
 
 package io.mantisrx.server.worker;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.WriteBufferWaterMark;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import io.netty.buffer.ByteBuf;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.WriteBufferWaterMark;
 import mantis.io.reactivex.netty.RxNetty;
 import mantis.io.reactivex.netty.pipeline.PipelineConfigurators;
 import mantis.io.reactivex.netty.protocol.http.server.HttpServer;
@@ -63,7 +62,7 @@ public class TestSseServerFactory {
                 })
                 .pipelineConfigurator(PipelineConfigurators.<String>serveSseConfigurator())
                 .channelOption(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(1024 * 1024, 5 * 1024 * 1024))
-                
+
                 .build();
         server.start();
         synchronized (servers) {

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/MetricsClientImplTest.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/MetricsClientImplTest.java
@@ -18,16 +18,6 @@ package io.mantisrx.server.worker.client;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
-import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
-import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import io.mantisrx.common.MantisServerSentEvent;
 import io.mantisrx.common.metrics.measurement.CounterMeasurement;
 import io.mantisrx.common.metrics.measurement.GaugeMeasurement;
@@ -37,7 +27,16 @@ import io.mantisrx.common.network.WorkerEndpoint;
 import io.mantisrx.runtime.parameter.SinkParameters;
 import io.mantisrx.server.core.stats.MetricStringConstants;
 import io.mantisrx.server.worker.TestSseServerFactory;
+import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import io.reactivex.mantis.remote.observable.EndpointChange;
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionFunctionTest.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionFunctionTest.java
@@ -19,11 +19,10 @@ package io.mantisrx.server.worker.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import io.mantisrx.common.MantisServerSentEvent;
 import io.mantisrx.server.worker.TestSseServerFactory;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
@@ -16,6 +16,11 @@
 
 package io.mantisrx.server.worker.client;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.netflix.spectator.api.DefaultRegistry;
 import io.mantisrx.common.MantisServerSentEvent;
 import io.mantisrx.common.metrics.Counter;
@@ -25,6 +30,10 @@ import io.mantisrx.common.metrics.spectator.MetricGroupId;
 import io.mantisrx.common.metrics.spectator.SpectatorRegistryFactory;
 import io.netty.buffer.Unpooled;
 import io.reactivx.mantis.operators.DropOperator;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.TimeUnit;
 import mantis.io.reactivex.netty.protocol.http.client.HttpClientResponse;
 import mantis.io.reactivex.netty.protocol.http.sse.ServerSentEvent;
 import org.junit.Test;
@@ -34,16 +43,6 @@ import rx.Observable;
 import rx.observers.TestSubscriber;
 import rx.schedulers.Schedulers;
 import rx.schedulers.TestScheduler;
-
-import java.nio.charset.Charset;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class SseWorkerConnectionTest {
     private static final Logger logger = LoggerFactory.getLogger(SseWorkerConnectionTest.class);


### PR DESCRIPTION
### Context

Applying autoformatting to all subprojects under mantis-server

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
