### PR TITLE
Introducing Source::close

### DIFF
--- a/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
@@ -268,7 +268,7 @@ public class MantisClient {
                 .getJobId();
     }
 
-    public void killJob(final String jobId) throws Exception {
+    public void killJob(final String jobId) {
         clientWrapper.getMasterClientApi()
                 .flatMap((MantisMasterGateway mantisMasterClientApi) -> {
                     return mantisMasterClientApi.killJob(jobId)

--- a/mantis-client/src/main/java/io/mantisrx/client/MantisSSEJob.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/MantisSSEJob.java
@@ -25,6 +25,8 @@ import io.mantisrx.runtime.parameter.SinkParameters;
 import io.mantisrx.server.master.client.ConditionalRetry;
 import io.mantisrx.server.master.client.NoSuchJobException;
 import io.reactivx.mantis.operators.DropOperator;
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -38,7 +40,7 @@ import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 
 
-public class MantisSSEJob implements AutoCloseable {
+public class MantisSSEJob implements Closeable {
 
     private static final String ConnectTimeoutSecsPropertyName = "MantisClientConnectTimeoutSecs";
     private static final Logger logger = LoggerFactory.getLogger(MantisSSEJob.class);
@@ -57,7 +59,7 @@ public class MantisSSEJob implements AutoCloseable {
     }
 
     @Override
-    public synchronized void close() throws Exception {
+    public synchronized void close() {
         if (mode == Mode.Submit && builder.ephemeral) {
             if (jobId != null) {
                 builder.mantisClient.killJob(jobId);

--- a/mantis-connectors/mantis-connector-publish/src/main/java/io/mantisrx/connector/publish/source/http/PushHttpSource.java
+++ b/mantis-connectors/mantis-connector-publish/src/main/java/io/mantisrx/connector/publish/source/http/PushHttpSource.java
@@ -27,6 +27,7 @@ import io.mantisrx.runtime.parameter.validator.Validators;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
 import io.reactivx.mantis.operators.DropOperator;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -53,6 +54,8 @@ public class PushHttpSource implements Source<String> {
 
     private static final String NETTY_THREAD_COUNT_PARAM_NAME = "nettyThreadCount";
 
+    private SourceHttpServer server;
+
     public PushHttpSource(QueryRegistry registry, int serverPort) {
         this.queryRegistry = registry;
         this.serverPort = serverPort;
@@ -72,7 +75,7 @@ public class PushHttpSource implements Source<String> {
 
         LOGGER.info("PushHttpSource server starting at Port " + serverPort);
 
-        SourceHttpServer server = new NettySourceHttpServer(context, threadCount);
+        server = new NettySourceHttpServer(context, threadCount);
         try {
             server.init(queryRegistry, eventSubject, serverPort);
         } catch (InterruptedException e) {
@@ -120,5 +123,13 @@ public class PushHttpSource implements Source<String> {
                 .build());
 
         return parameters;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (server != null) {
+            server.shutdownServer();
+            server = null;
+        }
     }
 }

--- a/mantis-examples/mantis-examples-groupby-sample/src/main/java/com/netflix/mantis/samples/source/RandomRequestSource.java
+++ b/mantis-examples/mantis-examples-groupby-sample/src/main/java/com/netflix/mantis/samples/source/RandomRequestSource.java
@@ -20,6 +20,7 @@ import com.netflix.mantis.samples.proto.RequestEvent;
 import io.mantisrx.runtime.Context;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import net.andreinc.mockneat.MockNeat;
@@ -55,4 +56,8 @@ public class RandomRequestSource implements Source<RequestEvent> {
         mockDataGenerator = MockNeat.threadLocal();
     }
 
+    @Override
+    public void close() throws IOException {
+
+    }
 }

--- a/mantis-examples/mantis-examples-sine-function/src/main/java/io/mantisrx/mantis/examples/sinefunction/SineFunctionJob.java
+++ b/mantis-examples/mantis-examples-sine-function/src/main/java/io/mantisrx/mantis/examples/sinefunction/SineFunctionJob.java
@@ -36,6 +36,7 @@ import io.mantisrx.runtime.sink.ServerSentEventsSink;
 import io.mantisrx.runtime.sink.predicate.Predicate;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
+import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import rx.Observable;
@@ -212,6 +213,11 @@ public class SineFunctionJob extends MantisJobProvider<Point> {
                                 return (value <= randomRate);
                             })
             );
+        }
+
+        @Override
+        public void close() throws IOException {
+
         }
     }
 }

--- a/mantis-examples/mantis-examples-synthetic-sourcejob/src/main/java/io/mantisrx/sourcejob/synthetic/source/SyntheticSource.java
+++ b/mantis-examples/mantis-examples-synthetic-sourcejob/src/main/java/io/mantisrx/sourcejob/synthetic/source/SyntheticSource.java
@@ -23,6 +23,7 @@ import io.mantisrx.runtime.parameter.validator.Validators;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
 import io.mantisrx.sourcejob.synthetic.proto.RequestEvent;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -59,6 +60,7 @@ public class SyntheticSource implements Source<String> {
         mockDataGenerator = MockNeat.threadLocal();
         dataGenerateRateMsec = (int)context.getParameters().get(DATA_GENERATION_RATE_MSEC_PARAM,250);
     }
+
     @Override
     public List<ParameterDefinition<?>> getParameters() {
         List<ParameterDefinition<?>> params = new ArrayList<>();
@@ -106,4 +108,7 @@ public class SyntheticSource implements Source<String> {
                 .build();
     }
 
+    @Override
+    public void close() throws IOException {
+    }
 }

--- a/mantis-examples/mantis-examples-twitter-sample/src/main/java/com/netflix/mantis/examples/wordcount/sources/TwitterSource.java
+++ b/mantis-examples/mantis-examples-twitter-sample/src/main/java/com/netflix/mantis/examples/wordcount/sources/TwitterSource.java
@@ -31,6 +31,7 @@ import io.mantisrx.runtime.parameter.validator.Validators;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import rx.Observable;
@@ -148,5 +149,10 @@ public class TwitterSource implements Source<String> {
                 .build();
 
         client.connect();
+    }
+
+    @Override
+    public void close() throws IOException {
+        client.stop();
     }
 }

--- a/mantis-examples/mantis-examples-wordcount/src/main/java/com/netflix/mantis/examples/wordcount/sources/IlliadSource.java
+++ b/mantis-examples/mantis-examples-wordcount/src/main/java/com/netflix/mantis/examples/wordcount/sources/IlliadSource.java
@@ -59,4 +59,9 @@ public class IlliadSource implements Source<String> {
                     return Observable.empty();
                 });
     }
+
+  @Override
+  public void close() throws IOException {
+
+  }
 }

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/Sources.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/Sources.java
@@ -17,6 +17,7 @@
 package io.mantisrx.runtime.source;
 
 import io.mantisrx.runtime.Context;
+import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import rx.Observable;
 import rx.functions.Func1;
@@ -32,6 +33,11 @@ public class Sources {
             public Observable<Observable<T>> call(Context context, Index t1) {
                 return Observable.just(o);
             }
+
+            @Override
+            public void close() throws IOException {
+
+            }
         };
     }
 
@@ -40,6 +46,11 @@ public class Sources {
             @Override
             public Observable<Observable<T>> call(Context context, Index t1) {
                 return o;
+            }
+
+            @Override
+            public void close() throws IOException {
+
             }
         };
     }
