### PR TITLE
[Part 3] Refactoring Mantis Master Client code into a Gateway interface that defines the spec and a curator based implementation that matches that.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,13 +48,15 @@ ext {
 }
 
 ext.libraries = [
+        asyncHttpClient: 'org.asynchttpclient:async-http-client:2.12.3',
         flinkRpcApi: [
                 "org.apache.flink:flink-rpc-core:1.14.2"
         ],
         flinkRpcImpl: [
                 "org.apache.flink:flink-rpc-akka:1.14.2",
                 "org.apache.flink:flink-rpc-akka-loader:1.14.2"
-        ]
+        ],
+        spotifyFutures: "com.spotify:completable-futures:0.3.1"
 ]
 
 allprojects {

--- a/mantis-client/src/main/java/io/mantisrx/client/StageWorkersCount.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/StageWorkersCount.java
@@ -20,7 +20,7 @@ import com.sampullara.cli.Args;
 import com.sampullara.cli.Argument;
 import io.mantisrx.server.core.JobSchedulingInfo;
 import io.mantisrx.server.core.WorkerAssignments;
-import io.mantisrx.server.master.client.MantisMasterClientApi;
+import io.mantisrx.server.master.client.MantisMasterGateway;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -90,9 +90,9 @@ public class StageWorkersCount {
         return mantisClient
                 .getClientWrapper()
                 .getMasterClientApi()
-                .flatMap(new Func1<MantisMasterClientApi, Observable<Integer>>() {
+                .flatMap(new Func1<MantisMasterGateway, Observable<Integer>>() {
                     @Override
-                    public Observable<Integer> call(MantisMasterClientApi mantisMasterClientApi) {
+                    public Observable<Integer> call(MantisMasterGateway mantisMasterClientApi) {
                         return mantisMasterClientApi
                                 .schedulingChanges(jobId)
                                 .map(new Func1<JobSchedulingInfo, Integer>() {

--- a/mantis-client/src/main/java/io/mantisrx/client/examples/ConnectToNamedJob.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/examples/ConnectToNamedJob.java
@@ -21,10 +21,14 @@ import com.sampullara.cli.Argument;
 import io.mantisrx.client.MantisSSEJob;
 import io.mantisrx.client.SinkConnectionsStatus;
 import io.mantisrx.common.MantisServerSentEvent;
+import io.mantisrx.server.core.Configurations;
+import io.mantisrx.server.core.CoreConfiguration;
 import io.mantisrx.server.core.JobSchedulingInfo;
 import io.mantisrx.server.core.WorkerAssignments;
 import io.mantisrx.server.core.WorkerHost;
-import io.mantisrx.server.master.client.MantisMasterClientApi;
+import io.mantisrx.server.master.client.HighAvailabilityServices;
+import io.mantisrx.server.master.client.HighAvailabilityServicesUtil;
+import io.mantisrx.server.master.client.MantisMasterGateway;
 import io.mantisrx.server.master.client.MasterClientWrapper;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -74,11 +78,13 @@ public class ConnectToNamedJob {
         } catch (IOException e) {
             e.printStackTrace();
         }
-        MasterClientWrapper clientWrapper = new MasterClientWrapper(properties);
+        HighAvailabilityServices haServices = HighAvailabilityServicesUtil.createHAServices(
+            Configurations.frmProperties(properties, CoreConfiguration.class));
+        MasterClientWrapper clientWrapper = new MasterClientWrapper(haServices.getMasterClientApi());
         clientWrapper.getMasterClientApi()
-                .doOnNext(new Action1<MantisMasterClientApi>() {
+                .doOnNext(new Action1<MantisMasterGateway>() {
                     @Override
-                    public void call(MantisMasterClientApi clientApi) {
+                    public void call(MantisMasterGateway clientApi) {
                         logger.info("************** connecting to schedInfo for job " + jobId);
                         clientApi.schedulingChanges(jobId)
                                 .doOnNext(new Action1<JobSchedulingInfo>() {

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServices.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServices.java
@@ -15,15 +15,22 @@
  */
 package io.mantisrx.server.master.client;
 
-import io.mantisrx.server.core.master.MasterDescription;
 import io.mantisrx.server.core.master.MasterMonitor;
 import io.mantisrx.shaded.com.google.common.util.concurrent.Service;
-import rx.Observable;
 
+/**
+ * HighAvailabilityServices is a container for a group of services which are considered to be highly available because
+ * of multiple standbys capable of handling the service in case the leader goes down for instance.
+ *
+ * In Mantis, the following services are considered highly-available:
+ *   1. Mantis master which handles all the job-cluster/job/stage/worker interactions.
+ *   2. Resource Manager which handles all the resource specific interactions such as resource status updates,
+ *   registrations and heartbeats.
+ *
+ * These services can be obtained from the HighAvailabilityServices implementation.
+ */
 public interface HighAvailabilityServices extends Service {
   MantisMasterGateway getMasterClientApi();
-
-  Observable<MasterDescription> getMasterDescription();
 
   MasterMonitor getMasterMonitor();
 }

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServices.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServices.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.mantisrx.server.master.client;
 
-dependencies {
-    implementation libraries.asyncHttpClient
-    implementation libraries.spotifyFutures
-    api project(":mantis-control-plane:mantis-control-plane-core")
+import io.mantisrx.server.core.master.MasterDescription;
+import io.mantisrx.server.core.master.MasterMonitor;
+import io.mantisrx.shaded.com.google.common.util.concurrent.Service;
+import rx.Observable;
 
-    api project(":mantis-remote-observable")
+public interface HighAvailabilityServices extends Service {
+  MantisMasterGateway getMasterClientApi();
 
-    testImplementation "junit:junit-dep:$junitVersion"
-    testImplementation "org.mockito:mockito-all:$mockitoVersion"
+  Observable<MasterDescription> getMasterDescription();
+
+  MasterMonitor getMasterMonitor();
 }
-
-

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
@@ -16,13 +16,14 @@
 package io.mantisrx.server.master.client;
 
 import io.mantisrx.server.core.CoreConfiguration;
-import io.mantisrx.server.core.master.MasterDescription;
 import io.mantisrx.server.core.master.MasterMonitor;
 import io.mantisrx.server.core.zookeeper.CuratorService;
 import io.mantisrx.shaded.com.google.common.util.concurrent.AbstractIdleService;
 import lombok.extern.slf4j.Slf4j;
-import rx.Observable;
 
+/**
+ * HighAvailabilityServicesUtil helps you create HighAvailabilityServices instance based on the core configuration.
+ */
 @Slf4j
 public class HighAvailabilityServicesUtil {
 
@@ -34,6 +35,10 @@ public class HighAvailabilityServicesUtil {
     }
   }
 
+  /**
+   * Zookeeper based implementation of HighAvailabilityServices that finds the various leader instances
+   * through metadata stored on zookeeper.
+   */
   private static class ZkHighAvailabilityServices extends AbstractIdleService implements
       HighAvailabilityServices {
 
@@ -56,11 +61,6 @@ public class HighAvailabilityServicesUtil {
     @Override
     public MantisMasterGateway getMasterClientApi() {
       return new MantisMasterClientApi(curatorService.getMasterMonitor());
-    }
-
-    @Override
-    public Observable<MasterDescription> getMasterDescription() {
-      return curatorService.getMasterMonitor().getMasterObservable();
     }
 
     @Override

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mantisrx.server.master.client;
+
+import io.mantisrx.server.core.CoreConfiguration;
+import io.mantisrx.server.core.master.MasterDescription;
+import io.mantisrx.server.core.master.MasterMonitor;
+import io.mantisrx.server.core.zookeeper.CuratorService;
+import io.mantisrx.shaded.com.google.common.util.concurrent.AbstractIdleService;
+import lombok.extern.slf4j.Slf4j;
+import rx.Observable;
+
+@Slf4j
+public class HighAvailabilityServicesUtil {
+
+  public static HighAvailabilityServices createHAServices(CoreConfiguration configuration) {
+    if (configuration.isLocalMode()) {
+      throw new UnsupportedOperationException();
+    } else {
+      return new ZkHighAvailabilityServices(configuration);
+    }
+  }
+
+  private static class ZkHighAvailabilityServices extends AbstractIdleService implements
+      HighAvailabilityServices {
+
+    private final CuratorService curatorService;
+
+    public ZkHighAvailabilityServices(CoreConfiguration configuration) {
+      curatorService = new CuratorService(configuration, null);
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+      curatorService.start();
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+      curatorService.shutdown();
+    }
+
+    @Override
+    public MantisMasterGateway getMasterClientApi() {
+      return new MantisMasterClientApi(curatorService.getMasterMonitor());
+    }
+
+    @Override
+    public Observable<MasterDescription> getMasterDescription() {
+      return curatorService.getMasterMonitor().getMasterObservable();
+    }
+
+    @Override
+    public MasterMonitor getMasterMonitor() {
+      return curatorService.getMasterMonitor();
+    }
+  }
+}

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
@@ -16,6 +16,11 @@
 
 package io.mantisrx.server.master.client;
 
+import static org.asynchttpclient.Dsl.asyncHttpClient;
+import static org.asynchttpclient.Dsl.post;
+
+import com.spotify.futures.CompletableFutures;
+import io.mantisrx.common.Ack;
 import io.mantisrx.common.Label;
 import io.mantisrx.common.network.Endpoint;
 import io.mantisrx.runtime.JobSla;
@@ -29,6 +34,8 @@ import io.mantisrx.runtime.parameter.Parameter;
 import io.mantisrx.server.core.JobAssignmentResult;
 import io.mantisrx.server.core.JobSchedulingInfo;
 import io.mantisrx.server.core.NamedJobInfo;
+import io.mantisrx.server.core.PostJobStatusRequest;
+import io.mantisrx.server.core.Status;
 import io.mantisrx.server.core.master.MasterDescription;
 import io.mantisrx.server.core.master.MasterMonitor;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
@@ -53,6 +60,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import mantis.io.reactivex.netty.RxNetty;
 import mantis.io.reactivex.netty.channel.ObservableConnection;
@@ -62,6 +70,8 @@ import mantis.io.reactivex.netty.protocol.http.client.HttpClientRequest;
 import mantis.io.reactivex.netty.protocol.http.client.HttpClientResponse;
 import mantis.io.reactivex.netty.protocol.http.sse.ServerSentEvent;
 import mantis.io.reactivex.netty.protocol.http.websocket.WebSocketClient;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.RequestBuilder;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -75,7 +85,7 @@ import rx.functions.Func2;
 /**
  *
  */
-public class MantisMasterClientApi {
+public class MantisMasterClientApi implements MantisMasterGateway {
 
     static final String ConnectTimeoutSecsPropertyName = "MantisClientConnectTimeoutSecs";
     private static final ObjectMapper objectMapper;
@@ -143,6 +153,8 @@ public class MantisMasterClientApi {
                             " swapping out client API connection to new master.");
                     return new Endpoint(description.getHostname(), description.getApiPortV2());
                 });
+
+        apiClient = asyncHttpClient();
         int a = SUBSCRIBE_ATTEMPTS_TO_MASTER;
         final String p = System.getProperty(ConnectTimeoutSecsPropertyName);
         if (p != null) {
@@ -784,4 +796,31 @@ public class MantisMasterClientApi {
 
         return Observable.merge(reconciliator.observables());
     }
+
+  private final AsyncHttpClient apiClient;
+
+  @Override
+  public CompletableFuture<Ack> updateStatus(Status status) {
+
+    try {
+      final String statusUpdate = objectMapper.writeValueAsString(
+          new PostJobStatusRequest(status.getJobId(), status));
+      final RequestBuilder requestBuilder =
+          post(masterMonitor.getLatestMaster().getFullApiStatusUri())
+              .setBody(statusUpdate);
+      return apiClient
+          .executeRequest(requestBuilder)
+          .toCompletableFuture()
+          .thenCompose(response -> {
+            if (response.getStatusCode() == 200) {
+              return CompletableFuture.completedFuture(Ack.getInstance());
+            } else {
+              return CompletableFutures.exceptionallyCompletedFuture(
+                  new Exception(response.getResponseBody()));
+            }
+          });
+    } catch (Exception e) {
+      return CompletableFutures.exceptionallyCompletedFuture(e);
+    }
+  }
 }

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
@@ -797,30 +797,36 @@ public class MantisMasterClientApi implements MantisMasterGateway {
         return Observable.merge(reconciliator.observables());
     }
 
-  private final AsyncHttpClient apiClient;
+    private final AsyncHttpClient apiClient;
 
-  @Override
-  public CompletableFuture<Ack> updateStatus(Status status) {
+    /**
+     * Implementation of updateStatus that updates the status of the worker on the mantis-master.
+     * @param status status that contains all the information about the worker such as the WorkerId,
+     *               State of the worker, etc...
+     * @return Acknowledgement if the update was received by the mantis-master leader.
+     */
+    @Override
+    public CompletableFuture<Ack> updateStatus(Status status) {
 
-    try {
-      final String statusUpdate = objectMapper.writeValueAsString(
-          new PostJobStatusRequest(status.getJobId(), status));
-      final RequestBuilder requestBuilder =
-          post(masterMonitor.getLatestMaster().getFullApiStatusUri())
-              .setBody(statusUpdate);
-      return apiClient
-          .executeRequest(requestBuilder)
-          .toCompletableFuture()
-          .thenCompose(response -> {
-            if (response.getStatusCode() == 200) {
-              return CompletableFuture.completedFuture(Ack.getInstance());
-            } else {
-              return CompletableFutures.exceptionallyCompletedFuture(
-                  new Exception(response.getResponseBody()));
-            }
-          });
-    } catch (Exception e) {
-      return CompletableFutures.exceptionallyCompletedFuture(e);
+        try {
+          final String statusUpdate = objectMapper.writeValueAsString(
+              new PostJobStatusRequest(status.getJobId(), status));
+          final RequestBuilder requestBuilder =
+              post(masterMonitor.getLatestMaster().getFullApiStatusUri())
+                  .setBody(statusUpdate);
+          return apiClient
+              .executeRequest(requestBuilder)
+              .toCompletableFuture()
+              .thenCompose(response -> {
+                if (response.getStatusCode() == 200) {
+                  return CompletableFuture.completedFuture(Ack.getInstance());
+                } else {
+                  return CompletableFutures.exceptionallyCompletedFuture(
+                      new Exception(response.getResponseBody()));
+                }
+              });
+        } catch (Exception e) {
+          return CompletableFutures.exceptionallyCompletedFuture(e);
+        }
     }
-  }
 }

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterGateway.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterGateway.java
@@ -93,5 +93,12 @@ public interface MantisMasterGateway {
 
   Observable<JobAssignmentResult> assignmentResults(String jobId);
 
+  /**
+   * Update the status of the worker to the mantis-master.
+   *
+   * @param status status that contains all the information about the worker such as the WorkerId,
+   *               State of the worker, etc...
+   * @return Acknowledgement if the update was received by the mantis-master.
+   */
   CompletableFuture<Ack> updateStatus(Status status);
 }

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterGateway.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterGateway.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mantisrx.server.master.client;
+
+import io.mantisrx.common.Ack;
+import io.mantisrx.common.Label;
+import io.mantisrx.runtime.JobSla;
+import io.mantisrx.runtime.MantisJobState;
+import io.mantisrx.runtime.WorkerMigrationConfig;
+import io.mantisrx.runtime.descriptor.SchedulingInfo;
+import io.mantisrx.runtime.parameter.Parameter;
+import io.mantisrx.server.core.JobAssignmentResult;
+import io.mantisrx.server.core.JobSchedulingInfo;
+import io.mantisrx.server.core.NamedJobInfo;
+import io.mantisrx.server.core.Status;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import rx.Observable;
+
+public interface MantisMasterGateway {
+  Observable<JobSchedulingInfo> schedulingChanges(final String jobId);
+
+  Observable<Boolean> scaleJobStage(
+      final String jobId,
+      final int stageNum,
+      final int numWorkers,
+      final String reason);
+
+  Observable<Boolean> resubmitJobWorker(final String jobId, final String user, final int workerNum,
+      final String reason);
+
+  Observable<NamedJobInfo> namedJobInfo(final String jobName);
+
+  Observable<Boolean> namedJobExists(final String jobName);
+
+  Observable<Integer> getSinkStageNum(final String jobId);
+
+  Observable<JobSubmitResponse> submitJob(final String name, final String version,
+      final List<Parameter> parameters,
+      final JobSla jobSla,
+      final SchedulingInfo schedulingInfo);
+
+  Observable<JobSubmitResponse> submitJob(final String name, final String version,
+      final List<Parameter> parameters,
+      final JobSla jobSla,
+      final long subscriptionTimeoutSecs,
+      final SchedulingInfo schedulingInfo);
+
+  Observable<JobSubmitResponse> submitJob(final String name, final String version,
+      final List<Parameter> parameters,
+      final JobSla jobSla,
+      final long subscriptionTimeoutSecs,
+      final SchedulingInfo schedulingInfo,
+      final boolean readyForJobMaster);
+
+  Observable<JobSubmitResponse> submitJob(final String name, final String version,
+      final List<Parameter> parameters,
+      final JobSla jobSla,
+      final long subscriptionTimeoutSecs,
+      final SchedulingInfo schedulingInfo,
+      final boolean readyForJobMaster,
+      final WorkerMigrationConfig migrationConfig);
+
+  Observable<JobSubmitResponse> submitJob(final String name, final String version,
+      final List<Parameter> parameters,
+      final JobSla jobSla,
+      final long subscriptionTimeoutSecs,
+      final SchedulingInfo schedulingInfo,
+      final boolean readyForJobMaster,
+      final WorkerMigrationConfig migrationConfig,
+      final List<Label> labels);
+
+  Observable<Void> killJob(final String jobId);
+
+  Observable<Void> killJob(final String jobId, final String user, final String reason);
+
+  Observable<String> getJobsOfNamedJob(final String jobName, final MantisJobState.MetaState state);
+
+  Observable<String> getJobStatusObservable(final String jobId);
+
+  Observable<JobAssignmentResult> assignmentResults(String jobId);
+
+  CompletableFuture<Ack> updateStatus(Status status);
+}

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/SimpleSchedulerObserver.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/SimpleSchedulerObserver.java
@@ -18,6 +18,8 @@ package io.mantisrx.server.master.client;
 
 import com.sampullara.cli.Args;
 import com.sampullara.cli.Argument;
+import io.mantisrx.server.core.Configurations;
+import io.mantisrx.server.core.CoreConfiguration;
 import io.mantisrx.server.core.JobAssignmentResult;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
@@ -45,7 +47,10 @@ public class SimpleSchedulerObserver {
     private final MasterClientWrapper clientWrapper;
 
     SimpleSchedulerObserver(Properties properties) {
-        clientWrapper = new MasterClientWrapper(properties);
+        HighAvailabilityServices haServices =
+            HighAvailabilityServicesUtil.createHAServices(
+                Configurations.frmProperties(properties, CoreConfiguration.class));
+        clientWrapper = new MasterClientWrapper(haServices.getMasterClientApi());
     }
 
     public static void main(String[] args) {
@@ -116,9 +121,9 @@ public class SimpleSchedulerObserver {
     Observable<JobAssignmentResult> getObservable(final String jobId) {
         return clientWrapper
                 .getMasterClientApi()
-                .flatMap(new Func1<MantisMasterClientApi, Observable<? extends JobAssignmentResult>>() {
+                .flatMap(new Func1<MantisMasterGateway, Observable<? extends JobAssignmentResult>>() {
                     @Override
-                    public Observable<? extends JobAssignmentResult> call(MantisMasterClientApi mantisMasterClientApi) {
+                    public Observable<? extends JobAssignmentResult> call(MantisMasterGateway mantisMasterClientApi) {
                         return mantisMasterClientApi.assignmentResults(jobId);
                     }
                 });

--- a/mantis-control-plane/mantis-control-plane-client/src/test/java/io/mantisrx/server/master/client/MasterClientWrapperTest.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/test/java/io/mantisrx/server/master/client/MasterClientWrapperTest.java
@@ -30,7 +30,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.junit.Ignore;
 import org.junit.Test;
 import rx.Observable;
 import rx.functions.Func1;

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/Configurations.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/Configurations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.mantisrx.server.core;
 
-dependencies {
-    implementation libraries.asyncHttpClient
-    implementation libraries.spotifyFutures
-    api project(":mantis-control-plane:mantis-control-plane-core")
+import java.util.Properties;
+import org.skife.config.ConfigurationObjectFactory;
 
-    api project(":mantis-remote-observable")
+public class Configurations {
 
-    testImplementation "junit:junit-dep:$junitVersion"
-    testImplementation "org.mockito:mockito-all:$mockitoVersion"
+  public static <T> T frmProperties(Properties properties, Class<T> tClass) {
+    ConfigurationObjectFactory configurationObjectFactory = new ConfigurationObjectFactory(
+        properties);
+    configurationObjectFactory.addCoercible(new MetricsCoercer(properties));
+    return configurationObjectFactory.build(tClass);
+  }
 }
-
-


### PR DESCRIPTION

Refactored all usages of the mantis mantis client to make use of the interface instead of the actual implementation.

### Context

Explain context and other details for this pull request.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
