### PR TITLE
Add isLeaderReadyGauge

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/LeadershipManagerZkImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/LeadershipManagerZkImpl.java
@@ -32,6 +32,7 @@ public class LeadershipManagerZkImpl implements ILeadershipManager {
 
     private static final Logger logger = LoggerFactory.getLogger(LeadershipManagerZkImpl.class);
     private final Gauge isLeaderGauge;
+    private final Gauge isLeaderReadyGauge;
     private final AtomicBoolean firstTimeLeaderMode = new AtomicBoolean(false);
     private final MasterConfiguration config;
     private final ServiceLifecycle serviceLifecycle;
@@ -45,9 +46,11 @@ public class LeadershipManagerZkImpl implements ILeadershipManager {
         Metrics m = new Metrics.Builder()
                 .name(MasterMain.class.getCanonicalName())
                 .addGauge("isLeaderGauge")
+                .addGauge("isLeaderReadyGauge")
                 .build();
         m = MetricsRegistry.getInstance().registerAndGet(m);
         isLeaderGauge = m.getGauge("isLeaderGauge");
+        isLeaderReadyGauge = m.getGauge("isLeaderReadyGauge");
     }
 
     public void becomeLeader() {
@@ -71,6 +74,7 @@ public class LeadershipManagerZkImpl implements ILeadershipManager {
 
     public void setLeaderReady() {
         logger.info("marking leader READY");
+        isLeaderReadyGauge.set(1L);
         isReady = true;
     }
 
@@ -79,6 +83,7 @@ public class LeadershipManagerZkImpl implements ILeadershipManager {
         isReady = false;
         isLeader = false;
         isLeaderGauge.set(0L);
+        isLeaderReadyGauge.set(0L);
         if (!firstTimeLeaderMode.get()) {
             logger.warn("Unexpected to be told to stop being leader when we haven't entered leader mode before, ignoring.");
             return;


### PR DESCRIPTION
### Context

Add gauge to track whether an elected leader has finished the bootstrap process and becomes ready to serve requests.
This helps determine when a leader gets elected successfully but fails to finish bootstrap to be in the ready state.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