@@ -63,6 +74,11 @@ public class Sources {
                                 return (int) (long) t1;
                             }
                         }));
+            }
+
+            @Override
+            public void close() throws IOException {
+
             }
         };
     }

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/ContextualHttpSource.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/ContextualHttpSource.java
@@ -23,6 +23,7 @@ import io.mantisrx.runtime.source.http.impl.HttpSourceImpl;
 import io.mantisrx.runtime.source.http.impl.HttpSourceImpl.HttpSourceEvent;
 import io.mantisrx.runtime.source.http.impl.ServerContext;
 import io.netty.buffer.ByteBuf;
+import java.io.IOException;
 import rx.Observable;
 import rx.Observer;
 
@@ -59,6 +60,11 @@ public class ContextualHttpSource<E> implements Source<ServerContext<E>> {
     @Override
     public Observable<Observable<ServerContext<E>>> call(Context context, Index t2) {
         return impl.call(context, t2);
+    }
+
+    @Override
+    public void close() throws IOException {
+        impl.close();
     }
 
     public static class Builder<E> {

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/HttpSource.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/HttpSource.java
@@ -22,6 +22,7 @@ import io.mantisrx.runtime.source.Source;
 import io.mantisrx.runtime.source.http.impl.HttpSourceImpl;
 import io.mantisrx.runtime.source.http.impl.HttpSourceImpl.HttpSourceEvent;
 import io.netty.buffer.ByteBuf;
+import java.io.IOException;
 import rx.Observable;
 import rx.Observer;
 
@@ -62,6 +63,11 @@ public class HttpSource<E, T> implements Source<T> {
     @Override
     public Observable<Observable<T>> call(Context context, Index index) {
         return impl.call(context, index);
+    }
+
+    @Override
+    public void close() throws IOException {
+        impl.close();
     }
 
     public static class Builder<E, T> {

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/impl/ClientWithResponse.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/impl/ClientWithResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Netflix, Inc.
+ * Copyright 2022 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,14 @@
  * limitations under the License.
  */
 
-package io.mantisrx.runtime.source;
+package io.mantisrx.runtime.source.http.impl;
 
-import io.mantisrx.runtime.Context;
-import io.mantisrx.runtime.parameter.ParameterDefinition;
-import java.io.Closeable;
-import java.util.Collections;
-import java.util.List;
-import rx.Observable;
-import rx.functions.Func2;
+import lombok.Value;
+import mantis.io.reactivex.netty.protocol.http.client.HttpClient;
+import mantis.io.reactivex.netty.protocol.http.client.HttpClientResponse;
 
-
-public interface Source<T> extends Func2<Context, Index, Observable<Observable<T>>>, Closeable {
-
-    default List<ParameterDefinition<?>> getParameters() {
-        return Collections.emptyList();
-    }
-
-    default void init(Context context, Index index) {
-
-    }
+@Value
+class ClientWithResponse<R, E> {
+    HttpClient<R, E> client;
+    HttpClientResponse<E> response;
 }

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/impl/ServerContext.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/impl/ServerContext.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.runtime.source.http.impl;
 
+import java.util.function.Function;
 import mantis.io.reactivex.netty.client.RxClient.ServerInfo;
 
 
@@ -30,7 +31,6 @@ public class ServerContext<T> {
     private final ServerInfo server;
     private final T value;
 
-
     public ServerContext(ServerInfo server, T value) {
         this.server = server;
         this.value = value;
@@ -42,5 +42,9 @@ public class ServerContext<T> {
 
     public T getValue() {
         return value;
+    }
+
+    public <R> ServerContext<R> map(Function<? super T, ? extends R> mapper) {
+        return new ServerContext<>(server, mapper.apply(value));
     }
 }

--- a/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/TestJob.java
+++ b/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/TestJob.java
@@ -56,6 +56,11 @@ public class TestJob extends MantisJobProvider<Integer> {
                                                                 Index t2) {
                         return Observable.just(Observable.range(0, 10));
                     }
+
+                    @Override
+                    public void close() throws IOException {
+
+                    }
                 })
                 // doubles number
                 .stage(new ScalarComputation<Integer, Integer>() {

--- a/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/TestJobParameterized.java
+++ b/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/TestJobParameterized.java
@@ -32,6 +32,7 @@ import io.mantisrx.runtime.parameter.validator.Validators;
 import io.mantisrx.runtime.sink.Sink;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import rx.Observable;
@@ -67,6 +68,11 @@ public class TestJobParameterized extends MantisJobProvider<Integer> {
                         Integer start = (Integer) context.getParameters().get("start-range");
                         Integer end = (Integer) context.getParameters().get("end-range");
                         return Observable.just(Observable.range(start, end));
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+
                     }
                 })
                 // doubles number

--- a/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/TestJobSingleStage.java
+++ b/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/TestJobSingleStage.java
@@ -27,6 +27,7 @@ import io.mantisrx.runtime.computation.ScalarComputation;
 import io.mantisrx.runtime.sink.Sink;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import rx.Observable;
@@ -54,6 +55,11 @@ public class TestJobSingleStage extends MantisJobProvider<Integer> {
                     public Observable<Observable<Integer>> call(Context t1,
                                                                 Index t2) {
                         return Observable.just(Observable.range(0, 10));
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+
                     }
                 })
                 // doubles number

--- a/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/TestJobThreeStage.java
+++ b/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/TestJobThreeStage.java
@@ -27,6 +27,7 @@ import io.mantisrx.runtime.computation.ScalarComputation;
 import io.mantisrx.runtime.sink.Sink;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
+import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import rx.Observable;
@@ -54,6 +55,11 @@ public class TestJobThreeStage extends MantisJobProvider<Integer> {
                     public Observable<Observable<Integer>> call(Context t1,
                                                                 Index t2) {
                         return Observable.just(Observable.range(0, 10));
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+
                     }
                 })
                 // doubles number

--- a/mantis-runtime/src/test/java/io/mantisrx/runtime/source/http/HttpSourceTest.java
+++ b/mantis-runtime/src/test/java/io/mantisrx/runtime/source/http/HttpSourceTest.java
@@ -43,6 +43,7 @@ import io.mantisrx.runtime.source.http.impl.HttpClientFactories;
 import io.mantisrx.runtime.source.http.impl.HttpRequestFactories;
 import io.mantisrx.runtime.source.http.impl.HttpSourceImpl.HttpSourceEvent.EventType;
 import io.netty.buffer.ByteBuf;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Random;
@@ -425,6 +426,11 @@ public class HttpSourceTest {
                                 return aLong.toString();
                             }
                         }));
+            }
+
+            @Override
+            public void close() throws IOException {
+
             }
         };
 

--- a/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/SineFunctionJobProvider.java
+++ b/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/SineFunctionJobProvider.java
@@ -32,6 +32,7 @@ import io.mantisrx.runtime.sink.ServerSentEventsSink;
 import io.mantisrx.runtime.sink.predicate.Predicate;
 import io.mantisrx.runtime.source.Index;
 import io.mantisrx.runtime.source.Source;
+import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import rx.Observable;
@@ -187,6 +188,10 @@ public class SineFunctionJobProvider extends MantisJobProvider<Point> {
                         return (value <= randomRate);
                     })
             );
+        }
+
+        @Override
+        public void close() throws IOException {
         }
     }
 


### PR DESCRIPTION
### Context

Every source needs to close any resources such as HTTP clients or thread pools associated with creating the Observable as part of the Source::call API. This diff adds a new method to the source API, which will eventually be called as part of stage execution. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
