### PR TITLE
Allow Mantis Job object to be passed in to stage executor as an option

### DIFF
--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
@@ -125,7 +125,8 @@ public class MantisWorker extends BaseService {
                             new MantisMasterClientApi(new LocalMasterMonitor(getInitialMasterDescription())),
                             config,
                             workerMetricsClient),
-                    getJobProviderClass()));
+                    getJobProviderClass(),
+                    null));
         } else {
             mantisServices.add(new VirualMachineWorkerServiceMesosImpl(executeStageSubject, vmTaskStatusSubject));
             CuratorService curatorService = new CuratorService(config, getInitialMasterDescription());
@@ -137,7 +138,8 @@ public class MantisWorker extends BaseService {
                     tasksStatusSubject,
                     new WorkerExecutionOperationsNetworkStage(vmTaskStatusSubject,
                             new MantisMasterClientApi(masterMonitor), config, workerMetricsClient),
-                    getJobProviderClass()));
+                    getJobProviderClass(),
+                    null));
         }
     }
 


### PR DESCRIPTION
### Context

In preparation for Spring Boot integration, a small refactor to allow a Job object to be passed in to stage executor. Instead of loading the job via ClassLoader, the job may be provided as a Bean for example.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
