### PR TITLE
Iceberg sink uses Parameters::get to ensure parameter definition exists

### DIFF
--- a/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/config/CommitterConfig.java
+++ b/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/committer/config/CommitterConfig.java
@@ -17,7 +17,6 @@
 package io.mantisrx.connector.iceberg.sink.committer.config;
 
 import static io.mantisrx.connector.iceberg.sink.committer.config.CommitterProperties.COMMIT_FREQUENCY_MS;
-import static io.mantisrx.connector.iceberg.sink.committer.config.CommitterProperties.COMMIT_FREQUENCY_MS_DEFAULT;
 
 import io.mantisrx.connector.iceberg.sink.config.SinkConfig;
 import io.mantisrx.runtime.parameter.Parameters;
@@ -34,8 +33,7 @@ public class CommitterConfig extends SinkConfig {
      */
     public CommitterConfig(Parameters parameters) {
         super(parameters);
-        this.commitFrequencyMs =
-                Long.parseLong((String) parameters.get(COMMIT_FREQUENCY_MS, COMMIT_FREQUENCY_MS_DEFAULT));
+        this.commitFrequencyMs = Long.parseLong((String) parameters.get(COMMIT_FREQUENCY_MS));
     }
 
     /**

--- a/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterConfig.java
+++ b/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/config/WriterConfig.java
@@ -39,16 +39,11 @@ public class WriterConfig extends SinkConfig {
      */
     public WriterConfig(Parameters parameters, Configuration hadoopConfig) {
         super(parameters);
-        this.writerRowGroupSize = (int) parameters.get(
-                WRITER_ROW_GROUP_SIZE, WRITER_ROW_GROUP_SIZE_DEFAULT);
-        this.writerFlushFrequencyBytes = Long.parseLong((String) parameters.get(
-                WRITER_FLUSH_FREQUENCY_BYTES, WRITER_FLUSH_FREQUENCY_BYTES_DEFAULT));
-        this.writerFlushFrequencyMsec = Long.parseLong((String) parameters.get(
-                WRITER_FLUSH_FREQUENCY_MSEC, WRITER_FLUSH_FREQUENCY_MSEC_DEFAULT));
-        this.writerFileFormat = (String) parameters.get(
-                WRITER_FILE_FORMAT, WRITER_FILE_FORMAT_DEFAULT);
-        this.writerMaximumPoolSize = (int) parameters.get(
-                WRITER_MAXIMUM_POOL_SIZE, WRITER_MAXIMUM_POOL_SIZE_DEFAULT);
+        this.writerRowGroupSize = (int) parameters.get(WRITER_ROW_GROUP_SIZE);
+        this.writerFlushFrequencyBytes = Long.parseLong((String) parameters.get(WRITER_FLUSH_FREQUENCY_BYTES));
+        this.writerFlushFrequencyMsec = Long.parseLong((String) parameters.get(WRITER_FLUSH_FREQUENCY_MSEC));
+        this.writerFileFormat = (String) parameters.get(WRITER_FILE_FORMAT);
+        this.writerMaximumPoolSize = (int) parameters.get(WRITER_MAXIMUM_POOL_SIZE);
         this.hadoopConfig = hadoopConfig;
     }
 

--- a/mantis-connectors/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/StageOverrideParameters.java
+++ b/mantis-connectors/mantis-connector-iceberg/src/test/java/io/mantisrx/connector/iceberg/sink/StageOverrideParameters.java
@@ -16,13 +16,18 @@
 
 package io.mantisrx.connector.iceberg.sink;
 
+import com.google.common.collect.Lists;
+import io.mantisrx.connector.iceberg.sink.committer.IcebergCommitterStage;
 import io.mantisrx.connector.iceberg.sink.config.SinkProperties;
+import io.mantisrx.connector.iceberg.sink.writer.IcebergWriterStage;
 import io.mantisrx.connector.iceberg.sink.writer.config.WriterProperties;
+import io.mantisrx.runtime.parameter.Parameter;
+import io.mantisrx.runtime.parameter.ParameterDefinition;
+import io.mantisrx.runtime.parameter.ParameterUtils;
 import io.mantisrx.runtime.parameter.Parameters;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class StageOverrideParameters {
 
@@ -30,21 +35,18 @@ public class StageOverrideParameters {
     }
 
     public static Parameters newParameters() {
-        Map<String, Object> state = new HashMap<>();
-        Set<String> required = new HashSet<>();
+        Map<String, ParameterDefinition<?>> definition = new HashMap<>();
+        IcebergWriterStage.parameters().forEach(p -> definition.put(p.getName(), p));
+        IcebergCommitterStage.parameters().forEach(p -> definition.put(p.getName(), p));
 
-        required.add(SinkProperties.SINK_CATALOG);
-        state.put(SinkProperties.SINK_CATALOG, "catalog");
+        List<Parameter> parameters = Lists.newArrayList(
+            new Parameter(SinkProperties.SINK_CATALOG, "catalog"),
+            new Parameter(SinkProperties.SINK_DATABASE, "database"),
+            new Parameter(SinkProperties.SINK_TABLE, "table"),
+            new Parameter(WriterProperties.WRITER_FLUSH_FREQUENCY_MSEC, "500"),
+            new Parameter(WriterProperties.WRITER_MAXIMUM_POOL_SIZE, "10")
+        );
 
-        required.add(SinkProperties.SINK_DATABASE);
-        state.put(SinkProperties.SINK_DATABASE, "database");
-
-        required.add(SinkProperties.SINK_TABLE);
-        state.put(SinkProperties.SINK_TABLE, "table");
-
-        required.add(WriterProperties.WRITER_FLUSH_FREQUENCY_MSEC);
-        state.put(WriterProperties.WRITER_FLUSH_FREQUENCY_MSEC, "500");
-
-        return new Parameters(state, required, required);
+        return ParameterUtils.createContextParameters(definition, parameters);
     }
 }

--- a/mantis-runtime/build.gradle
+++ b/mantis-runtime/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     api project(':mantis-common')
     api libraries.slf4jApi
     testImplementation libraries.junit4
-    testImplementation libraries.junitJupiter
     testImplementation libraries.mockitoCore
 
 }

