### PR TITLE
Fix bug in CompressionUtils that fails with certain delimiters

### DIFF
--- a/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SinkClientImpl.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import lombok.ToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;

--- a/mantis-common/src/main/java/io/mantisrx/common/compression/CompressionUtils.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/compression/CompressionUtils.java
@@ -217,10 +217,19 @@ public class CompressionUtils {
             for (int i = 0; i < line.length(); i++) {
                 if (line.charAt(i) != delimiterArray[delimiterCount]) {
                     if (delimiterCount > 0) {
-                        for (int j = 0; j < delimiterCount; ++j) {
-                            sb.append(delimiterArray[j]);
+                        boolean prefixMatch = true;
+                        for (int j = delimiterCount - 1; j >= 0; j--) {
+                            if (line.charAt(i) != delimiterArray[j]) {
+                                prefixMatch = false;
+                                break;
+                            }
                         }
-                        delimiterCount = 0;
+                        if (!prefixMatch) {
+                            for (int j = 0; j < delimiterCount; ++j) {
+                                sb.append(delimiterArray[j]);
+                            }
+                            delimiterCount = 0;
+                        }
                     }
                     if (line.charAt(i) != delimiterArray[delimiterCount]) {
                         sb.append(line.charAt(i));

--- a/mantis-common/src/test/java/io/mantisrx/common/compression/CompressionUtilsTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/common/compression/CompressionUtilsTest.java
@@ -19,14 +19,11 @@ import static org.junit.Assert.assertEquals;
 
 import io.mantisrx.common.MantisServerSentEvent;
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.junit.Assert;
 import org.junit.Test;
 
 public class CompressionUtilsTest {

--- a/mantis-common/src/test/java/io/mantisrx/common/compression/CompressionUtilsTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/common/compression/CompressionUtilsTest.java
@@ -28,7 +28,8 @@ import org.junit.Test;
 
 public class CompressionUtilsTest {
 
-    @Test public void shouldTokenizeWithEventsContainingPartialDelimiterMatches() {
+    @Test
+    public void shouldTokenizeWithEventsContainingPartialDelimiterMatches() {
         String testInput = "ab$cdef$$$ghi$jkl$$$lmno$$pqrst$";
         try (BufferedReader reader = new BufferedReader(new StringReader(testInput))) {
             List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader);
@@ -43,7 +44,8 @@ public class CompressionUtilsTest {
         }
     }
 
-    @Test public void shouldTokenizeWithEventsContainingPartialDelimiterMatchesWithCustomDelimiter() {
+    @Test
+    public void shouldTokenizeWithEventsContainingPartialDelimiterMatchesWithCustomDelimiter() {
         String delimiter = "a04f0418-bdff-4f53-af7d-9f5a093b9d65";
 
         String event1 = "ab" + delimiter.substring(0, 9) + "cdef";
@@ -67,7 +69,8 @@ public class CompressionUtilsTest {
         }
     }
 
-    @Test public void testDelimiterWiithPrefixMatchingEndOfMEssage() {
+    @Test
+    public void testDelimiterWiithPrefixMatchingEndOfMEssage() {
         // Delimiter starts with 'c', event1 ends with 'c'
         String delimiter = "ccd";
 
@@ -92,7 +95,8 @@ public class CompressionUtilsTest {
         }
     }
 
-    @Test public void testMultiline() {
+    @Test
+    public void testMultiline() {
         String delimiter = "ccd";
 
         String event1 = "abc";

--- a/mantis-common/src/test/java/io/mantisrx/common/compression/CompressionUtilsTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/common/compression/CompressionUtilsTest.java
@@ -22,30 +22,29 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 public class CompressionUtilsTest {
 
     @Test
-    public void shouldTokenizeWithEventsContainingPartialDelimiterMatches() {
+    public void shouldTokenizeWithEventsContainingPartialDelimiterMatches() throws Exception {
         String testInput = "ab$cdef$$$ghi$jkl$$$lmno$$pqrst$";
-        try (BufferedReader reader = new BufferedReader(new StringReader(testInput))) {
-            List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader);
+        BufferedReader reader = new BufferedReader(new StringReader(testInput));
+        List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader);
 
-            assertEquals(result.size(), 3);
-            assertEquals(result.get(0).getEventAsString(), "ab$cdef");
-            assertEquals(result.get(1).getEventAsString(), "ghi$jkl");
-            assertEquals(result.get(2).getEventAsString(), "lmno$$pqrst$");
-
-        } catch (IOException ex) {
-            Assert.fail("Tokenization threw an IO exception that was unexpected");
-        }
+        assertEquals(result.size(), 3);
+        assertEquals(result.get(0).getEventAsString(), "ab$cdef");
+        assertEquals(result.get(1).getEventAsString(), "ghi$jkl");
+        assertEquals(result.get(2).getEventAsString(), "lmno$$pqrst$");
     }
 
     @Test
-    public void shouldTokenizeWithEventsContainingPartialDelimiterMatchesWithCustomDelimiter() {
+    public void shouldTokenizeWithEventsContainingPartialDelimiterMatchesWithCustomDelimiter() throws Exception {
         String delimiter = "a04f0418-bdff-4f53-af7d-9f5a093b9d65";
 
         String event1 = "ab" + delimiter.substring(0, 9) + "cdef";
@@ -56,21 +55,15 @@ public class CompressionUtilsTest {
                 + event2
                 + delimiter
                 + event3;
-        try (BufferedReader reader = new BufferedReader(new StringReader(testInput))) {
-            List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader, delimiter);
+        BufferedReader reader = new BufferedReader(new StringReader(testInput));
+        List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader, delimiter);
 
-            assertEquals("Delimiter: '" + delimiter + "'", result.size(), 3);
-            assertEquals(result.get(0).getEventAsString(), event1);
-            assertEquals(result.get(1).getEventAsString(), event2);
-            assertEquals(result.get(2).getEventAsString(), event3);
-
-        } catch (IOException ex) {
-            Assert.fail("Tokenization threw an IO exception that was unexpected");
-        }
+        List<String> actual = result.stream().map(e -> e.getEventAsString()).collect(Collectors.toList());
+        assertEquals("Delimiter: '" + delimiter + "'", Arrays.asList(event1,event2,event3), actual);
     }
 
     @Test
-    public void testDelimiterWiithPrefixMatchingEndOfMEssage() {
+    public void testDelimiterWiithPrefixMatchingEndOfMEssage() throws Exception {
         // Delimiter starts with 'c', event1 ends with 'c'
         String delimiter = "ccd";
 
@@ -82,21 +75,15 @@ public class CompressionUtilsTest {
                 + event2
                 + delimiter
                 + event3;
-        try (BufferedReader reader = new BufferedReader(new StringReader(testInput))) {
-            List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader, delimiter);
+        BufferedReader reader = new BufferedReader(new StringReader(testInput));
+        List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader, delimiter);
 
-            assertEquals("Delimiter: '" + delimiter + "'", result.size(), 3);
-            assertEquals(event1, result.get(0).getEventAsString());
-            assertEquals(event2, result.get(1).getEventAsString());
-            assertEquals(event3, result.get(2).getEventAsString());
-
-        } catch (IOException ex) {
-            Assert.fail("Tokenization threw an IO exception that was unexpected");
-        }
+        List<String> actual = result.stream().map(e -> e.getEventAsString()).collect(Collectors.toList());
+        assertEquals("Delimiter: '" + delimiter + "'", Arrays.asList(event1,event2,event3), actual);
     }
 
     @Test
-    public void testMultiline() {
+    public void testMultiline() throws Exception {
         String delimiter = "ccd";
 
         String event1 = "abc";
@@ -108,22 +95,17 @@ public class CompressionUtilsTest {
                 + event2
                 + delimiter
                 + event3;
+        // Turn input into 1 character per line
         for (int i = 0; i < testInput.length(); i++) {
             buf.append(testInput.charAt(i)).append("\n");
         }
         testInput = buf.toString();
 
-        try (BufferedReader reader = new BufferedReader(new StringReader(testInput))) {
-            List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader, delimiter);
+        BufferedReader reader = new BufferedReader(new StringReader(testInput));
+        List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader, delimiter);
 
-            assertEquals("Delimiter: '" + delimiter + "'", result.size(), 3);
-            assertEquals(event1, result.get(0).getEventAsString());
-            assertEquals(event2, result.get(1).getEventAsString());
-            assertEquals(event3, result.get(2).getEventAsString());
-
-        } catch (IOException ex) {
-            Assert.fail("Tokenization threw an IO exception that was unexpected");
-        }
+        List<String> actual = result.stream().map(e -> e.getEventAsString()).collect(Collectors.toList());
+        assertEquals("Delimiter: '" + delimiter + "'", Arrays.asList(event1,event2,event3), actual);
     }
 
     @Test

--- a/mantis-common/src/test/java/io/mantisrx/common/compression/CompressionUtilsTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/common/compression/CompressionUtilsTest.java
@@ -67,6 +67,61 @@ public class CompressionUtilsTest {
         }
     }
 
+    @Test public void testDelimiterWiithPrefixMatchingEndOfMEssage() {
+        // Delimiter starts with 'c', event1 ends with 'c'
+        String delimiter = "ccd";
+
+        String event1 = "abc";
+        String event2 = "def";
+        String event3 = "ghi";
+        String testInput = event1
+                + delimiter
+                + event2
+                + delimiter
+                + event3;
+        try (BufferedReader reader = new BufferedReader(new StringReader(testInput))) {
+            List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader, delimiter);
+
+            assertEquals("Delimiter: '" + delimiter + "'", result.size(), 3);
+            assertEquals(event1, result.get(0).getEventAsString());
+            assertEquals(event2, result.get(1).getEventAsString());
+            assertEquals(event3, result.get(2).getEventAsString());
+
+        } catch (IOException ex) {
+            Assert.fail("Tokenization threw an IO exception that was unexpected");
+        }
+    }
+
+    @Test public void testMultiline() {
+        String delimiter = "ccd";
+
+        String event1 = "abc";
+        String event2 = "def";
+        String event3 = "ghi";
+        StringBuffer buf = new StringBuffer();
+        String testInput = event1
+                + delimiter
+                + event2
+                + delimiter
+                + event3;
+        for (int i = 0; i < testInput.length(); i++) {
+            buf.append(testInput.charAt(i)).append("\n");
+        }
+        testInput = buf.toString();
+
+        try (BufferedReader reader = new BufferedReader(new StringReader(testInput))) {
+            List<MantisServerSentEvent> result = CompressionUtils.tokenize(reader, delimiter);
+
+            assertEquals("Delimiter: '" + delimiter + "'", result.size(), 3);
+            assertEquals(event1, result.get(0).getEventAsString());
+            assertEquals(event2, result.get(1).getEventAsString());
+            assertEquals(event3, result.get(2).getEventAsString());
+
+        } catch (IOException ex) {
+            Assert.fail("Tokenization threw an IO exception that was unexpected");
+        }
+    }
+
     @Test
     public void testCompression() throws Exception {
         List<byte[]> events1 = new ArrayList<>();


### PR DESCRIPTION
### Context

There is a bug in CompressionUtils if the delimiter has a prefix that matches the end of a segment, the data is not properly tokenized.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
