### PR TITLE
Depend on remote artifacts for mantis-shaded instead of local subproject

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,16 +34,17 @@ buildscript {
 }
 
 ext {
-    versionRxNetty = '0.4.19'
-    versionSuffixRxNettyShaded = '1'
-    versionIoNetty = '4.1.5.Final'
-    versionSlf4j = '1.7.0'
-    versionRxJava = '1.3.8'
-
     junitVersion = '4.11'
     mockitoVersion = '1.9.+'
     slf4jVersion = '1.7.+'
     vavrVersion = '0.9.2'
+
+    versionIoNetty = '4.1.5.Final'
+    versionMantisShaded = '1.3+'
+    versionRxJava = '1.3.8'
+    versionRxNetty = '0.4.19'
+    versionSlf4j = '1.7.0'
+    versionSuffixRxNettyShaded = '1'
 }
 
 allprojects {
@@ -66,6 +67,10 @@ subprojects {
         repositories {
             mavenLocal()
         }
+    }
+
+    configurations.all {
+        exclude group: 'ch.qos.logback', module: 'logback-classic'
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,16 @@ subprojects {
     }
 
     configurations.all {
+        if (!"mantis-shaded".equals(project.name)) {
+            exclude group: 'com.fasterxml'
+            exclude group: 'io.vavr.jackson.datatype'
+            exclude group: 'com.google'
+            exclude group: 'org.apache.curator'
+            exclude group: 'org.apache.zookeeper'
+            exclude group: 'org.apache.jute'
+            exclude group: 'jline'
+            exclude group: 'org.jboss.netty'
+        }
         exclude group: 'ch.qos.logback', module: 'logback-classic'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,16 +69,19 @@ subprojects {
         }
     }
 
-    configurations.all {
+    configurations.compileClasspath {
         if (!"mantis-shaded".equals(project.name)) {
-            exclude group: 'com.fasterxml'
-            exclude group: 'io.vavr.jackson.datatype'
-            exclude group: 'com.google'
+            exclude group: 'com.fasterxml.jackson.core'
+            exclude group: 'com.fasterxml.jackson.datatype'
+            exclude group: 'com.fasterxml.jackson.module'
+            exclude group: 'com.fasterxml.jackson.dataformat'
+            exclude group: 'com.google.guava', module: 'guava'
+            exclude group: 'io.netty', module: 'netty'
+            exclude group: 'io.vavr', module: 'vavr-jackson'
+            exclude group: 'jline', module: 'jline'
             exclude group: 'org.apache.curator'
             exclude group: 'org.apache.zookeeper'
             exclude group: 'org.apache.jute'
-            exclude group: 'jline'
-            exclude group: 'org.jboss.netty'
         }
         exclude group: 'ch.qos.logback', module: 'logback-classic'
     }

--- a/mantis-common/build.gradle
+++ b/mantis-common/build.gradle
@@ -25,7 +25,7 @@ ext {
 }
 
 dependencies {
-    api project(path: ':mantis-shaded', configuration: 'shadow')
+    api "io.mantisrx:mantis-shaded:${rootProject.versionMantisShaded}"
     api "com.netflix:mantis-rxnetty:${rootProject.versionRxNetty}.${rootProject.versionSuffixRxNettyShaded}"
     api "io.reactivex:rxjava:$versionRxJava"
     api "io.netty:netty-codec-http:$nettyVersion"

--- a/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
+++ b/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
@@ -16,7 +16,6 @@
 
 package io.mantisrx.connector.iceberg.sink.writer;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.mantisrx.connector.iceberg.sink.codecs.IcebergCodecs;
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterConfig;
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterProperties;
@@ -37,12 +36,9 @@ import io.mantisrx.runtime.parameter.type.StringParameter;
 import io.mantisrx.runtime.parameter.validator.Validators;
 import io.mantisrx.runtime.scheduler.MantisRxSingleThreadScheduler;
 import io.mantisrx.shaded.com.google.common.annotations.VisibleForTesting;
+import io.mantisrx.shaded.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.DataFile;
@@ -133,17 +129,17 @@ public class IcebergWriterStage implements ScalarComputation<Record, DataFile> {
 
     @VisibleForTesting
     static Transformer newTransformer(
-        WriterConfig writerConfig,
-        WriterMetrics writerMetrics,
-        IcebergWriterPool writerPool,
-        Partitioner partitioner,
-        WorkerInfo workerInfo) {
+            WriterConfig writerConfig,
+            WriterMetrics writerMetrics,
+            IcebergWriterPool writerPool,
+            Partitioner partitioner,
+            WorkerInfo workerInfo) {
         int workerIdx = workerInfo.getWorkerIndex();
         String nameFormat = "IcebergWriter (" + (workerIdx + 1) + ")-%d";
         Scheduler executingService = new MantisRxSingleThreadScheduler(
-            new ThreadFactoryBuilder().setNameFormat(nameFormat).build());
+                new ThreadFactoryBuilder().setNameFormat(nameFormat).build());
         return new Transformer(writerConfig, writerMetrics, writerPool, partitioner,
-            Schedulers.computation(), executingService);
+                Schedulers.computation(), executingService);
     }
 
     public IcebergWriterStage() {

--- a/mantis-connectors/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergTableExtension.java
+++ b/mantis-connectors/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/writer/IcebergTableExtension.java
@@ -16,7 +16,7 @@
 
 package io.mantisrx.connector.iceberg.sink.writer;
 
-import com.google.common.io.Files;
+import io.mantisrx.shaded.com.google.common.io.Files;
 import java.io.File;
 import lombok.Builder;
 import lombok.Getter;
@@ -53,57 +53,57 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 @Slf4j
 @Builder
 public class IcebergTableExtension implements BeforeAllCallback, BeforeEachCallback,
-    AfterEachCallback {
+        AfterEachCallback {
 
-  private File rootDir;
+    private File rootDir;
 
-  @Getter
-  @Builder.Default
-  private String catalog = "catalog";
+    @Getter
+    @Builder.Default
+    private String catalog = "catalog";
 
-  @Getter
-  @Builder.Default
-  private String database = "database";
+    @Getter
+    @Builder.Default
+    private String database = "database";
 
-  @Getter
-  @Builder.Default
-  private String tableName = "table";
+    @Getter
+    @Builder.Default
+    private String tableName = "table";
 
-  @Getter
-  private Schema schema;
-  private PartitionSpec spec;
+    @Getter
+    private Schema schema;
+    private PartitionSpec spec;
 
-  @Getter
-  private Table table;
+    @Getter
+    private Table table;
 
-  @Override
-  public void beforeAll(ExtensionContext context) throws Exception {
-    log.info("Before All");
-  }
-
-  @Override
-  public void beforeEach(ExtensionContext context) throws Exception {
-    log.info("Before Each");
-    if (rootDir == null) {
-      rootDir = Files.createTempDir();
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        log.info("Before All");
     }
 
-    final File tableDir = new File(rootDir, getTableIdentifier().toString());
-    final HadoopTables tables = new HadoopTables();
-    table = tables.create(schema, spec, tableDir.getPath());
-  }
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        log.info("Before Each");
+        if (rootDir == null) {
+            rootDir = Files.createTempDir();
+        }
 
-  @Override
-  public void afterEach(ExtensionContext context) throws Exception {
-    FileUtils.deleteDirectory(rootDir);
-    rootDir = null;
-  }
+        final File tableDir = new File(rootDir, getTableIdentifier().toString());
+        final HadoopTables tables = new HadoopTables();
+        table = tables.create(schema, spec, tableDir.getPath());
+    }
 
-  public LocationProvider getLocationProvider() {
-    return table.locationProvider();
-  }
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        FileUtils.deleteDirectory(rootDir);
+        rootDir = null;
+    }
 
-  public TableIdentifier getTableIdentifier() {
-    return TableIdentifier.of(catalog, database, tableName);
-  }
+    public LocationProvider getLocationProvider() {
+        return table.locationProvider();
+    }
+
+    public TableIdentifier getTableIdentifier() {
+        return TableIdentifier.of(catalog, database, tableName);
+    }
 }

--- a/mantis-connectors/mantis-connector-kafka/build.gradle
+++ b/mantis-connectors/mantis-connector-kafka/build.gradle
@@ -23,7 +23,7 @@ ext {
 }
 
 dependencies {
-    implementation project(":mantis-shaded")
+    implementation "io.mantisrx:mantis-shaded:${rootProject.versionMantisShaded}"
     implementation project(":mantis-runtime")
 
     api "org.apache.kafka:kafka-clients:$kafkaVersion"

--- a/mantis-connectors/mantis-connector-publish/build.gradle
+++ b/mantis-connectors/mantis-connector-publish/build.gradle
@@ -19,7 +19,7 @@ ext {
 }
 
 dependencies {
-    implementation project(":mantis-shaded")
+    implementation "io.mantisrx:mantis-shaded:${rootProject.versionMantisShaded}"
     implementation project(":mantis-runtime")
 
     api project(":mantis-control-plane:mantis-control-plane-core")

--- a/mantis-discovery-proto/build.gradle
+++ b/mantis-discovery-proto/build.gradle
@@ -15,7 +15,7 @@
  */
 
 dependencies {
-    api project(path: ':mantis-shaded', configuration: 'shadow')
+    api "io.mantisrx:mantis-shaded:${rootProject.versionMantisShaded}"
 
     testImplementation "junit:junit-dep:$junitVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/mantis-examples/mantis-examples-jobconnector-sample/src/main/java/com/netflix/mantis/samples/JobConnectorJob.java
+++ b/mantis-examples/mantis-examples-jobconnector-sample/src/main/java/com/netflix/mantis/samples/JobConnectorJob.java
@@ -16,8 +16,6 @@
 
 package com.netflix.mantis.samples;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.mantis.samples.stage.EchoStage;
 import io.mantisrx.connector.job.core.MantisSourceJobConnector;
 import io.mantisrx.connector.job.source.JobSource;
@@ -28,6 +26,8 @@ import io.mantisrx.runtime.Metadata;
 import io.mantisrx.runtime.executor.LocalJobExecutorNetworked;
 import io.mantisrx.runtime.parameter.Parameter;
 import io.mantisrx.runtime.sink.Sinks;
+import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -41,11 +41,11 @@ import lombok.extern.slf4j.Slf4j;
  * by passing an MQL query.
  * In this example we connect to the latest running instance of SyntheticSourceJob using the query
  * select country from stream where status==500 and simply echo the output.
- *
+ * <p>
  * Run this sample by executing the main method of this class. Then look for the SSE port where the output of this job
  * will be available for streaming. E.g  Serving modern HTTP SSE server sink on port: 8299
  * via command line do ../gradlew execute
- *
+ * <p>
  * Note: this sample may not work in your IDE as the Mantis runtime needs to discover the location of the
  * SyntheticSourceJob.
  */
@@ -77,7 +77,7 @@ public class JobConnectorJob extends MantisJobProvider<String> {
     }
 
     public static void main(String[] args) throws JsonProcessingException {
-        Map<String,Object> targetMap = new HashMap<>();
+        Map<String, Object> targetMap = new HashMap<>();
         List<JobSource.TargetInfo> targetInfos = new ArrayList<>();
 
         JobSource.TargetInfo targetInfo = new JobSource.TargetInfoBuilder().withClientId("abc")
@@ -85,7 +85,7 @@ public class JobConnectorJob extends MantisJobProvider<String> {
                 .withQuery("select country from stream where status==500")
                 .build();
         targetInfos.add(targetInfo);
-        targetMap.put("targets",targetInfos);
+        targetMap.put("targets", targetInfos);
         ObjectMapper mapper = new ObjectMapper();
         String target = mapper.writeValueAsString(targetMap);
 

--- a/mantis-examples/mantis-examples-jobconnector-sample/src/main/java/com/netflix/mantis/samples/stage/EchoStage.java
+++ b/mantis-examples/mantis-examples-jobconnector-sample/src/main/java/com/netflix/mantis/samples/stage/EchoStage.java
@@ -16,12 +16,12 @@
 
 package com.netflix.mantis.samples.stage;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.mantisrx.common.MantisServerSentEvent;
 import io.mantisrx.common.codec.Codecs;
 import io.mantisrx.runtime.Context;
 import io.mantisrx.runtime.ScalarToScalar;
 import io.mantisrx.runtime.computation.ScalarComputation;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import rx.Observable;
 
@@ -30,8 +30,9 @@ import rx.Observable;
  * A simple stage that extracts data from the incoming {@link MantisServerSentEvent} and echoes it.
  */
 @Slf4j
-public class EchoStage implements ScalarComputation<MantisServerSentEvent,String> {
+public class EchoStage implements ScalarComputation<MantisServerSentEvent, String> {
     private static final ObjectMapper mapper = new ObjectMapper();
+
     @Override
     public Observable<String> call(Context context, Observable<MantisServerSentEvent> eventsO) {
         return eventsO
@@ -47,8 +48,8 @@ public class EchoStage implements ScalarComputation<MantisServerSentEvent,String
 
     }
 
-    public static ScalarToScalar.Config<MantisServerSentEvent,String> config(){
-        return new ScalarToScalar.Config<MantisServerSentEvent,String>()
+    public static ScalarToScalar.Config<MantisServerSentEvent, String> config() {
+        return new ScalarToScalar.Config<MantisServerSentEvent, String>()
                 .codec(Codecs.string());
     }
 

--- a/mantis-examples/mantis-examples-mantis-publish-sample/src/main/java/com/netflix/mantis/examples/mantispublishsample/proto/RequestEvent.java
+++ b/mantis-examples/mantis-examples-mantis-publish-sample/src/main/java/com/netflix/mantis/examples/mantispublishsample/proto/RequestEvent.java
@@ -16,9 +16,9 @@
 
 package com.netflix.mantis.examples.mantispublishsample.proto;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectReader;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.Builder;
@@ -41,8 +41,8 @@ public class RequestEvent {
     private final String country;
     private final String deviceType;
 
-    public Map<String,Object> toMap() {
-        Map<String,Object> data = new HashMap<>();
+    public Map<String, Object> toMap() {
+        Map<String, Object> data = new HashMap<>();
         data.put("userId", userId);
         data.put("uri", uri);
         data.put("status", status);
@@ -59,7 +59,6 @@ public class RequestEvent {
             return null;
         }
     }
-
 
 
 }

--- a/mantis-examples/mantis-examples-twitter-sample/src/main/java/com/netflix/mantis/examples/wordcount/sources/TwitterSource.java
+++ b/mantis-examples/mantis-examples-twitter-sample/src/main/java/com/netflix/mantis/examples/wordcount/sources/TwitterSource.java
@@ -16,7 +16,6 @@
 
 package com.netflix.mantis.examples.wordcount.sources;
 
-import com.google.common.collect.Lists;
 import com.netflix.mantis.examples.core.ObservableQueue;
 import com.twitter.hbc.ClientBuilder;
 import com.twitter.hbc.core.Constants;
@@ -31,6 +30,7 @@ import io.mantisrx.runtime.parameter.type.StringParameter;
 import io.mantisrx.runtime.parameter.validator.Validators;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
+import io.mantisrx.shaded.com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.List;
 import rx.Observable;

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/jobmaster/JobMasterService.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/jobmaster/JobMasterService.java
@@ -30,9 +30,6 @@ import io.mantisrx.server.worker.client.WorkerMetricsClient;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -40,6 +37,9 @@ import rx.Observer;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 
 public class JobMasterService implements Service {
@@ -105,8 +105,6 @@ public class JobMasterService implements Service {
 
         } catch (JsonProcessingException e) {
             logger.error("failed to parse json", e);
-        } catch (IOException e) {
-            logger.error("failed to process json", e);
         } catch (Exception e) {
             logger.error("caught exception", e);
         }

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/jobmaster/JobMasterService.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/jobmaster/JobMasterService.java
@@ -30,6 +30,7 @@ import io.mantisrx.server.worker.client.WorkerMetricsClient;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -104,6 +105,8 @@ public class JobMasterService implements Service {
 
         } catch (JsonProcessingException e) {
             logger.error("failed to parse json", e);
+        } catch (IOException e) {
+            logger.error("failed to process json", e);
         } catch (Exception e) {
             logger.error("caught exception", e);
         }

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/jobmaster/JobMasterService.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/jobmaster/JobMasterService.java
@@ -30,6 +30,8 @@ import io.mantisrx.server.worker.client.WorkerMetricsClient;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -37,9 +39,6 @@ import rx.Observer;
 import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 
 public class JobMasterService implements Service {

--- a/mantis-shaded/README.md
+++ b/mantis-shaded/README.md
@@ -1,8 +1,0 @@
-## Working with IntelliJ
-
-If you are using IntelliJ, you will need to manually add a dependency to the shadow jar due to this issue:
-
-https://github.com/johnrengelman/shadow/issues/264
-
-First build the jar under `mantis-shaded`. The jar file should be created under `mantis-shaded/build/libs`. Then in IntelliJ under `Project Settings` -> `Libraries`, add a dependency to the jar file.
-

--- a/mantis-shaded/build.gradle
+++ b/mantis-shaded/build.gradle
@@ -16,6 +16,14 @@
 
 apply plugin: 'com.github.johnrengelman.shadow'
 
+/**
+ * NOTE: About releasing
+ * When updating dependencies here, you need to release/publish twice
+ * because all the subprojects depend on the artifactory version as
+ * opposed to subproject.
+ * On the first publish, you update mantis-shaded artifacts in artifactory
+ * On the second publish, you update all subprojects that depend on mantis-shaded
+ */
 ext {
     jacksonVersion = '2.10.+'
     guavaVersion = '18.+'


### PR DESCRIPTION

### Context

Currently, we depend on the local copy of jar (subproject) for mantis-shaded dependency. However, this leads to problems with IntelliJ where you have to manually add the mantis-shaded subproject as an explicit library dependency at the root OR deal with a bunch of redlines for these shaded components.

We tried a bunch of alternatives like publishing to local maven or including these shaded dependencies at the terminal level (leaf projects) and they open-up more issues. We decided to host mantis-shaded in a separate repo but we think this could be a better alternative 
### Checklist

- [*] `./gradlew build` compiles code correctly
- [*] Added new tests where applicable
- [*] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [*] Added copyright headers for new files from `CONTRIBUTING.md`