--- a/mantis-runtime/build.gradle
+++ b/mantis-runtime/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     api project(':mantis-common')
     api libraries.slf4jApi
     testImplementation libraries.junit4
+    testImplementation libraries.junitJupiter
     testImplementation libraries.mockitoCore
 
 }

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/Parameters.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/Parameters.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-
 public class Parameters {
 
     private Set<String> requiredParameters = new HashSet<>();
@@ -38,22 +37,34 @@ public class Parameters {
         this.parameterDefinitions = parameterDefinitions;
     }
 
+    /**
+     * Get parameter value given key with validation.
+     *
+     * If the key is required, parameters must have a value provided otherwise it will throw an exception.
+     * If the key is not defined, it will throw an exception.
+     */
     public Object get(String key) {
-        // check if required parameter, make sure
-        // has a value
+        // check if required parameter, make sure has a value
         if (requiredParameters.contains(key) &&
                 !state.containsKey(key)) {
-            throw new ParameterException("Attempting to reference a required parameter witn no value: " + key + ", check parameter definitions for job.");
+            throw new ParameterException("Attempting to reference a required parameter witn no value: " + key +
+                ", check parameter definitions for job.");
         }
         // check if parameter definition exists
         if (!parameterDefinitions.contains(key)) {
-            throw new ParameterException("Attempting to reference parameter: " + key + ", with no definition, check parameter definitions in job.");
+            throw new ParameterException("Attempting to reference parameter: " + key +
+                ", with no definition, check parameter definitions in job.");
         }
         return state.get(key);
     }
 
+    /**
+     * Get parameter value given key without validation.
+     *
+     * If the key is not defined or missing a provided value, the given default value will be returned.
+     */
     public Object get(String key, Object defaultValue) {
-        Object value = defaultValue;
+        Object value;
         try {
             value = get(key);
             if (value == null) {

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/Parameters.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/Parameters.java
@@ -61,18 +61,14 @@ public class Parameters {
     /**
      * Get parameter value given key without validation.
      *
-     * If the key is not defined or missing a provided value, the given default value will be returned.
+     * If the key is not defined, value is missing or is null, given {@code defaultValue} will be returned.
      */
     public Object get(String key, Object defaultValue) {
-        Object value;
         try {
-            value = get(key);
-            if (value == null) {
-                value = defaultValue;
-            }
+            final Object value = get(key);
+            return value != null ? value : defaultValue;
         } catch (ParameterException ex) {
-            value = defaultValue;
+            return defaultValue;
         }
-        return value;
     }
 }

--- a/mantis-runtime/src/test/java/io/mantisrx/runtime/parameter/ParametersTest.java
+++ b/mantis-runtime/src/test/java/io/mantisrx/runtime/parameter/ParametersTest.java
@@ -18,7 +18,7 @@ package io.mantisrx.runtime.parameter;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.fail;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,5 +82,16 @@ public class ParametersTest {
         assertEquals("defaultValue", parameters.get("o2", "defaultValue"));
         // Get undefined parameter u1 should return the provided default value
         assertEquals("defaultValue", parameters.get("u2", "defaultValue"));
+    }
+
+    static <T extends Throwable> void assertThrows(Class<T> expectedType, Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (Throwable t) {
+            if (expectedType.isInstance(t)) {
+                return;
+            }
+        }
+        fail("Should have failed with exception class " + expectedType);
     }
 }

--- a/mantis-runtime/src/test/java/io/mantisrx/runtime/parameter/ParametersTest.java
+++ b/mantis-runtime/src/test/java/io/mantisrx/runtime/parameter/ParametersTest.java
@@ -17,6 +17,7 @@
 package io.mantisrx.runtime.parameter;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
@@ -40,13 +41,17 @@ public class ParametersTest {
         parameterDefinitions.add("r1");
         state.put("r1", "v1");
 
-        // required parameter r2 -> null
+        // required parameter r2 -> N/A
         requiredParameters.add("r2");
         parameterDefinitions.add("r2");
 
         // optional parameter o1 -> v1
         parameterDefinitions.add("o1");
         state.put("o1", "v1");
+
+        // optional parameter o2 -> null
+        parameterDefinitions.add("o2");
+        state.put("o2", null);
 
         parameters = new Parameters(state, requiredParameters, parameterDefinitions);
     }
@@ -55,10 +60,12 @@ public class ParametersTest {
     public void testGet() {
         // Get required parameter r1 should succeed
         assertEquals("v1", parameters.get("r1"));
-        // Get optional parameter o1 should succeed
-        assertEquals("v1", parameters.get("o1"));
         // Get required parameter r2 should fail because it does not have a value
         assertThrows(ParameterException.class, () -> parameters.get("r2"));
+        // Get optional parameter o1 should succeed
+        assertEquals("v1", parameters.get("o1"));
+        // Get optional parameter o2 should succeed with null value
+        assertNull(parameters.get("o2"));
         // Get undefined parameter u1 should fail
         assertThrows(ParameterException.class, () -> parameters.get("u1"));
     }
@@ -67,10 +74,12 @@ public class ParametersTest {
     public void testGetWithDefaultValue() {
         // Get required parameter r1 should return value in state
         assertEquals("v1", parameters.get("r1", "defaultValue"));
-        // Get optional parameter o1 should return value in state
-        assertEquals("v1", parameters.get("o1", "defaultValue"));
         // Get required parameter r2 should return the provided default value
         assertEquals("defaultValue", parameters.get("r2", "defaultValue"));
+        // Get optional parameter o1 should return value in state
+        assertEquals("v1", parameters.get("o1", "defaultValue"));
+        // Get optional parameter o2 should return the provided default value instead of null
+        assertEquals("defaultValue", parameters.get("o2", "defaultValue"));
         // Get undefined parameter u1 should return the provided default value
         assertEquals("defaultValue", parameters.get("u2", "defaultValue"));
     }

--- a/mantis-runtime/src/test/java/io/mantisrx/runtime/parameter/ParametersTest.java
+++ b/mantis-runtime/src/test/java/io/mantisrx/runtime/parameter/ParametersTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.runtime.parameter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ParametersTest {
+    private Parameters parameters;
+
+    @Before
+    public void setup() {
+        final Set<String> requiredParameters = new HashSet<>();
+        final Set<String> parameterDefinitions = new HashSet<>();
+        final Map<String, Object> state = new HashMap<>();
+
+        // required parameter r1 -> v1
+        requiredParameters.add("r1");
+        parameterDefinitions.add("r1");
+        state.put("r1", "v1");
+
+        // required parameter r2 -> null
+        requiredParameters.add("r2");
+        parameterDefinitions.add("r2");
+
+        // optional parameter o1 -> v1
+        parameterDefinitions.add("o1");
+        state.put("o1", "v1");
+
+        parameters = new Parameters(state, requiredParameters, parameterDefinitions);
+    }
+
+    @Test
+    public void testGet() {
+        // Get required parameter r1 should succeed
+        assertEquals("v1", parameters.get("r1"));
+        // Get optional parameter o1 should succeed
+        assertEquals("v1", parameters.get("o1"));
+        // Get required parameter r2 should fail because it does not have a value
+        assertThrows(ParameterException.class, () -> parameters.get("r2"));
+        // Get undefined parameter u1 should fail
+        assertThrows(ParameterException.class, () -> parameters.get("u1"));
+    }
+
+    @Test
+    public void testGetWithDefaultValue() {
+        // Get required parameter r1 should return value in state
+        assertEquals("v1", parameters.get("r1", "defaultValue"));
+        // Get optional parameter o1 should return value in state
+        assertEquals("v1", parameters.get("o1", "defaultValue"));
+        // Get required parameter r2 should return the provided default value
+        assertEquals("defaultValue", parameters.get("r2", "defaultValue"));
+        // Get undefined parameter u1 should return the provided default value
+        assertEquals("defaultValue", parameters.get("u2", "defaultValue"));
+    }
+}


### PR DESCRIPTION
### Context
https://github.com/Netflix/mantis/pull/170#issuecomment-1098264092

> It looks like we should be using Parameters::get without the default value in this case. That would surface the runtime exception and hence the problem in this case.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] ~Added new tests where applicable~
- [x] `./gradlew test` passes all tests
- [ ] ~Extended README or added javadocs where applicable~
- [ ] ~Added copyright headers for new files from `CONTRIBUTING.md`~
