### PR TITLE
Avoid SlaEnforcer on empty cluster

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
@@ -1233,8 +1233,14 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
             // change behavior to enabled
             getContext().become(initializedBehavior);
 
-            //start SLA timer
-            setBookkeepingTimer(BOOKKEEPING_INTERVAL_SECS);
+            //start SLA timer if there is previous job record to be able to enforce SLA.
+            if (this.jobManager.getAllNonTerminalJobsList().isEmpty() && this.jobManager.getCompletedJobsList().isEmpty()) {
+                logger.warn("No previous job found in cluster: {}, skip bookkeeping timer.", this.name);
+            }
+            else {
+                setBookkeepingTimer(BOOKKEEPING_INTERVAL_SECS);
+            }
+
             eventPublisher.publishAuditEvent(
                     new LifecycleEventsProto.AuditEvent(LifecycleEventsProto.AuditEvent.AuditEventType.JOB_CLUSTER_ENABLED,
                         this.jobClusterMetadata.getJobClusterDefinition().getName(), name + " enabled")


### PR DESCRIPTION
### Context

If a job cluster gets enabled without any prior jobs, the `SlaEnforcer` will cause repeated errors when submitting a new job instance, which will fail in submission due to lacking any previous job record.

Sample stack traces:
`SLAEnforcer:66 - Submit 1 jobs per sla min of 1
JobClusterActor:1809 - Submitting 1 jobs for job name SpaasLWCRequestSource as active count is 0 and accepted count is 0
JobClusterActor:1297 - Submitting job
JobClusterActor:2158 - Could not find any previous submitted Job for cluster SpaasLWCRequestSource
JobClusterActor:1314 - Exception submitting job SpaasLWCRequestSource from MantisMaster
java.lang.Exception: Job Definition could not retrieved from a previous submission (There may not be a previous submission)
	at io.mantisrx.master.jobcluster.JobClusterActor.getResolvedJobDefinition(JobClusterActor.java:1346)
	at io.mantisrx.master.jobcluster.JobClusterActor.onJobSubmit(JobClusterActor.java:1299)
`

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
