### PR TITLE
Enabling gradle cache for the whole repository in order to speed up the builds

### DIFF
--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -16,30 +16,33 @@ jobs:
         java: [ 8 ]
     name: CI with Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Setup jdk
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
-        id: gradle-cache
+      - uses: gradle/gradle-build-action@v2
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
-          restore-keys: |
-            - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
-        id: gradle-wrapper-cache
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
-          restore-keys: |
-            - ${{ runner.os }}-gradlewrapper-
-      - name: Build with Gradle
-        run: ./gradlew --info --stacktrace build
-        env:
-          CI_NAME: github_actions
-          CI_BUILD_NUMBER: ${{ github.sha }}
-          CI_BUILD_URL: 'https://github.com/${{ github.repository }}'
-          CI_BRANCH: ${{ github.ref }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          arguments: build
+#      - uses: actions/cache@v1
+#        id: gradle-cache
+#        with:
+#          path: ~/.gradle/caches
+#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
+#          restore-keys: |
+#            - ${{ runner.os }}-gradle-
+#      - uses: actions/cache@v1
+#        id: gradle-wrapper-cache
+#        with:
+#          path: ~/.gradle/wrapper
+#          key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
+#          restore-keys: |
+#            - ${{ runner.os }}-gradlewrapper-
+#      - name: Build with Gradle
+#        run: ./gradlew --info --stacktrace build
+#        env:
+#          CI_NAME: github_actions
+#          CI_BUILD_NUMBER: ${{ github.sha }}
+#          CI_BUILD_URL: 'https://github.com/${{ github.repository }}'
+#          CI_BRANCH: ${{ github.ref }}
+#          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -23,27 +23,11 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
       - uses: gradle/gradle-build-action@v2
+        env:
+          CI_NAME: github_actions
+          CI_BUILD_NUMBER: ${{ github.sha }}
+          CI_BUILD_URL: 'https://github.com/${{ github.repository }}'
+          CI_BRANCH: ${{ github.ref }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           arguments: build
-#      - uses: actions/cache@v1
-#        id: gradle-cache
-#        with:
-#          path: ~/.gradle/caches
-#          key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
-#          restore-keys: |
-#            - ${{ runner.os }}-gradle-
-#      - uses: actions/cache@v1
-#        id: gradle-wrapper-cache
-#        with:
-#          path: ~/.gradle/wrapper
-#          key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
-#          restore-keys: |
-#            - ${{ runner.os }}-gradlewrapper-
-#      - name: Build with Gradle
-#        run: ./gradlew --info --stacktrace build
-#        env:
-#          CI_NAME: github_actions
-#          CI_BUILD_NUMBER: ${{ github.sha }}
-#          CI_BUILD_URL: 'https://github.com/${{ github.repository }}'
-#          CI_BRANCH: ${{ github.ref }}
-#          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: ${{ matrix.java }}
+          distribution: 'zulu'
       - uses: gradle/gradle-build-action@v2
         with:
           arguments: build

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
### Context

Gradle cache is a fairly mature feature right now and has been battle-tested at Netflix and other places. Thus, enabling this feature in the mantis repo in the hope that it would help reduce build times. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
