### PR TITLE
Upgrade jackson version in shaded jar

### DIFF
--- a/mantis-shaded/build.gradle
+++ b/mantis-shaded/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
  * On the second publish, you update all subprojects that depend on mantis-shaded
  */
 ext {
-    jacksonVersion = '2.10.+'
+    jacksonVersion = '2.12.+'
     guavaVersion = '18.+'
     curatorVersion = '2.12.+'
     zookeeperVersion = '3.4.+'


### PR DESCRIPTION
Move Jackson version to "1.12+".

### Context

Explain context and other details for this pull request.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
