### PR TITLE
[Part 6]: Blob Store abstractions and a classloader factory that uses the blob store

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @codyrioux @nickmahilani @jeffchao @piygoyal @calvin681 @sundargates @Andyz26 @hmitnflx
+* @codyrioux @nickmahilani @jeffchao @piygoyal @calvin681 @sundargates @Andyz26 @hmitnflx @markcho @liuml07

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ ext.versions = [
 
 ext.libraries = [
         asyncHttpClient: "org.asynchttpclient:async-http-client:2.12.3",
+        commonsIo      : "commons-io:commons-io:2.11.0",
         commonsLang3   : 'org.apache.commons:commons-lang3:3.5',
         flinkRpcApi    : [
                 "org.apache.flink:flink-rpc-core:${versions.flink}",
@@ -56,6 +57,8 @@ ext.libraries = [
                 "junit:junit:${versions.junit4}",
                 "junit:junit-dep:${versions.junit4}",
         ],
+        hadoopCommon   : "org.apache.hadoop:hadoop-common:2.7.7",
+        hadoopS3       : "org.apache.hadoop:hadoop-aws:2.7.7",
         junitJupiter   : [
                 "org.junit.jupiter:junit-jupiter-api:${versions.junit5}",
                 "org.junit.jupiter:junit-jupiter-engine:${versions.junit5}",
@@ -72,6 +75,7 @@ ext.libraries = [
         vavr           : "io.vavr:vavr:${versions.vavr}",
         vavrJackson    : "io.vavr:vavr-jackson:${versions.vavr}",
         vavrTest       : "io.vavr:vavr-test:${versions.vavr}",
+        zip4j          : "net.lingala.zip4j:zip4j:2.9.0",
 ]
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ buildscript {
 
 ext.versions = [
         flink  : "1.14.2",
+        hadoop : "2.7.7",
         junit4 : "4.11",
         junit5 : "5.4.+",
         mockito: "2.0.+",
@@ -57,8 +58,8 @@ ext.libraries = [
                 "junit:junit:${versions.junit4}",
                 "junit:junit-dep:${versions.junit4}",
         ],
-        hadoopCommon   : "org.apache.hadoop:hadoop-common:2.7.7",
-        hadoopS3       : "org.apache.hadoop:hadoop-aws:2.7.7",
+        hadoopCommon   : "org.apache.hadoop:hadoop-common:${versions.hadoop}",
+        hadoopS3       : "org.apache.hadoop:hadoop-aws:${versions.hadoop}",
         junitJupiter   : [
                 "org.junit.jupiter:junit-jupiter-api:${versions.junit5}",
                 "org.junit.jupiter:junit-jupiter-engine:${versions.junit5}",
@@ -124,7 +125,7 @@ subprojects {
         mavenCentral()
         /**
          * This repository locates artifacts that don't exist in maven central but we had to backup from jcenter
-         * The exclusiveContent 
+         * The exclusiveContent
          */
         exclusiveContent {
             forRepository {

--- a/mantis-common/build.gradle
+++ b/mantis-common/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     api libraries.rxJava
     api libraries.slf4jApi
     api libraries.slf4jLog4j12
+    implementation libraries.commonsIo
 
     testImplementation libraries.commonsLang3
     testImplementation "org.hamcrest:hamcrest-core:1.3"

--- a/mantis-common/src/main/java/com/mantisrx/common/utils/Closeables.java
+++ b/mantis-common/src/main/java/com/mantisrx/common/utils/Closeables.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mantisrx.common.utils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.apache.commons.io.IOExceptionList;
+
+public class Closeables {
+    /**
+     * Combines a list of closeables into a composite closeable which when called closes the closeables one-by-one.
+     *
+     * @param closeables closeables that all need to be closed
+     * @return a composite closeable
+     */
+    public static Closeable combine(Collection<? extends Closeable> closeables) {
+        return combine(closeables.toArray(new Closeable[0]));
+    }
+
+    public static Closeable combine(Closeable... closeables) {
+        return () -> {
+            List<Throwable> list = new ArrayList<>();
+            for (Closeable closeable: closeables) {
+                try {
+                    closeable.close();
+                } catch (IOException e) {
+                    list.add(new Exception(String.format("Failed to close %s", closeable), e));
+                }
+            }
+
+            if (!list.isEmpty()) {
+                throw new IOExceptionList(list);
+            }
+        };
+    }
+}

--- a/mantis-server/mantis-server-worker/build.gradle
+++ b/mantis-server/mantis-server-worker/build.gradle
@@ -30,6 +30,10 @@ dependencies {
     compile project(":mantis-server:mantis-server-worker-client")
 
     api libraries.flinkRpcApi
+    implementation libraries.commonsIo
+    implementation libraries.hadoopCommon
+    implementation libraries.zip4j
+    implementation libraries.hadoopS3
     implementation libraries.flinkRpcImpl
 
     compile "org.apache.mesos:mesos:$mesosVersion"

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/BlobStore.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/BlobStore.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mantisrx.server.worker;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import net.lingala.zip4j.ZipFile;
+import org.apache.commons.io.FilenameUtils;
+
+/**
+ * Abstraction to deal with getting files stored in object stores such as s3.
+ */
+public interface BlobStore extends Closeable {
+    File get(URI blobUrl) throws IOException;
+
+    /**
+     * blob store that adds a prefix to every requested URI.
+     *
+     * @param prefixUri prefix that needs to be prepended to every requested resource.
+     * @return blob store with the prefix patterns baked in.
+     */
+    default BlobStore withPrefix(URI prefixUri) {
+        return new PrefixedBlobStore(prefixUri, this);
+    }
+
+    /**
+     * blob store that when downloading zip files, also unpacks them and returns the unpacked file/directory to the caller.
+     *
+     * @return blob store that can effectively deal with zip files
+     */
+    default BlobStore withZipCapabilities() {
+        return new ZipHandlingBlobStore(this);
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+    class PrefixedBlobStore implements BlobStore {
+        private final URI rootUri;
+        private final BlobStore blobStore;
+
+        @Override
+        public File get(URI blobUrl) throws IOException {
+            final String fileName = FilenameUtils.getName(blobUrl.toString());
+            return blobStore.get(rootUri.resolve(fileName));
+        }
+
+        @Override
+        public void close() throws IOException {
+            blobStore.close();
+        }
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+    class ZipHandlingBlobStore implements BlobStore {
+
+        private final BlobStore blobStore;
+
+        @Override
+        public File get(URI blobUrl) throws IOException {
+            final File localFile = blobStore.get(blobUrl);
+            final ZipFile zipFile = isZipFile(localFile);
+            if (zipFile == null) {
+                return localFile;
+            } else {
+                String destDirStr = getDestDir(zipFile);
+                File destDir = new File(destDirStr);
+                if (!destDir.exists()) {
+                    zipFile.extractAll(destDirStr);
+                }
+                return destDir;
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            blobStore.close();
+        }
+
+        private String getDestDir(ZipFile zipFile) {
+            return zipFile.getFile().getPath() + "-unzipped";
+        }
+
+        private ZipFile isZipFile(File file) {
+            ZipFile file1 = new ZipFile(file);
+            if (file1.isValidZipFile()) {
+                return file1;
+            } else {
+                return null;
+            }
+        }
+    }
+
+
+}

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/BlobStoreAwareClassLoaderHandle.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/BlobStoreAwareClassLoaderHandle.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mantisrx.server.worker;
+
+import com.mantisrx.common.utils.Closeables;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.WeakHashMap;
+import java.util.function.Consumer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOCase;
+import org.apache.commons.io.filefilter.SuffixFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.flink.util.FlinkUserCodeClassLoader;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
+import org.apache.flink.util.UserCodeClassLoader;
+
+/**
+ * ClassLoader that gets created out of downloading blobs from the corresponding blob store.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class BlobStoreAwareClassLoaderHandle implements ClassLoaderHandle {
+
+    private final BlobStore blobStore;
+    private final WeakHashMap<URLClassLoader, Void> openedHandles = new WeakHashMap<>();
+
+    protected List<URL> getResolvedUrls(Collection<URI> requiredFiles, BlobStore blobStore)
+        throws IOException, URISyntaxException {
+        final List<URL> resolvedUrls = new ArrayList<>();
+
+        for (URI requiredFile : requiredFiles) {
+            // get a local version of the file that needs to be added to the classloader
+            final File file = blobStore.get(requiredFile);
+            log.info("Received file {} from blob store for creating class loader", file);
+            if (file.isDirectory()) {
+                // let's recursively add all jar files under this directory
+                final Collection<File> childJarFiles =
+                    FileUtils.listFiles(file, new SuffixFileFilter("jar", IOCase.INSENSITIVE),
+                        TrueFileFilter.INSTANCE);
+                log.info("Loading files {} into the class loader", childJarFiles);
+                for (File jarFile : childJarFiles) {
+                    resolvedUrls.add(jarFile.toURI().toURL());
+                }
+            } else {
+                // let's assume that this is actually a jar file
+                resolvedUrls.add(file.toURI().toURL());
+            }
+        }
+
+        return resolvedUrls;
+    }
+
+    @Override
+    public UserCodeClassLoader getOrResolveClassLoader(Collection<URI> requiredFiles,
+                                                       Collection<URL> requiredClasspaths) throws IOException {
+        final List<URL> resolvedUrls = new ArrayList<>();
+        try {
+            resolvedUrls.addAll(getResolvedUrls(requiredFiles, blobStore));
+        } catch (URISyntaxException e) {
+            throw new IOException(e);
+        }
+
+        resolvedUrls.addAll(requiredClasspaths);
+        final ParentFirstClassLoader classLoader = new ParentFirstClassLoader(resolvedUrls.toArray(new URL[0]), getClass().getClassLoader(),
+            error -> log.error("Failed to load class", error));
+        synchronized (openedHandles) {
+            openedHandles.put(classLoader, null);
+        }
+        return SimpleUserCodeClassLoader.create(classLoader);
+    }
+
+    public static class ParentFirstClassLoader extends FlinkUserCodeClassLoader {
+
+        ParentFirstClassLoader(
+            URL[] urls, ClassLoader parent, Consumer<Throwable> classLoadingExceptionHandler) {
+            super(urls, parent, classLoadingExceptionHandler);
+        }
+
+        static {
+            ClassLoader.registerAsParallelCapable();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        synchronized (openedHandles) {
+            try {
+                Closeables.combine(openedHandles.keySet()).close();
+            } finally {
+                openedHandles.clear();
+            }
+        }
+    }
+}

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/HadoopFileSystemBlobStore.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/HadoopFileSystemBlobStore.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mantisrx.server.worker;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+/**
+ * Blob store that uses the hadoop-filesystem base library to retrieve the requested resources.
+ * Hadoop FileSystem is a good abstraction as it can deal with a variety of cloud-native object stores
+ * such as s3, gfs, etc...
+ */
+@RequiredArgsConstructor
+public class HadoopFileSystemBlobStore implements BlobStore {
+
+  //  The file system in which blobs are stored. */
+  private final FileSystem fileSystem;
+
+  private final File localStoreDir;
+
+  @Override
+  public File get(URI blobUrl) throws IOException {
+    final Path src = new Path(blobUrl);
+    final Path dest = new Path(getStorageLocation(blobUrl));
+    if (!fileSystem.exists(dest)) {
+      fileSystem.copyToLocalFile(src, dest);
+    }
+
+    return new File(dest.toUri().getPath());
+  }
+
+  @Override
+  public void close() throws IOException {
+    fileSystem.close();
+  }
+
+  private String getStorageLocation(URI blobUri) {
+    return String.format("%s/%s", localStoreDir, FilenameUtils.getName(blobUri.getPath()));
+  }
+}

--- a/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/BlobStoreTest.java
+++ b/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/BlobStoreTest.java
@@ -28,22 +28,22 @@ import java.net.URI;
 import org.junit.Test;
 import org.mockito.Matchers;
 
-public class TestBlobStore {
-  @Test
-  public void testPrefixedBlobStore() throws Exception {
-    final BlobStore blobStore = mock(BlobStore.class);
-    final File file = mock(File.class);
-    when(blobStore.get(any())).thenReturn(file);
+public class BlobStoreTest {
+    @Test
+    public void testPrefixedBlobStore() throws Exception {
+        final BlobStore blobStore = mock(BlobStore.class);
+        final File file = mock(File.class);
+        when(blobStore.get(any())).thenReturn(file);
 
-    final BlobStore prefixedBlobStpre =
-        new PrefixedBlobStore(new URI("s3://netflix.s3.genpop.prod/mantis/jobs/"), blobStore);
-    prefixedBlobStpre.get(new URI("http://sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip"));
+        final BlobStore prefixedBlobStpre =
+            new PrefixedBlobStore(new URI("s3://netflix.s3.genpop.prod/mantis/jobs/"), blobStore);
+        prefixedBlobStpre.get(new URI("http://sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip"));
 
-    final URI expectedUri =
-        new URI("s3://netflix.s3.genpop.prod/mantis/jobs/sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip");
-    verify(blobStore, times(1)).get(Matchers.eq(expectedUri));
+        final URI expectedUri =
+            new URI("s3://netflix.s3.genpop.prod/mantis/jobs/sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip");
+        verify(blobStore, times(1)).get(Matchers.eq(expectedUri));
 
-    prefixedBlobStpre.get(new URI("https://mantis.us-east-1.prod.netflix.net/mantis-artifacts/sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip"));
-    verify(blobStore, times(2)).get(Matchers.eq(expectedUri));
-  }
+        prefixedBlobStpre.get(new URI("https://mantis.us-east-1.prod.netflix.net/mantis-artifacts/sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip"));
+        verify(blobStore, times(2)).get(Matchers.eq(expectedUri));
+    }
 }

--- a/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/TestBlobStore.java
+++ b/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/TestBlobStore.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.worker;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.mantisrx.server.worker.BlobStore.PrefixedBlobStore;
+import java.io.File;
+import java.net.URI;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+public class TestBlobStore {
+  @Test
+  public void testPrefixedBlobStore() throws Exception {
+    final BlobStore blobStore = mock(BlobStore.class);
+    final File file = mock(File.class);
+    when(blobStore.get(any())).thenReturn(file);
+
+    final BlobStore prefixedBlobStpre =
+        new PrefixedBlobStore(new URI("s3://netflix.s3.genpop.prod/mantis/jobs/"), blobStore);
+    prefixedBlobStpre.get(new URI("http://sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip"));
+
+    final URI expectedUri =
+        new URI("s3://netflix.s3.genpop.prod/mantis/jobs/sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip");
+    verify(blobStore, times(1)).get(Matchers.eq(expectedUri));
+
+    prefixedBlobStpre.get(new URI("https://mantis.us-east-1.prod.netflix.net/mantis-artifacts/sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip"));
+    verify(blobStore, times(2)).get(Matchers.eq(expectedUri));
+  }
+}

--- a/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/TestHadoopFileSystemBlobStore.java
+++ b/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/TestHadoopFileSystemBlobStore.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.worker;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.net.URI;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.mockito.Matchers;
+
+public class TestHadoopFileSystemBlobStore {
+
+  @Test
+  public void test() throws Exception {
+    FileSystem fileSystem = mock(FileSystem.class);
+
+    File localStoreDir = new File("/mnt/data/mantis-artifacts");
+    HadoopFileSystemBlobStore blobStore =
+        new HadoopFileSystemBlobStore(fileSystem, localStoreDir);
+    URI src =
+        new URI(
+            "s3://netflix.s3.genpop.prod/mantis/jobs/sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip");
+    URI dst =
+        new URI(
+            "/mnt/data/mantis-artifacts/sananthanarayanan-mantis-jobs-sine-function-thin-0.1.0.zip");
+    blobStore.get(src);
+    verify(fileSystem, times(1)).copyToLocalFile(Matchers.eq(new Path(src)),
+        Matchers.eq(new Path(dst)));
+  }
+}


### PR DESCRIPTION
Two features are added through this change.
1). Firstly, I'm introducing a new blob store abstraction and a few implementations that can help download the blob from various stores such as s3, artifactory, etc.
2). A new class loader implementation has also been added to use the blob store to download the requested artifacts from s3 or artifactory or elsewhere and create a class loader object that can run the user's application code.

### Context

In the new Titus world, one can use the cluster to run any user-submitted mantis job. Thus, we need capabilities to both download artifacts on demand and load them into the JVM to run the user's mantis job. This diff adds some of the abilities required for the above functionality. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
