### PR TITLE
Setting hostname as part of heartbeat

### DIFF
--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/Heartbeat.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/Heartbeat.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -39,11 +40,18 @@ class Heartbeat {
     private final int workerNumber;
     private final ConcurrentMap<String, String> payloads;
     private final BlockingQueue<PayloadPair> singleUsePayloads = new LinkedBlockingQueue<>();
+    private final Optional<String> host;
+
     Heartbeat(String jobId, int stageNumber, int workerIndex, int workerNumber) {
+        this(jobId, stageNumber, workerIndex, workerNumber, Optional.empty());
+    }
+
+    Heartbeat(String jobId, int stageNumber, int workerIndex, int workerNumber, Optional<String> host) {
         this.jobId = jobId;
         this.stageNumber = stageNumber;
         this.workerIndex = workerIndex;
         this.workerNumber = workerNumber;
+        this.host = host;
         payloads = new ConcurrentHashMap<>();
     }
 
@@ -79,6 +87,7 @@ class Heartbeat {
                 payloadList.add(new Status.Payload(entry.getKey(), entry.getValue()));
         }
         Status status = new Status(jobId, stageNumber, workerIndex, workerNumber, Status.TYPE.HEARTBEAT, "heartbeat", MantisJobState.Noop);
+        host.ifPresent(status::setHostname);
         if (!payloadList.isEmpty())
             status.setPayloads(payloadList);
         return status;

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
@@ -50,7 +50,10 @@ import org.slf4j.LoggerFactory;
 import rx.Subscription;
 import rx.subjects.PublishSubject;
 
-
+/**
+ * This class is the executable entry point for the worker. It constructs the related components (LeaderService),
+ * and starts them.
+ */
 public class MantisWorker extends BaseService {
 
     private static final Logger logger = LoggerFactory.getLogger(MantisWorker.class);
@@ -109,7 +112,8 @@ public class MantisWorker extends BaseService {
                                             .Factory
                                             .forEphemeralJobsThatNeedToBeKilledInAbsenceOfSubscriber(
                                                     gateway,
-                                                    Clock.systemDefaultZone()));
+                                                    Clock.systemDefaultZone()),
+                                Optional.empty());
                             taskStatusUpdateSubscription =
                                     task
                                             .getStatus()

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/Task.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/Task.java
@@ -52,6 +52,8 @@ public class Task extends AbstractIdleService {
 
     private final PublishSubject<Observable<Status>> tasksStatusSubject = PublishSubject.create();
 
+    private final Optional<String> hostname;
+
     @Override
     public void startUp() {
         try {
@@ -78,7 +80,9 @@ public class Task extends AbstractIdleService {
                 vmTaskStatusSubject,
                 masterMonitor,
                 config,
-                workerMetricsClient, sinkSubscriptionStateHandlerFactory),
+                workerMetricsClient,
+                sinkSubscriptionStateHandlerFactory,
+                hostname),
             getJobProviderClass(), classLoaderHandle, null));
 
         log.info("Starting Mantis Worker for task {}", this);

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
@@ -84,6 +84,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     private final TaskExecutorRegistration taskExecutorRegistration;
     private final CompletableFuture<Void> startFuture = new CompletableFuture<>();
     private final ExecutorService ioExecutor;
+    private final String hostName;
 
     // the reason the MantisMasterGateway field is not final is because we expect the HighAvailabilityServices
     // to be started before we can get the MantisMasterGateway
@@ -125,9 +126,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             Hardware.getSizeOfPhysicalMemory(),
             Hardware.getSizeOfDisk(),
             workerPorts.getNumberOfPorts());
+        this.hostName = workerConfiguration.getExternalAddress();
         this.taskExecutorRegistration =
             new TaskExecutorRegistration(
-                taskExecutorID, clusterID, getAddress(), workerConfiguration.getExternalAddress(), workerPorts, machineDefinition);
+                taskExecutorID, clusterID, getAddress(), hostName, workerPorts, machineDefinition);
         this.ioExecutor =
             Executors.newFixedThreadPool(
                 Hardware.getNumberCPUCores(),
@@ -412,7 +414,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             workerConfiguration,
             masterMonitor,
             classLoaderHandle,
-            subscriptionStateHandlerFactory);
+            subscriptionStateHandlerFactory,
+            Optional.of(getHostname()));
 
         setCurrentTask(task);
 


### PR DESCRIPTION
Every heartbeat sent from the new task executor will contain the hostname from which it is sent. Note that this field already exists but wasn't used by the Mesos-based task executor. The new task executor will use it.

### Context

Explain context and other details for this pull request.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
