### PR TITLE
SinkClient fix logging on unsubscribe

### DIFF
--- a/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
@@ -144,10 +144,10 @@ public class SinkClientImpl<T> implements SinkClient<T> {
                 })
                 .doOnUnsubscribe(() -> {
                     try {
-                        logger.warn("Closing connections to sink of job " + jobId);
+                        logger.warn("Closing connections to sink of job {}", jobId);
                         closeAllConnections();
                     } catch (Exception e) {
-                        Observable.error(e);
+                        logger.warn("Error closing all connections to sink of job {}", jobId, e);
                     }
                 })
                 .share()
@@ -212,7 +212,7 @@ public class SinkClientImpl<T> implements SinkClient<T> {
             }
         }
         return ((SinkConnection<T>) sinkConnection).call()
-                //.flatMap(o -> o)
+                .takeWhile(e -> !nowClosed.get())
                 ;
     }
 

--- a/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;


### PR DESCRIPTION
### Context

On stale connection issue, after checking the logs, `doOnUnsubscribe` was called. However, not all the connections were closed. There is likely an exception somewhere. The old exception catch doesn't do anything. It should at least log.

I also added another safe guard to terminate the inner observable once the sink is permanently closed.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
