### PR TITLE
Only count resubmission from worker failures

### DIFF
--- a/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;


### PR DESCRIPTION
### Context

If workers are resubmitted too frequently within a time period, the job is automatically terminated. However, there are scenarios where workers are supposed to be resubmitted, such as moving mesos clusters. We should only count resubmissions that are due to errors (worker is an error state and terminated unexpectedly).

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
