### PR TITLE
Enabling build scans and getting rid of deprecated configurations in build files

### DIFF
--- a/mantis-connectors/mantis-connector-kafka/build.gradle
+++ b/mantis-connectors/mantis-connector-kafka/build.gradle
@@ -26,17 +26,17 @@ dependencies {
     implementation project(":mantis-shaded")
     implementation project(":mantis-runtime")
 
-    compile "org.apache.kafka:kafka-clients:$kafkaVersion"
+    api "org.apache.kafka:kafka-clients:$kafkaVersion"
 
     api "io.reactivex:rxjava:$versionRxJava"
     api "com.netflix.spectator:spectator-api:$spectatorVersion"
     api "com.netflix.archaius:archaius2-api:$archaiusVersion"
     api "com.netflix.archaius:archaius2-core:$archaiusVersion"
 
-    testCompile "junit:junit"
-    testCompile "org.mockito:mockito-all:1.9.5"
+    testImplementation "junit:junit"
+    testImplementation "org.mockito:mockito-all:1.9.5"
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.21.0"
     testCompileOnly "com.netflix.archaius:archaius2-core:$archaiusVersion"
     // update kafka-unit version for kafka 2.2.+ once this PR is released https://github.com/chbatey/kafka-unit/pull/69
-    testCompile 'info.batey.kafka:kafka-unit:1.0'
+    testImplementation 'info.batey.kafka:kafka-unit:1.0'
 }

--- a/mantis-control-plane/mantis-control-plane-client/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-client/build.gradle
@@ -15,12 +15,12 @@
  */
 
 dependencies {
-    compile project(":mantis-control-plane:mantis-control-plane-core")
+    api project(":mantis-control-plane:mantis-control-plane-core")
 
-    compile project(":mantis-remote-observable")
+    api project(":mantis-remote-observable")
 
-    testCompile "junit:junit-dep:$junitVersion"
-    testCompile "org.mockito:mockito-all:$mockitoVersion"
+    testImplementation "junit:junit-dep:$junitVersion"
+    testImplementation "org.mockito:mockito-all:$mockitoVersion"
 }
 
 

--- a/mantis-network/build.gradle
+++ b/mantis-network/build.gradle
@@ -22,9 +22,9 @@ ext {
 }
 
 dependencies {
-    compile "io.netty:netty-handler:$nettyVersion"
-    compile "io.mantisrx:mql-jvm:$mqlVersion"
-    compile project(':mantis-common')
+    api "io.netty:netty-handler:$nettyVersion"
+    api "io.mantisrx:mql-jvm:$mqlVersion"
+    api project(':mantis-common')
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+plugins {
+    id 'com.gradle.enterprise' version '3.4.1'
+}
+
 rootProject.name = 'mantis'
 
 include 'mantis-client'
@@ -57,3 +61,11 @@ include 'mantis-shaded'
 
 include 'mantis-source-jobs:mantis-source-job-kafka'
 include 'mantis-source-jobs:mantis-source-job-publish'
+
+gradleEnterprise {
+    buildScan {
+        publishAlways()
+        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+        termsOfServiceAgree = 'yes'
+    }
+}


### PR DESCRIPTION
I want to get the mantis OSS repo ready for gradle 7.0. This means we will have to get rid of deprecated rules/configurations in build files. 

### Context

^^^

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
