### PR TITLE
Handle nullptr on killJobRequest requestor

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
@@ -1716,7 +1716,15 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
             jobInfo.get().jobActor.tell(req, getSelf());
         } else {
             logger.info("Job {} not found", req.jobId.getId() );
-            req.requestor.tell(new JobClusterManagerProto.KillJobResponse(req.requestId, CLIENT_ERROR_NOT_FOUND, JobState.Noop, "Job " + req.jobId + " not found", req.jobId, req.user), getSelf());
+            if (req.requestor != null) {
+                req.requestor.tell(
+                        new JobClusterManagerProto.KillJobResponse(
+                                req.requestId,
+                                CLIENT_ERROR_NOT_FOUND,
+                                JobState.Noop,
+                                "Job " + req.jobId + " not found", req.jobId, req.user),
+                        getSelf());
+            }
         }
     }
 


### PR DESCRIPTION
### Context

Handle null ptr exception for `KillJobRequest.requestor`. This can happen when the requestor is cluster manager actor itself e.g. worker resubmit count exceeded case.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
