### PR TITLE
Use lazy initialization for worker classes' loggers.

### DIFF
--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/DownloadJob.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/DownloadJob.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 public class DownloadJob {
 
-    private static final Logger logger = LoggerFactory.getLogger(DownloadJob.class);
+    private static volatile Logger logger;
     private URL jobArtifactUrl;
     private String jobName;
     private String locationToStore;
@@ -49,11 +49,19 @@ public class DownloadJob {
             System.exit(1);
         }
 
-        logger.info("parameters, jobArtifactUrl: " + args[0]);
-        logger.info("parameters, jobName: " + args[1]);
-        logger.info("parameters, locationToStore: " + args[2]);
+        logger().info("parameters, jobArtifactUrl: " + args[0]);
+        logger().info("parameters, jobName: " + args[1]);
+        logger().info("parameters, locationToStore: " + args[2]);
 
         new DownloadJob(new URL(args[0]), args[1], args[2]).execute();
+    }
+
+    private static Logger logger() {
+        if (logger == null) {
+            logger = LoggerFactory.getLogger(DownloadJob.class);
+        }
+
+        return logger;
     }
 
     public void execute() {
@@ -63,7 +71,7 @@ public class DownloadJob {
         Path path = Paths.get(locationToStore, jobName,
                 "lib");
 
-        logger.info("Started writing job to tmp directory: " + path);
+        logger().info("Started writing job to tmp directory: " + path);
         // download file to /tmp, then add file location
         try (InputStream is = jobArtifactUrl.openStream()) {
             Files.createDirectories(path);
@@ -75,9 +83,9 @@ public class DownloadJob {
                 }
             }
         } catch (IOException e1) {
-            logger.error("Failed to write job to local store at path: " + path, e1);
+            logger().error("Failed to write job to local store at path: " + path, e1);
             throw new RuntimeException(e1);
         }
-        logger.info("Finished writing job to tmp directory: " + path);
+        logger().info("Finished writing job to tmp directory: " + path);
     }
 }


### PR DESCRIPTION
Switch to lazy init for loggers used in worker instances to avoid missing logs.

### Context

Default static logger creation can cause logs to be dropped in certain cases if the properties were not picked up by the logging framework. Switch critical worker loggers to use lazy initialization instead.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
