### PR TITLE
Rename defaultStream to __default__.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,4 +194,10 @@ gradle-app.setting
 ### Gradle Patch ###
 **/build/
 
+.classpath
+.project
+.settings/
+bin/
+
 # End of https://www.gitignore.io/api/vim,java,linux,macos,gradle,intellij+all
+

--- a/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/StreamManager.java
+++ b/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/StreamManager.java
@@ -19,7 +19,6 @@ package io.mantisrx.publish;
 import com.netflix.spectator.api.Counter;
 import com.netflix.spectator.api.Registry;
 import io.mantisrx.publish.api.Event;
-import io.mantisrx.publish.api.StreamType;
 import io.mantisrx.publish.config.MrePublishConfiguration;
 import io.mantisrx.publish.core.Subscription;
 import io.mantisrx.publish.internal.metrics.SpectatorUtils;
@@ -35,7 +34,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/StreamManager.java
+++ b/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/StreamManager.java
@@ -136,19 +136,6 @@ public class StreamManager {
                 .orElse(false);
     }
 
-    private List<String> sanitizeStreamSubjects(final List<String> subjects) {
-        return subjects.stream()
-                .map(s -> {
-                    if (s.toLowerCase().equals("observable") ||
-                            s.toLowerCase().equals("stream")) {
-                        // Translate the legacy default stream names to map to the default stream.
-                        return StreamType.DEFAULT_EVENT_STREAM;
-                    } else {
-                        return s;
-                    }
-                }).collect(Collectors.toList());
-    }
-
     private void handleDuplicateSubscriptionId(final Subscription sub) {
         String subId = sub.getSubscriptionId();
         Optional.ofNullable(subscriptionIdToStreamsMap.get(subId))
@@ -156,7 +143,7 @@ public class StreamManager {
     }
 
     synchronized void addStreamSubscription(final Subscription sub) {
-        List<String> streams = sanitizeStreamSubjects(sub.getSubjects());
+        List<String> streams = sub.getSubjects();
         LOG.info("adding subscription {} with streams {}", sub, streams);
 
         handleDuplicateSubscriptionId(sub);
@@ -224,7 +211,7 @@ public class StreamManager {
 
     synchronized boolean removeStreamSubscription(final Subscription sub) {
         LOG.info("removing subscription {}", sub);
-        final List<String> streams = sanitizeStreamSubjects(sub.getSubjects());
+        final List<String> streams = sub.getSubjects();
         removeSubscriptionId(streams, sub.getSubscriptionId());
         subscriptionIdToStreamsMap.remove(sub.getSubscriptionId());
 

--- a/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/api/StreamType.java
+++ b/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/api/StreamType.java
@@ -21,7 +21,6 @@ public class StreamType {
     /**
      * Default Stream name for emitting events.
      */
-    //public static final String DEFAULT_EVENT_STREAM = "defaultStream";
 	public static final String DEFAULT_EVENT_STREAM = "__default__";
 
     /**

--- a/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/api/StreamType.java
+++ b/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/api/StreamType.java
@@ -21,7 +21,8 @@ public class StreamType {
     /**
      * Default Stream name for emitting events.
      */
-    public static final String DEFAULT_EVENT_STREAM = "defaultStream";
+    //public static final String DEFAULT_EVENT_STREAM = "defaultStream";
+	public static final String DEFAULT_EVENT_STREAM = "__default__";
 
     /**
      * Stream name for emitting request events.

--- a/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/mql/MQLSubscription.java
+++ b/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/mql/MQLSubscription.java
@@ -123,7 +123,7 @@ public class MQLSubscription implements Subscription, Comparable {
                 .map((String s) -> {
                     if (s.toLowerCase().equals("observable") ||
                             s.toLowerCase().equals("stream") ||
-							s.toLowerCase().equals("defaultstream")) {
+                            s.toLowerCase().equals("defaultstream")) {
                         // Translate the legacy default stream names to map to the default stream.
                         return StreamType.DEFAULT_EVENT_STREAM;
                     } else {

--- a/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/mql/MQLSubscription.java
+++ b/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/internal/mql/MQLSubscription.java
@@ -18,6 +18,7 @@ package io.mantisrx.publish.internal.mql;
 
 import io.mantisrx.mql.jvm.core.Query;
 import io.mantisrx.publish.api.Event;
+import io.mantisrx.publish.api.StreamType;
 import io.mantisrx.publish.core.Subscription;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -117,8 +118,26 @@ public class MQLSubscription implements Subscription, Comparable {
         }
     }
 
+	private List<String> sanitizeStreamSubjects(final List<String> subjects) {
+        return subjects.stream()
+                .map((String s) -> {
+                    if (s.toLowerCase().equals("observable") ||
+                            s.toLowerCase().equals("stream") ||
+							s.toLowerCase().equals("defaultstream")) {
+                        // Translate the legacy default stream names to map to the default stream.
+                        return StreamType.DEFAULT_EVENT_STREAM;
+                    } else {
+                        return s;
+                    }
+                }).collect(Collectors.toList());
+    }
+
+	public List<String> getSubjects() {
+		return sanitizeStreamSubjects(getSubjectsInternal());
+	}
+
     @SuppressWarnings("unchecked")
-    public List<String> getSubjects() {
+    public List<String> getSubjectsInternal() {
         return this.query.getSubjects();
     }
 

--- a/mantis-publish/mantis-publish-core/src/test/java/io/mantisrx/publish/AbstractSubscriptionTrackerTest.java
+++ b/mantis-publish/mantis-publish-core/src/test/java/io/mantisrx/publish/AbstractSubscriptionTrackerTest.java
@@ -81,8 +81,7 @@ public class AbstractSubscriptionTrackerTest {
         subscriptionTracker.setNextSubscriptions(ImmutableMap.of(StreamType.DEFAULT_EVENT_STREAM, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        Set<Subscription> subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        Set<String> subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+		Set<String> subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         Set<String> expected = ImmutableSet.of("id1", "id2");
         assertEquals(expected, subIds);
     }
@@ -101,8 +100,7 @@ public class AbstractSubscriptionTrackerTest {
         subscriptionTracker.setNextSubscriptions(ImmutableMap.of(StreamType.DEFAULT_EVENT_STREAM, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        Set<Subscription> subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        Set<String> subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        Set<String> subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         Set<String> expected = ImmutableSet.of("id1", "id2");
         assertEquals(expected, subIds);
 
@@ -118,8 +116,7 @@ public class AbstractSubscriptionTrackerTest {
         subscriptionTracker.setNextSubscriptions(ImmutableMap.of(StreamType.DEFAULT_EVENT_STREAM, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         expected = ImmutableSet.of("id1", "id2", "id3", "id4");
         assertEquals(expected, subIds);
     }
@@ -135,8 +132,7 @@ public class AbstractSubscriptionTrackerTest {
         subscriptionTracker.setNextSubscriptions(ImmutableMap.of(StreamType.DEFAULT_EVENT_STREAM, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        Set<Subscription> subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        Set<String> subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        Set<String> subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         Set<String> expected = ImmutableSet.of("id1", "id2", "id3");
         assertEquals(expected, subIds);
 
@@ -149,8 +145,7 @@ public class AbstractSubscriptionTrackerTest {
         subscriptionTracker.setNextSubscriptions(ImmutableMap.of(StreamType.DEFAULT_EVENT_STREAM, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         expected = ImmutableSet.of("id1", "id2", "id3", "id4");
         assertEquals(expected, subIds);
 
@@ -161,8 +156,7 @@ public class AbstractSubscriptionTrackerTest {
         subscriptionTracker.setNextSubscriptions(ImmutableMap.of(StreamType.DEFAULT_EVENT_STREAM, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         expected = ImmutableSet.of("id2", "id4");
         assertEquals(expected, subIds);
     }
@@ -188,13 +182,11 @@ public class AbstractSubscriptionTrackerTest {
                 requestStream, nextRequestSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        Set<Subscription> subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        Set<String> subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        Set<String> subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         Set<String> expected = ImmutableSet.of("default_id1", "default_id2", "default_id3");
         assertEquals(expected, subIds);
 
-        subs = streamManager.getStreamSubscriptions(requestStream);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(requestStream);
         expected = ImmutableSet.of("request_id1", "request_id2", "default_id3");
         assertEquals(expected, subIds);
 
@@ -211,13 +203,11 @@ public class AbstractSubscriptionTrackerTest {
                 requestStream, nextRequestSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         expected = ImmutableSet.of("default_id1");
         assertEquals(expected, subIds);
 
-        subs = streamManager.getStreamSubscriptions(requestStream);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(requestStream);
         expected = ImmutableSet.of("request_id1", "request_id2", "request_id4");
         assertEquals(expected, subIds);
 
@@ -236,13 +226,11 @@ public class AbstractSubscriptionTrackerTest {
                 requestStream, nextRequestSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         expected = ImmutableSet.of("default_id1", "default_id3");
         assertEquals(expected, subIds);
 
-        subs = streamManager.getStreamSubscriptions(requestStream);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(requestStream);
         expected = ImmutableSet.of("request_id1", "request_id2", "request_id4", "default_id3");
         assertEquals(expected, subIds);
     }
@@ -265,13 +253,11 @@ public class AbstractSubscriptionTrackerTest {
                 requestStream, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        Set<Subscription> subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        Set<String> subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        Set<String> subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         Set<String> expected = ImmutableSet.of("default_id1", "default_id2", "default_id3");
         assertEquals(expected, subIds);
 
-        subs = streamManager.getStreamSubscriptions(requestStream);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(requestStream);
         expected = ImmutableSet.of("request_id1", "request_id2", "default_id3");
         assertEquals(expected, subIds);
 
@@ -285,13 +271,11 @@ public class AbstractSubscriptionTrackerTest {
                 requestStream, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         expected = ImmutableSet.of("default_id1");
         assertEquals(expected, subIds);
 
-        subs = streamManager.getStreamSubscriptions(requestStream);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(requestStream);
         expected = ImmutableSet.of("request_id1", "request_id2", "request_id4");
         assertEquals(expected, subIds);
 
@@ -306,13 +290,11 @@ public class AbstractSubscriptionTrackerTest {
                 requestStream, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-        subs = streamManager.getStreamSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         expected = ImmutableSet.of("default_id1", "default_id3");
         assertEquals(expected, subIds);
 
-        subs = streamManager.getStreamSubscriptions(requestStream);
-        subIds = subs.stream().map(Subscription::getSubscriptionId).collect(Collectors.toSet());
+        subIds = subscriptionTracker.getCurrentSubIds(requestStream);
         expected = ImmutableSet.of("request_id1", "request_id2", "request_id4", "default_id3");
         assertEquals(expected, subIds);
     }

--- a/mantis-publish/mantis-publish-core/src/test/java/io/mantisrx/publish/AbstractSubscriptionTrackerTest.java
+++ b/mantis-publish/mantis-publish-core/src/test/java/io/mantisrx/publish/AbstractSubscriptionTrackerTest.java
@@ -31,7 +31,6 @@ import com.netflix.spectator.api.Registry;
 import io.mantisrx.publish.api.StreamType;
 import io.mantisrx.publish.config.MrePublishConfiguration;
 import io.mantisrx.publish.config.SampleArchaiusMrePublishConfiguration;
-import io.mantisrx.publish.core.Subscription;
 import io.mantisrx.publish.internal.discovery.MantisJobDiscovery;
 import io.mantisrx.publish.proto.MantisServerSubscription;
 import io.mantisrx.publish.proto.MantisServerSubscriptionEnvelope;
@@ -43,7 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/mantis-publish/mantis-publish-core/src/test/java/io/mantisrx/publish/AbstractSubscriptionTrackerTest.java
+++ b/mantis-publish/mantis-publish-core/src/test/java/io/mantisrx/publish/AbstractSubscriptionTrackerTest.java
@@ -81,7 +81,7 @@ public class AbstractSubscriptionTrackerTest {
         subscriptionTracker.setNextSubscriptions(ImmutableMap.of(StreamType.DEFAULT_EVENT_STREAM, nextSubs));
         subscriptionTracker.refreshSubscriptions();
 
-		Set<String> subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
+        Set<String> subIds = subscriptionTracker.getCurrentSubIds(StreamType.DEFAULT_EVENT_STREAM);
         Set<String> expected = ImmutableSet.of("id1", "id2");
         assertEquals(expected, subIds);
     }


### PR DESCRIPTION
We experienced a bug in production in which the `mreAppJobClusterMap`
uses `__default__` as the routing key when a stream does not have a
routing entry. These routing keys are internally used as stream names,
however internally mantis-published used `defaultStream`. This commit
reconciles these two by renaming defaultStream to `__default__`.
`
More work to come in the future to avoid conflation of routing keys and
stream names.

### Context

Explain context and other details for this pull request.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
