### PR TITLE
Cleaning up other github workflows to make use of the latest and greatest github actions versions

### DIFF
--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -12,36 +12,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: Setup jdk 8
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v2
+      - name: Setup jdk
+        uses: actions/setup-java@v2
         with:
-          java-version: 1.8
-      - uses: actions/cache@v1
-        id: gradle-cache
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
-          restore-keys: |
-            - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
-        id: gradle-wrapper-cache
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
-          restore-keys: |
-            - ${{ runner.os }}-gradlewrapper-
+          java-version: 8
+          distribution: 'zulu'
       - name: Publish candidate
         if: contains(github.ref, '-rc.')
-        run: ./gradlew --info --stacktrace -Prelease.useLastTag=true candidate
+        uses: gradle/gradle-build-action@v2
         env:
           NETFLIX_OSS_SIGNING_KEY: ${{ secrets.ORG_SIGNING_KEY }}
           NETFLIX_OSS_SIGNING_PASSWORD: ${{ secrets.ORG_SIGNING_PASSWORD }}
           NETFLIX_OSS_REPO_USERNAME: ${{ secrets.ORG_NETFLIXOSS_USERNAME }}
           NETFLIX_OSS_REPO_PASSWORD: ${{ secrets.ORG_NETFLIXOSS_PASSWORD }}
+        with:
+          arguments: -Prelease.useLastTag=true candidate
       - name: Publish release
         if: (!contains(github.ref, '-rc.'))
-        run: ./gradlew --info -Prelease.useLastTag=true final
+        uses: gradle/gradle-build-action@v2
         env:
           NETFLIX_OSS_SONATYPE_USERNAME: ${{ secrets.ORG_SONATYPE_USERNAME }}
           NETFLIX_OSS_SONATYPE_PASSWORD: ${{ secrets.ORG_SONATYPE_PASSWORD }}
@@ -50,3 +39,5 @@ jobs:
           NETFLIX_OSS_REPO_USERNAME: ${{ secrets.ORG_NETFLIXOSS_USERNAME }}
           NETFLIX_OSS_REPO_PASSWORD: ${{ secrets.ORG_NETFLIXOSS_PASSWORD }}
           NETFLIX_OSS_SONATYPE_STAGING_PROFILE_ID: "c3547130240327"
+        with:
+          arguments: -Prelease.useLastTag=true final

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -12,26 +12,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Setup jdk
+        uses: actions/setup-java@v2
         with:
           java-version: 8
-      - uses: actions/cache@v2
-        id: gradle-cache
-        with:
-          path: |
-            ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-      - uses: actions/cache@v2
-        id: gradle-wrapper-cache
-        with:
-          path: |
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradlewrapper-${{ hashFiles('gradle/wrapper/*') }}
+          distribution: 'zulu'
       - name: Build
-        run: ./gradlew build snapshot
+        uses: gradle/gradle-build-action@v2
         env:
           NETFLIX_OSS_SIGNING_KEY: ${{ secrets.ORG_SIGNING_KEY }}
           NETFLIX_OSS_SIGNING_PASSWORD: ${{ secrets.ORG_SIGNING_PASSWORD }}
           NETFLIX_OSS_REPO_USERNAME: ${{ secrets.ORG_NETFLIXOSS_USERNAME }}
           NETFLIX_OSS_REPO_PASSWORD: ${{ secrets.ORG_NETFLIXOSS_PASSWORD }}
+        with:
+          arguments: build snapshot


### PR DESCRIPTION
### Context

Similar to https://github.com/Netflix/mantis/pull/138, this PR updates other workflows so that they use 
1. the latest and greatest version of github actions plugins
2. use gradle cache appropriately. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
