### PR TITLE
RTDI-2167 source job has incorrect subscriptions

### DIFF
--- a/mantis-common/src/main/java/com/mantisrx/common/utils/MantisSSEConstants.java
+++ b/mantis-common/src/main/java/com/mantisrx/common/utils/MantisSSEConstants.java
@@ -43,4 +43,6 @@ public class MantisSSEConstants {
     public static final String ID = "id";
 
     public static final String MQL = "mql";
+
+    public static final String TARGET_JOB = "sourceJobName";
 }


### PR DESCRIPTION
### Context

We have detected an issue internally that occurs with low probability. Connectors retrying an `IP:PORT` combination may connect to an unrelated job if that same `IP:PORT` combination is reused in a time frame less than the the client's expiration period. To address this we'll be making connection intentions explicit by passing a `sourceJobName` parameter when making a connection.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
