### PR TITLE
Iceberg writer stage should include WRITER_MAXIMUM_POOL_SIZE in its parameters

### DIFF
--- a/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
+++ b/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/IcebergWriterStage.java
@@ -102,7 +102,12 @@ public class IcebergWriterStage implements ScalarComputation<Record, DataFile> {
                         .description(WriterProperties.WRITER_FILE_FORMAT_DESCRIPTION)
                         .validator(Validators.alwaysPass())
                         .defaultValue(WriterProperties.WRITER_FILE_FORMAT_DEFAULT)
-                        .build()
+                        .build(),
+                new IntParameter().name(WriterProperties.WRITER_MAXIMUM_POOL_SIZE)
+                    .description(WriterProperties.WRITER_MAXIMUM_POOL_SIZE_DESCRIPTION)
+                    .validator(Validators.alwaysPass())
+                    .defaultValue(WriterProperties.WRITER_MAXIMUM_POOL_SIZE_DEFAULT)
+                    .build()
         );
     }
 


### PR DESCRIPTION
### Context

Iceberg writer stage missed to add `WRITER_MAXIMUM_POOL_SIZE` into the parameter list. So all overrides in jobs will be ignored and the default value will be used regardless.

### Checklist

- [X] `./gradlew build` compiles code correctly
- [ ] ~Added new tests where applicable~
- [X] `./gradlew test` passes all tests
- [ ] ~Extended README or added javadocs where applicable~
- [ ] ~Added copyright headers for new files from `CONTRIBUTING.md`~
