### PR TITLE
Scheduler Integration with Mantis Master

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/JobClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/JobClustersManagerActor.java
@@ -102,9 +102,10 @@ import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.domain.IJobClusterDefinition;
 import io.mantisrx.server.master.domain.JobClusterDefinitionImpl;
 import io.mantisrx.server.master.domain.JobClusterDefinitionImpl.CompletedJob;
+import io.mantisrx.server.master.domain.JobDefinition;
 import io.mantisrx.server.master.domain.JobId;
 import io.mantisrx.server.master.persistence.MantisJobStore;
-import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.server.master.scheduler.WorkerEvent;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
 import java.time.Duration;
@@ -142,7 +143,7 @@ public class JobClustersManagerActor extends AbstractActorWithTimers implements 
 
     private final MantisJobStore jobStore;
     private final LifecycleEventPublisher eventPublisher;
-    private MantisScheduler mantisScheduler = null;
+    private MantisSchedulerFactory mantisSchedulerFactory = null;
 
     JobClusterInfoManager jobClusterInfoManager;
 
@@ -311,10 +312,10 @@ public class JobClustersManagerActor extends AbstractActorWithTimers implements 
             this.jobListHelperActor = getContext().actorOf(JobListHelperActor.props(), "JobListHelperActor");
             getContext().watch(jobListHelperActor);
 
-            mantisScheduler = initMsg.getScheduler();
+            mantisSchedulerFactory = initMsg.getScheduler();
             Map<String, IJobClusterMetadata> jobClusterMap = new HashMap<>();
 
-            this.jobClusterInfoManager = new JobClusterInfoManager(jobStore, mantisScheduler, eventPublisher);
+            this.jobClusterInfoManager = new JobClusterInfoManager(jobStore, mantisSchedulerFactory, eventPublisher);
 
             if (!initMsg.isLoadJobsFromStore()) {
                 getContext().become(initializedBehavior);
@@ -537,7 +538,15 @@ public class JobClustersManagerActor extends AbstractActorWithTimers implements 
             if(!JobHelper.isTerminalWorkerEvent(workerEvent)) {
                 logger.warn("Event from Worker {} for a cluster {} that no longer exists. Terminate worker", workerEvent, workerEvent.getWorkerId().getJobCluster());
                 Optional<String> host = JobHelper.getWorkerHostFromWorkerEvent(workerEvent);
-                mantisScheduler.unscheduleAndTerminateWorker(workerEvent.getWorkerId(), host);
+                Optional<JobDefinition> archivedJobDefinition =
+                    jobClusterInfoManager.getArchivedJobDefinition(workerEvent.getWorkerId().getJobId());
+                if (archivedJobDefinition.isPresent()) {
+                    mantisSchedulerFactory
+                        .forJob(archivedJobDefinition.get())
+                        .unscheduleAndTerminateWorker(workerEvent.getWorkerId(), host);
+                } else {
+                    logger.error("Non-Terminal Event {} from worker {} for a cluster {} that no longer exists and the job definition not yet archived", workerEvent, workerEvent.getWorkerId(), workerEvent.getWorkerId().getJobCluster());
+                }
             } else {
                 logger.warn("Terminal Event from Worker {} for a cluster {} that no longer exists. Ignore worker", workerEvent, workerEvent.getWorkerId().getJobCluster());
             }
@@ -802,13 +811,13 @@ public class JobClustersManagerActor extends AbstractActorWithTimers implements 
         private final Map<String, JobClusterInfo> jobClusterNameToInfoMap = new HashMap<>();
 
         private final LifecycleEventPublisher eventPublisher;
-        private MantisScheduler mantisScheduler;
+        private MantisSchedulerFactory mantisSchedulerFactory;
         private final MantisJobStore jobStore;
         private final Metrics metrics;
 
-        JobClusterInfoManager(MantisJobStore jobStore, MantisScheduler mantisScheduler, LifecycleEventPublisher eventPublisher) {
+        JobClusterInfoManager(MantisJobStore jobStore, MantisSchedulerFactory mantisSchedulerFactory, LifecycleEventPublisher eventPublisher) {
             this.eventPublisher = eventPublisher;
-            this.mantisScheduler  = mantisScheduler;
+            this.mantisSchedulerFactory  = mantisSchedulerFactory;
             this.jobStore = jobStore;
 
 
@@ -835,7 +844,10 @@ public class JobClustersManagerActor extends AbstractActorWithTimers implements 
                     logger.error("Cannot create actor for cluster with invalid name {}", clusterName);
                     return empty();
                 }
-                ActorRef jobClusterActor = getContext().actorOf(JobClusterActor.props(clusterName, this.jobStore, this.mantisScheduler, this.eventPublisher), "JobClusterActor-" + clusterName);
+                ActorRef jobClusterActor =
+                    getContext().actorOf(
+                        JobClusterActor.props(clusterName, this.jobStore, this.mantisSchedulerFactory, this.eventPublisher),
+                        "JobClusterActor-" + clusterName);
                 getContext().watch(jobClusterActor);
 
                 JobClusterInfo jobClusterInfo = new JobClusterInfo(clusterName, jobClusterDefn, jobClusterActor);
@@ -895,6 +907,10 @@ public class JobClustersManagerActor extends AbstractActorWithTimers implements 
 
         Optional<JobClusterInfo> getJobClusterInfo(String jobClusterName) {
             return ofNullable(jobClusterNameToInfoMap.get(jobClusterName));
+        }
+
+        Optional<JobDefinition> getArchivedJobDefinition(String jobId) {
+            return jobStore.getArchivedJob(jobId).map(IMantisJobMetadata::getJobDefinition);
         }
 
         Map<String, JobClusterInfo> getAllJobClusterInfo() {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/JobClustersManagerService.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/JobClustersManagerService.java
@@ -24,7 +24,7 @@ import io.mantisrx.master.jobcluster.proto.BaseResponse;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.server.core.BaseService;
 import io.mantisrx.server.master.config.ConfigurationProvider;
-import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -34,15 +34,15 @@ import org.slf4j.LoggerFactory;
 public class JobClustersManagerService extends BaseService {
     private static final Logger logger = LoggerFactory.getLogger(JobClustersManagerService.class);
     private final ActorRef jobClustersManagerActor;
-    private final MantisScheduler scheduler;
+    private final MantisSchedulerFactory schedulerFactory;
     private final boolean loadJobsFromStore;
 
     public JobClustersManagerService(final ActorRef jobClustersManagerActor,
-                                     final MantisScheduler scheduler,
+                                     final MantisSchedulerFactory schedulerFactory,
                                      final boolean loadJobsFromStore) {
         super(true);
         this.jobClustersManagerActor = jobClustersManagerActor;
-        this.scheduler = scheduler;
+        this.schedulerFactory = schedulerFactory;
         this.loadJobsFromStore = loadJobsFromStore;
     }
 
@@ -56,7 +56,7 @@ public class JobClustersManagerService extends BaseService {
                 long masterInitTimeoutSecs = ConfigurationProvider.getConfig().getMasterInitTimeoutSecs();
                 CompletionStage<JobClusterManagerProto.JobClustersManagerInitializeResponse> initResponse =
                     ask(jobClustersManagerActor,
-                        new JobClusterManagerProto.JobClustersManagerInitialize(scheduler, loadJobsFromStore),
+                        new JobClusterManagerProto.JobClustersManagerInitialize(schedulerFactory, loadJobsFromStore),
                         Timeout.apply(masterInitTimeoutSecs, TimeUnit.SECONDS))
                         .thenApply(JobClusterManagerProto.JobClustersManagerInitializeResponse.class::cast);
                 initResponse.whenComplete((resp, t) -> {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
@@ -124,6 +124,7 @@ import io.mantisrx.server.master.domain.SLA;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.exceptions.JobClusterAlreadyExistsException;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.server.master.scheduler.WorkerEvent;
 import io.mantisrx.shaded.com.google.common.base.Throwables;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
@@ -190,9 +191,9 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
     private final Counter numSLAEnforcementExecutions;
 
 
-    public static Props props(final String name, final MantisJobStore jobStore, final MantisScheduler mantisScheduler,
+    public static Props props(final String name, final MantisJobStore jobStore, final MantisSchedulerFactory mantisSchedulerFactory,
                               final LifecycleEventPublisher eventPublisher) {
-        return Props.create(JobClusterActor.class, name, jobStore, mantisScheduler, eventPublisher);
+        return Props.create(JobClusterActor.class, name, jobStore, mantisSchedulerFactory, eventPublisher);
     }
 
     private Receive initializedBehavior;
@@ -206,20 +207,20 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
 
     private SLAEnforcer slaEnforcer;
     private final JobManager jobManager;
-    private final MantisScheduler mantisScheduler;
+    private final MantisSchedulerFactory mantisSchedulerFactory;
     private final LifecycleEventPublisher eventPublisher;
 
     private BehaviorSubject<JobId> jobIdSubmissionSubject;
     private final JobDefinitionResolver jobDefinitionResolver = new JobDefinitionResolver();
 
 
-    public JobClusterActor(final String name, final MantisJobStore jobStore, final MantisScheduler scheduler, final LifecycleEventPublisher eventPublisher) {
+    public JobClusterActor(final String name, final MantisJobStore jobStore, final MantisSchedulerFactory schedulerFactory, final LifecycleEventPublisher eventPublisher) {
         this.name = name;
         this.jobStore = jobStore;
-        this.mantisScheduler = scheduler;
+        this.mantisSchedulerFactory = schedulerFactory;
         this.eventPublisher = eventPublisher;
 
-        this.jobManager = new JobManager(name, getContext(), mantisScheduler, eventPublisher, jobStore);
+        this.jobManager = new JobManager(name, getContext(), mantisSchedulerFactory, eventPublisher, jobStore);
 
         jobIdSubmissionSubject = BehaviorSubject.create();
 
@@ -1680,7 +1681,17 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
             if(!JobHelper.isTerminalWorkerEvent(r)) {
                 logger.warn("Event from worker {} has no valid running job. Terminating worker ", r.getWorkerId());
                 Optional<String> host = JobHelper.getWorkerHostFromWorkerEvent(r);
-                mantisScheduler.unscheduleAndTerminateWorker(r.getWorkerId(), host);
+                Optional<IMantisJobMetadata> completedJobOptional =
+                    jobManager.getJobDataForCompletedJob(r.getWorkerId().getJobId());
+                if (completedJobOptional.isPresent()) {
+                    JobDefinition jobDefinition =
+                        completedJobOptional.get().getJobDefinition();
+                    mantisSchedulerFactory
+                        .forJob(jobDefinition)
+                        .unscheduleAndTerminateWorker(r.getWorkerId(), host);
+                } else {
+                    logger.error("Non-terminal Event from worker {} has no completed job. Ignoring event ", r.getWorkerId());
+                }
             } else {
                 logger.warn("Terminal Event from worker {} has no valid running job. Ignoring event ", r.getWorkerId());
             }
@@ -2524,7 +2535,7 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
 
 
         private final ActorContext context;
-        private final MantisScheduler scheduler;
+        private final MantisSchedulerFactory scheduler;
         private final LifecycleEventPublisher publisher;
 
         private final MantisJobStore jobStore;
@@ -2532,11 +2543,11 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
         private final LabelCache labelCache = new LabelCache();
 
 
-        JobManager(String clusterName, ActorContext context, MantisScheduler scheduler, LifecycleEventPublisher publisher, MantisJobStore jobStore) {
+        JobManager(String clusterName, ActorContext context, MantisSchedulerFactory schedulerFactory, LifecycleEventPublisher publisher, MantisJobStore jobStore) {
             this.name = clusterName;
             this.jobStore = jobStore;
             this.context = context;
-            this.scheduler = scheduler;
+            this.scheduler = schedulerFactory;
             this.publisher = publisher;
             this.completedJobsCache = new CompletedJobCache(name, labelCache);
         }
@@ -2613,8 +2624,9 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
 
         JobInfo createJobInfoAndActorAndWatchActor(MantisJobMetadataImpl jobMeta, IJobClusterMetadata jobClusterMetadata) {
 
+            MantisScheduler scheduler1 = scheduler.forJob(jobMeta.getJobDefinition());
             ActorRef jobActor = context.actorOf(JobActor.props(jobClusterMetadata.getJobClusterDefinition(),
-                    jobMeta, jobStore, scheduler, publisher), "JobActor-" + jobMeta.getJobId().getId());
+                    jobMeta, jobStore, scheduler1, publisher), "JobActor-" + jobMeta.getJobId().getId());
 
 
             context.watch(jobActor);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
@@ -36,7 +36,7 @@ import io.mantisrx.server.master.domain.JobClusterDefinitionImpl;
 import io.mantisrx.server.master.domain.JobClusterDefinitionImpl.CompletedJob;
 import io.mantisrx.server.master.domain.JobDefinition;
 import io.mantisrx.server.master.domain.JobId;
-import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
@@ -154,19 +154,19 @@ public class JobClusterManagerProto {
     }
 
     public static final class JobClustersManagerInitialize extends BaseRequest {
-        private final MantisScheduler scheduler;
+        private final MantisSchedulerFactory schedulerFactory;
         private final boolean loadJobsFromStore;
 
         public JobClustersManagerInitialize(
-                final MantisScheduler scheduler,
+                final MantisSchedulerFactory schedulerFactory,
                 final boolean loadJobsFromStore) {
-            Preconditions.checkNotNull(scheduler, "MantisScheduler cannot be null");
-            this.scheduler = scheduler;
+            Preconditions.checkNotNull(schedulerFactory, "MantisScheduler cannot be null");
+            this.schedulerFactory = schedulerFactory;
             this.loadJobsFromStore = loadJobsFromStore;
         }
 
-        public MantisScheduler getScheduler() {
-            return scheduler;
+        public MantisSchedulerFactory getScheduler() {
+            return schedulerFactory;
         }
 
         public boolean isLoadJobsFromStore() {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -166,7 +166,7 @@ public class MasterMain implements Service {
                 RpcUtils.createRemoteRpcService(rpcSystem, configuration, null, "6123", null, Optional.empty());
             final ResourceClusters resourceClusters =
                 ResourceClustersAkkaImpl.load(getConfig(), rpcService, system, mantisJobStore);
-            
+
             // end of new stuff
 
             final JobMessageRouter jobMessageRouter = new JobMessageRouterImpl(jobClusterManagerActor);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -16,6 +16,8 @@
 
 package io.mantisrx.server.master;
 
+import static org.apache.flink.configuration.GlobalConfiguration.loadConfiguration;
+
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.DeadLetter;
@@ -42,10 +44,12 @@ import io.mantisrx.master.events.StatusEventSubscriber;
 import io.mantisrx.master.events.StatusEventSubscriberAkkaImpl;
 import io.mantisrx.master.events.WorkerEventSubscriber;
 import io.mantisrx.master.events.WorkerRegistryV2;
+import io.mantisrx.master.resourcecluster.ResourceClustersAkkaImpl;
 import io.mantisrx.master.scheduler.AgentsErrorMonitorActor;
 import io.mantisrx.master.scheduler.JobMessageRouterImpl;
 import io.mantisrx.master.vm.AgentClusterOperationsImpl;
 import io.mantisrx.master.zk.LeaderElector;
+import io.mantisrx.server.core.MantisAkkaRpcSystemLoader;
 import io.mantisrx.server.core.Service;
 import io.mantisrx.server.core.json.DefaultObjectMapper;
 import io.mantisrx.server.core.master.LocalMasterMonitor;
@@ -62,7 +66,10 @@ import io.mantisrx.server.master.mesos.VirtualMachineMasterServiceMesosImpl;
 import io.mantisrx.server.master.persistence.IMantisStorageProvider;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.MantisStorageProviderAdapter;
+import io.mantisrx.server.master.resourcecluster.ResourceClusters;
 import io.mantisrx.server.master.scheduler.JobMessageRouter;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactoryImpl;
 import io.mantisrx.server.master.scheduler.WorkerRegistry;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import io.mantisrx.shaded.org.apache.curator.utils.ZKPaths;
@@ -74,10 +81,15 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.rpc.RpcUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -143,6 +155,20 @@ public class MasterMain implements Service {
             final MantisJobStore mantisJobStore = new MantisJobStore(storageProvider);
             final ActorRef jobClusterManagerActor = system.actorOf(JobClustersManagerActor.props(mantisJobStore, lifecycleEventPublisher), "JobClustersManager");
 
+            // Beginning of new stuff
+            Configuration configuration = loadConfiguration();
+
+            final RpcSystem rpcSystem =
+                MantisAkkaRpcSystemLoader.getInstance();
+            // the RPCService implementation will only be used for communicating with task executors but not for running a server itself.
+            // Thus, there's no need for any valid external and bind addresses.
+            final RpcService rpcService =
+                RpcUtils.createRemoteRpcService(rpcSystem, configuration, null, "6123", null, Optional.empty());
+            final ResourceClusters resourceClusters =
+                ResourceClustersAkkaImpl.load(getConfig(), rpcService, system, mantisJobStore);
+            
+            // end of new stuff
+
             final JobMessageRouter jobMessageRouter = new JobMessageRouterImpl(jobClusterManagerActor);
             final WorkerRegistry workerRegistry = WorkerRegistryV2.INSTANCE;
 
@@ -154,13 +180,16 @@ public class MasterMain implements Service {
                     getDescriptionJson(),
                     mesosDriverSupplier);
             schedulingService = new SchedulingService(jobMessageRouter, workerRegistry, vmLeaseRescindedSubject, vmService);
+
+            final MantisSchedulerFactory mantisSchedulerFactory =
+                new MantisSchedulerFactoryImpl(system, resourceClusters, new ExecuteStageRequestFactory(getConfig()), jobMessageRouter, schedulingService, getConfig());
             mesosDriverSupplier.setAddVMLeaseAction(schedulingService::addOffers);
 
             // initialize agents error monitor
             agentsErrorMonitorActor.tell(new AgentsErrorMonitorActor.InitializeAgentsErrorMonitor(schedulingService), ActorRef.noSender());
 
             final boolean loadJobsFromStoreOnInit = true;
-            final JobClustersManagerService jobClustersManagerService = new JobClustersManagerService(jobClusterManagerActor, schedulingService, loadJobsFromStoreOnInit);
+            final JobClustersManagerService jobClustersManagerService = new JobClustersManagerService(jobClusterManagerActor, mantisSchedulerFactory, loadJobsFromStoreOnInit);
 
             this.agentClusterOps = new AgentClusterOperationsImpl(storageProvider,
                     jobMessageRouter,

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/MantisMasterAPI.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/MantisMasterAPI.java
@@ -16,6 +16,10 @@
 
 package io.mantisrx.master.api.akka;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -79,6 +83,7 @@ import io.mantisrx.server.master.LeadershipManagerLocalImpl;
 import io.mantisrx.server.master.persistence.IMantisStorageProvider;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.MantisStorageProviderAdapter;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.server.master.store.SimpleCachedFileStorageProvider;
 import java.time.Duration;
 import java.util.Collections;
@@ -168,9 +173,11 @@ public class MantisMasterAPI extends AllDirectives {
                 JobClustersManagerActor.props(
                         new MantisJobStore(storageProvider), lifecycleEventPublisher),
                 "JobClustersManager");
+        MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
         final FakeMantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManager);
+        when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
         jobClustersManager.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                fakeScheduler,
+                fakeSchedulerFactory,
                 true), ActorRef.noSender());
 
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/AgentClusterRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/AgentClusterRouteTest.java
@@ -19,6 +19,9 @@ package io.mantisrx.master.api.akka.route.v0;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import akka.NotUsed;
 import akka.actor.ActorRef;
@@ -52,6 +55,7 @@ import io.mantisrx.server.master.persistence.IMantisStorageProvider;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.type.TypeReference;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
@@ -119,9 +123,11 @@ public class AgentClusterRouteTest {
 
                 ActorRef jobClustersManagerActor = system.actorOf(
                     JobClustersManagerActor.props(new MantisJobStore(storageProvider), lifecycleEventPublisher), "jobClustersManager");
+                MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
+                when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
                 jobClustersManagerActor.tell(
-                    new JobClusterManagerProto.JobClustersManagerInitialize(fakeScheduler, false), ActorRef.noSender());
+                    new JobClusterManagerProto.JobClustersManagerInitialize(fakeSchedulerFactory, false), ActorRef.noSender());
 
                 setupDummyAgentClusterAutoScaler();
                 final AgentClusterRoute v0AgentClusterRoute = new AgentClusterRoute(

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobClusterRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobClusterRouteTest.java
@@ -19,6 +19,9 @@ package io.mantisrx.master.api.akka.route.v0;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import akka.NotUsed;
 import akka.actor.ActorRef;
@@ -56,6 +59,7 @@ import io.mantisrx.master.scheduler.FakeMantisScheduler;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.util.List;
@@ -118,8 +122,10 @@ public class JobClusterRouteTest {
                 final LifecycleEventPublisher lifecycleEventPublisher = new LifecycleEventPublisherImpl(new AuditEventSubscriberLoggingImpl(), new StatusEventSubscriberLoggingImpl(), new WorkerEventSubscriberLoggingImpl());
 
                 ActorRef jobClustersManagerActor = system.actorOf(JobClustersManagerActor.props(new MantisJobStore(new SimpleCachedFileStorageProvider(true)), lifecycleEventPublisher), "jobClustersManager");
+                MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
-                jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(fakeScheduler, false), ActorRef.noSender());
+                when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
+                jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(fakeSchedulerFactory, false), ActorRef.noSender());
 
 
                 final JobClusterRouteHandler jobClusterRouteHandler = new JobClusterRouteHandlerAkkaImpl(jobClustersManagerActor);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobDiscoveryRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobDiscoveryRouteTest.java
@@ -16,6 +16,10 @@
 
 package io.mantisrx.master.api.akka.route.v0;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -43,6 +47,7 @@ import io.mantisrx.server.core.JobSchedulingInfo;
 import io.mantisrx.server.core.NamedJobInfo;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
@@ -83,8 +88,10 @@ public class JobDiscoveryRouteTest {
                 ActorRef jobClustersManagerActor = system.actorOf(JobClustersManagerActor.props(
                     new MantisJobStore(new io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider(true)), lifecycleEventPublisher), "jobClustersManager");
 
+                MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
-                jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(fakeScheduler, false), ActorRef.noSender());
+                when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
+                jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(fakeSchedulerFactory, false), ActorRef.noSender());
 
                 agentsErrorMonitorActor.tell(new AgentsErrorMonitorActor.InitializeAgentsErrorMonitor(fakeScheduler), ActorRef.noSender());
                 Duration idleTimeout = system.settings().config().getDuration("akka.http.server.idle-timeout");

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -84,6 +85,7 @@ import io.mantisrx.server.master.LeadershipManagerLocalImpl;
 import io.mantisrx.server.master.http.api.CompactJobInfo;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.server.master.store.MantisStageMetadataWritable;
 import io.mantisrx.server.master.store.MantisWorkerMetadataWritable;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.type.TypeReference;
@@ -189,9 +191,11 @@ public class JobRouteTest {
                         new MantisJobStore(new io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider(
                                 true)), lifecycleEventPublisher), "jobClustersManager");
 
+                MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
+                when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
                 jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                        fakeScheduler,
+                        fakeSchedulerFactory,
                         false), ActorRef.noSender());
 
                 final JobClusterRouteHandler jobClusterRouteHandler = new JobClusterRouteHandlerAkkaImpl(

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobStatusRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobStatusRouteTest.java
@@ -16,6 +16,10 @@
 
 package io.mantisrx.master.api.akka.route.v0;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -46,6 +50,7 @@ import io.mantisrx.master.scheduler.FakeMantisScheduler;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
@@ -84,8 +89,10 @@ public class JobStatusRouteTest {
                 ActorRef jobClustersManagerActor = system.actorOf(JobClustersManagerActor.props(
                     new MantisJobStore(new io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider(true)), lifecycleEventPublisher), "jobClustersManager");
 
+                MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
-                jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(fakeScheduler, false), ActorRef.noSender());
+                when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
+                jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(fakeSchedulerFactory, false), ActorRef.noSender());
 
                 agentsErrorMonitorActor.tell(new AgentsErrorMonitorActor.InitializeAgentsErrorMonitor(fakeScheduler), ActorRef.noSender());
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/AgentClustersRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/AgentClustersRouteTest.java
@@ -19,6 +19,9 @@ package io.mantisrx.master.api.akka.route.v1;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import akka.NotUsed;
 import akka.actor.ActorRef;
@@ -52,6 +55,7 @@ import io.mantisrx.server.master.persistence.IMantisStorageProvider;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.type.TypeReference;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
@@ -110,10 +114,12 @@ public class AgentClustersRouteTest extends RouteTestBase {
                         "jobClustersManager");
 
 
+                MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
+                when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
                 jobClustersManagerActor.tell(
                         new JobClusterManagerProto.JobClustersManagerInitialize(
-                                fakeScheduler,
+                                fakeSchedulerFactory,
                                 false),
                         ActorRef.noSender());
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobClustersRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobClustersRouteTest.java
@@ -18,6 +18,9 @@ package io.mantisrx.master.api.akka.route.v1;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import akka.NotUsed;
 import akka.actor.ActorRef;
@@ -46,6 +49,7 @@ import io.mantisrx.master.scheduler.FakeMantisScheduler;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.JsonNode;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -94,10 +98,12 @@ public class JobClustersRouteTest extends RouteTestBase {
                                 new MantisJobStore(new SimpleCachedFileStorageProvider(true)),
                                 lifecycleEventPublisher),
                         "jobClustersManager");
+                MantisSchedulerFactory mantisSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
+                when(mantisSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
                 jobClustersManagerActor.tell(
                         new JobClusterManagerProto.JobClustersManagerInitialize(
-                                fakeScheduler, false), ActorRef.noSender());
+                                mantisSchedulerFactory, false), ActorRef.noSender());
 
 
                 final JobClusterRouteHandler jobClusterRouteHandler = new JobClusterRouteHandlerAkkaImpl(

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobDiscoveryStreamRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobDiscoveryStreamRouteTest.java
@@ -16,6 +16,10 @@
 
 package io.mantisrx.master.api.akka.route.v1;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.http.javadsl.ConnectHttp;
@@ -42,6 +46,7 @@ import io.mantisrx.server.core.JobSchedulingInfo;
 import io.mantisrx.server.core.NamedJobInfo;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import java.time.Duration;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
@@ -83,8 +88,10 @@ public class JobDiscoveryStreamRouteTest extends RouteTestBase {
                 ActorRef jobClustersManagerActor = system.actorOf(JobClustersManagerActor.props(
                     new MantisJobStore(new io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider(true)), lifecycleEventPublisher), "jobClustersManager");
 
+                MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
-                jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(fakeScheduler, false), ActorRef.noSender());
+                when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
+                jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(fakeSchedulerFactory, false), ActorRef.noSender());
 
                 agentsErrorMonitorActor = system.actorOf(AgentsErrorMonitorActor.props());
                 agentsErrorMonitorActor.tell(new AgentsErrorMonitorActor.InitializeAgentsErrorMonitor(fakeScheduler), ActorRef.noSender());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.api.akka.route.v1;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -62,6 +63,7 @@ import io.mantisrx.server.master.LeaderRedirectionFilter;
 import io.mantisrx.server.master.LeadershipManagerLocalImpl;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.JsonNode;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -110,9 +112,11 @@ public class JobsRouteTest extends RouteTestBase {
                         new MantisJobStore(new io.mantisrx.server.master.persistence.SimpleCachedFileStorageProvider(
                                 true)), lifecycleEventPublisher), "jobClustersManager");
 
+                MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
+                when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
                 jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                        fakeScheduler,
+                        fakeSchedulerFactory,
                         false), ActorRef.noSender());
 
                 final JobClusterRouteHandler jobClusterRouteHandler = new JobClusterRouteHandlerAkkaImpl(

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
@@ -354,7 +354,7 @@ public class JobClusterTest {
         try {
             TestKit probe = new TestKit(system);
             String clusterName = "testJobClusterEnable";
-            MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+            MantisScheduler schedulerMock = mock(MantisScheduler.class);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
             String jobId = clusterName + "-1";
             JobDefinition jobDefn = createJob(clusterName);
@@ -368,7 +368,7 @@ public class JobClusterTest {
             when(jobStoreMock.getArchivedJob(jobId)).thenReturn(of(job1));
             SLA sla = new SLA(1,1,null,null);
             final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla);
-            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
             jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
             JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
             assertEquals(SUCCESS, createResp.responseCode);
@@ -435,10 +435,10 @@ public class JobClusterTest {
         Label l = new Label("labelname","labelvalue");
         labels.add(l);
         String clusterName = "testJobClusterUpdateAndDelete";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, labels);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -501,10 +501,10 @@ public class JobClusterTest {
         Label l = new Label("labelname","labelvalue");
         labels.add(l);
         String clusterName = "testJobClusterUpdateFailsIfArtifactNotUnique";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, labels);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -529,10 +529,10 @@ public class JobClusterTest {
         Label l = new Label("labelname","labelvalue");
         labels.add(l);
         String clusterName = "testJobClusterDeleteFailsIfJobsActive";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, labels);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -565,10 +565,10 @@ public class JobClusterTest {
         Label l = new Label("labelname","labelvalue");
         labels.add(l);
         String clusterName = "testJobClusterDeletePurgesCompletedJobs";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, labels);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -608,10 +608,10 @@ public class JobClusterTest {
         TestKit probe = new TestKit(system);
         CountDownLatch storeCompletedCalled = new CountDownLatch(1);
         String clusterName = "testJobClusterDisable";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -691,10 +691,10 @@ public class JobClusterTest {
     public void testJobClusterSLAUpdate() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterSLAUpdate";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -724,10 +724,10 @@ public class JobClusterTest {
     public void testJobClusterMigrationConfigUpdate() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterMigrationConfigUpdate";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -757,10 +757,10 @@ public class JobClusterTest {
     public void testJobClusterArtifactUpdate() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterArtifactUpdate";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -796,10 +796,10 @@ public class JobClusterTest {
     public void testJobClusterArtifactUpdateNotUniqueFails() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterArtifactUpdateNotUniqueFails";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -833,10 +833,10 @@ public class JobClusterTest {
     public void testJobClusterArtifactUpdateMultipleTimes() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterArtifactUpdateMultipleTimes";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -900,11 +900,11 @@ public class JobClusterTest {
 
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterInvalidSLAUpdateIgnored";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -935,11 +935,11 @@ public class JobClusterTest {
     public void testJobClusterLabelsUpdate() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterLabelsUpdate";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
 
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -990,11 +990,11 @@ public class JobClusterTest {
     public void testJobSubmit() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmit";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1028,11 +1028,11 @@ public class JobClusterTest {
     public void testJobSubmitWithNoJarAndSchedInfo() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithNoJarAndSchedInfo";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1080,11 +1080,11 @@ public class JobClusterTest {
     public void testJobSubmitWithVersionAndNoSchedInfo() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithVersionAndNoSchedInfo";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1183,11 +1183,11 @@ public class JobClusterTest {
     public void testJobComplete() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobComplete";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1361,12 +1361,12 @@ public class JobClusterTest {
     public void testJobSubmitTriggersSLAToKillOldHandlesErrors() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitTriggersSLAToKillOldHandlesErrors";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         SLA sla = new SLA(1,1,null,null);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1440,12 +1440,12 @@ public class JobClusterTest {
     public void testCronTriggersSLAToKillOld() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitTriggersSLAToKillOld";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         SLA sla = new SLA(1,1,"0/1 * * * * ?",IJobClusterDefinition.CronPolicy.KEEP_NEW);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1491,11 +1491,11 @@ public class JobClusterTest {
     public void testJobSubmitWithUnique() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithUnique";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1540,11 +1540,11 @@ public class JobClusterTest {
     public void testJobSubmitWithoutInheritInstance() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithInheritInstance";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1592,11 +1592,11 @@ public class JobClusterTest {
     public void testJobSubmitWithInheritInstanceFlagsSingleStage() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithInheritInstance";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1648,7 +1648,7 @@ public class JobClusterTest {
     public void testJobSubmitWithInheritInstanceFlagsMultiStage() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithInheritInstance";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         // default job with 3 stage == (2 worker)
@@ -1661,7 +1661,7 @@ public class JobClusterTest {
                 .build();
         final JobClusterDefinitionImpl fakeJobCluster =
                 createFakeJobClusterDefn(clusterName, Lists.newArrayList(), NO_OP_SLA, schedulingInfo1);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(
                 fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp =
@@ -1726,7 +1726,7 @@ public class JobClusterTest {
     public void testJobSubmitWithInheritInstanceFlagsScaled() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithInheritInstance";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         // default job with 3 stage == (2 worker)
@@ -1737,7 +1737,7 @@ public class JobClusterTest {
                 .build();
         final JobClusterDefinitionImpl fakeJobCluster =
                 createFakeJobClusterDefn(clusterName, Lists.newArrayList(), NO_OP_SLA, schedulingInfo1);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(
                 fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp =
@@ -1802,11 +1802,11 @@ public class JobClusterTest {
     public void testQuickJobSubmit() {
         TestKit probe = new TestKit(system);
         String clusterName = "testQuickJobSubmit";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1843,11 +1843,11 @@ public class JobClusterTest {
     public void testQuickJobSubmitWithNoSchedInfoInPreviousJob() {
         TestKit probe = new TestKit(system);
         String clusterName = "testQuickJobSubmitWithNoSchedInfoInPreviousJob";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1894,14 +1894,14 @@ public class JobClusterTest {
     public void testJobSubmitWithNoSchedInfoUsesJobClusterValues() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithNoSchedInfoUsesJobClusterValues";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         List<Label> clusterLabels = new ArrayList<>();
         Label label = new Label("clabelName", "cLabelValue");
         clusterLabels.add(label);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, clusterLabels);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1975,10 +1975,10 @@ public class JobClusterTest {
     public void testQuickJobSubmitWithNoPreviousHistoryFails() {
         TestKit probe = new TestKit(system);
         String clusterName = "testQuickJobSubmitWithNoPreviousHistoryFails";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -2004,7 +2004,7 @@ public class JobClusterTest {
         TestKit probe = new TestKit(system);
         try {
             String clusterName = "testUpdateJobClusterArtifactWithAutoSubmit";
-            MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+            MantisScheduler schedulerMock = mock(MantisScheduler.class);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
             // when running concurrently with testGetJobDetailsForArchivedJob the following mock return is needed to avoid null pointer exception.
@@ -2013,7 +2013,7 @@ public class JobClusterTest {
             SLA sla = new SLA(1,1,null,null);
             final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla);
 
-            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
             jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
             JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
             assertEquals(SUCCESS, createResp.responseCode);
@@ -2080,11 +2080,11 @@ public class JobClusterTest {
         TestKit probe = new TestKit(system);
         try {
             String clusterName = "testJobSubmitFails";
-            MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+            MantisScheduler schedulerMock = mock(MantisScheduler.class);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
             final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
             Mockito.doThrow(Exception.class).when(jobStoreMock).storeNewJob(any());
-            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
             jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
             JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
             assertEquals(SUCCESS, createResp.responseCode);
@@ -2116,11 +2116,11 @@ public class JobClusterTest {
     public void testGetLastSubmittedJobSubject() {
         TestKit probe = new TestKit(system);
         String clusterName = "testGetLastSubmittedJobSubject";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -2169,11 +2169,11 @@ public class JobClusterTest {
     public void testGetLastSubmittedJobSubjectWithWrongClusterNameFails() {
         TestKit probe = new TestKit(system);
         String clusterName = "testGetLastSubmittedJobSubjectWithWrongClusterNameFails";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -2212,13 +2212,12 @@ public class JobClusterTest {
     public void testListArchivedWorkers() {
         TestKit probe = new TestKit(system);
         String clusterName = "testListArchivedWorkers";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisScheduler scheduler = mock(MantisScheduler.class);
-        when(schedulerMock.forJob(any())).thenReturn(scheduler);
 
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStore, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStore, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -2283,6 +2282,9 @@ public class JobClusterTest {
 
         try {
             String jobId = clusterName + "-1";
+            when(jobStoreMock.getArchivedJob(jobId))
+                .thenReturn(Optional.of(
+                    new MantisJobMetadataImpl.Builder().withJobDefinition(mock(JobDefinition.class)).build()));
             WorkerId workerId = new WorkerId(clusterName, jobId,0,1);
             WorkerEvent heartBeat2 = new WorkerHeartbeat(new Status(jobId, 1, workerId.getWorkerIndex(), workerId.getWorkerNum(), TYPE.HEARTBEAT, "", MantisJobState.Started, System.currentTimeMillis()));
             jobClusterActor.tell(heartBeat2, probe.getRef());
@@ -2454,11 +2456,11 @@ public class JobClusterTest {
     public void testGetJobDetailsForArchivedJob() {
         TestKit probe = new TestKit(system);
         String clusterName = "testGetJobDetailsForArchivedJob";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -2507,10 +2509,10 @@ public class JobClusterTest {
     public void testListJobIdsForCluster() throws InvalidJobException {
         TestKit probe = new TestKit(system);
         String clusterName = "testListJobsForCluster";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -2612,10 +2614,10 @@ public class JobClusterTest {
     public void testListJobsForCluster() throws InvalidJobException, InterruptedException {
         TestKit probe = new TestKit(system);
         String clusterName = "testListJobsForCluster";
-        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -2785,7 +2787,7 @@ public class JobClusterTest {
         TestKit probe = new TestKit(system);
         String clusterName = "testListJobWithLabelMatch";
         try {
-            MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
+            MantisScheduler schedulerMock = mock(MantisScheduler.class);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
             final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
             ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
@@ -118,6 +118,7 @@ import io.mantisrx.server.master.persistence.IMantisStorageProvider;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.MantisStorageProviderAdapter;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.server.master.scheduler.WorkerEvent;
 import io.mantisrx.server.master.store.NamedJob;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
@@ -307,7 +308,7 @@ public class JobClusterTest {
 
         String name = "testJobClusterCreate";
         TestKit probe = new TestKit(system);
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(name);
         ActorRef jobClusterActor = system.actorOf(props(name, jobStoreMock, schedulerMock, eventPublisher));
@@ -343,7 +344,7 @@ public class JobClusterTest {
         try {
             TestKit probe = new TestKit(system);
             String clusterName = "testJobClusterEnable";
-            MantisScheduler schedulerMock = mock(MantisScheduler.class);
+            MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
             String jobId = clusterName + "-1";
             JobDefinition jobDefn = createJob(clusterName);
@@ -424,7 +425,7 @@ public class JobClusterTest {
         Label l = new Label("labelname","labelvalue");
         labels.add(l);
         String clusterName = "testJobClusterUpdateAndDelete";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, labels);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -490,7 +491,7 @@ public class JobClusterTest {
         Label l = new Label("labelname","labelvalue");
         labels.add(l);
         String clusterName = "testJobClusterUpdateFailsIfArtifactNotUnique";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, labels);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -518,7 +519,7 @@ public class JobClusterTest {
         Label l = new Label("labelname","labelvalue");
         labels.add(l);
         String clusterName = "testJobClusterDeleteFailsIfJobsActive";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, labels);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -554,7 +555,7 @@ public class JobClusterTest {
         Label l = new Label("labelname","labelvalue");
         labels.add(l);
         String clusterName = "testJobClusterDeletePurgesCompletedJobs";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, labels);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -597,7 +598,7 @@ public class JobClusterTest {
         TestKit probe = new TestKit(system);
         CountDownLatch storeCompletedCalled = new CountDownLatch(1);
         String clusterName = "testJobClusterDisable";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -680,7 +681,7 @@ public class JobClusterTest {
     public void testJobClusterSLAUpdate() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterSLAUpdate";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -713,7 +714,7 @@ public class JobClusterTest {
     public void testJobClusterMigrationConfigUpdate() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterMigrationConfigUpdate";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -746,7 +747,7 @@ public class JobClusterTest {
     public void testJobClusterArtifactUpdate() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterArtifactUpdate";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -785,7 +786,7 @@ public class JobClusterTest {
     public void testJobClusterArtifactUpdateNotUniqueFails() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterArtifactUpdateNotUniqueFails";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -822,7 +823,7 @@ public class JobClusterTest {
     public void testJobClusterArtifactUpdateMultipleTimes() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterArtifactUpdateMultipleTimes";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -889,7 +890,7 @@ public class JobClusterTest {
 
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterInvalidSLAUpdateIgnored";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -924,7 +925,7 @@ public class JobClusterTest {
     public void testJobClusterLabelsUpdate() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterLabelsUpdate";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
 
@@ -979,7 +980,7 @@ public class JobClusterTest {
     public void testJobSubmit() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmit";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -1017,7 +1018,7 @@ public class JobClusterTest {
     public void testJobSubmitWithNoJarAndSchedInfo() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithNoJarAndSchedInfo";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -1069,7 +1070,7 @@ public class JobClusterTest {
     public void testJobSubmitWithVersionAndNoSchedInfo() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithVersionAndNoSchedInfo";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -1172,7 +1173,7 @@ public class JobClusterTest {
     public void testJobComplete() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobComplete";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -1210,12 +1211,14 @@ public class JobClusterTest {
     public void testJobKillTriggersSLAToLaunchNew() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobKillTriggersSLAToLaunchNew";
+        MantisSchedulerFactory schedulerMockFactory = mock(MantisSchedulerFactory.class);
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        when(schedulerMockFactory.forJob(any())).thenReturn(schedulerMock);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         SLA sla = new SLA(1,1,null,null);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMockFactory, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1264,12 +1267,14 @@ public class JobClusterTest {
     public void testJobSubmitTriggersSLAToKillOld() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitTriggersSLAToKillOld";
+        MantisSchedulerFactory schedulerMockFactory = mock(MantisSchedulerFactory.class);
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        when(schedulerMockFactory.forJob(any())).thenReturn(schedulerMock);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         SLA sla = new SLA(1,1,null,null);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMockFactory, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -1346,7 +1351,7 @@ public class JobClusterTest {
     public void testJobSubmitTriggersSLAToKillOldHandlesErrors() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitTriggersSLAToKillOldHandlesErrors";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         SLA sla = new SLA(1,1,null,null);
@@ -1425,7 +1430,7 @@ public class JobClusterTest {
     public void testCronTriggersSLAToKillOld() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitTriggersSLAToKillOld";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         SLA sla = new SLA(1,1,"0/1 * * * * ?",IJobClusterDefinition.CronPolicy.KEEP_NEW);
@@ -1476,7 +1481,7 @@ public class JobClusterTest {
     public void testJobSubmitWithUnique() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithUnique";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -1525,7 +1530,7 @@ public class JobClusterTest {
     public void testJobSubmitWithoutInheritInstance() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithInheritInstance";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -1577,7 +1582,7 @@ public class JobClusterTest {
     public void testJobSubmitWithInheritInstanceFlagsSingleStage() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithInheritInstance";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -1633,7 +1638,7 @@ public class JobClusterTest {
     public void testJobSubmitWithInheritInstanceFlagsMultiStage() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithInheritInstance";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         // default job with 3 stage == (2 worker)
@@ -1711,7 +1716,7 @@ public class JobClusterTest {
     public void testJobSubmitWithInheritInstanceFlagsScaled() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithInheritInstance";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         // default job with 3 stage == (2 worker)
@@ -1787,7 +1792,7 @@ public class JobClusterTest {
     public void testQuickJobSubmit() {
         TestKit probe = new TestKit(system);
         String clusterName = "testQuickJobSubmit";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -1828,7 +1833,7 @@ public class JobClusterTest {
     public void testQuickJobSubmitWithNoSchedInfoInPreviousJob() {
         TestKit probe = new TestKit(system);
         String clusterName = "testQuickJobSubmitWithNoSchedInfoInPreviousJob";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -1879,7 +1884,7 @@ public class JobClusterTest {
     public void testJobSubmitWithNoSchedInfoUsesJobClusterValues() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithNoSchedInfoUsesJobClusterValues";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         List<Label> clusterLabels = new ArrayList<>();
@@ -1960,7 +1965,7 @@ public class JobClusterTest {
     public void testQuickJobSubmitWithNoPreviousHistoryFails() {
         TestKit probe = new TestKit(system);
         String clusterName = "testQuickJobSubmitWithNoPreviousHistoryFails";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -1989,7 +1994,7 @@ public class JobClusterTest {
         TestKit probe = new TestKit(system);
         try {
             String clusterName = "testUpdateJobClusterArtifactWithAutoSubmit";
-            MantisScheduler schedulerMock = mock(MantisScheduler.class);
+            MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
             // when running concurrently with testGetJobDetailsForArchivedJob the following mock return is needed to avoid null pointer exception.
@@ -2065,7 +2070,7 @@ public class JobClusterTest {
         TestKit probe = new TestKit(system);
         try {
             String clusterName = "testJobSubmitFails";
-            MantisScheduler schedulerMock = mock(MantisScheduler.class);
+            MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
             final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
             Mockito.doThrow(Exception.class).when(jobStoreMock).storeNewJob(any());
@@ -2101,7 +2106,7 @@ public class JobClusterTest {
     public void testGetLastSubmittedJobSubject() {
         TestKit probe = new TestKit(system);
         String clusterName = "testGetLastSubmittedJobSubject";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -2154,7 +2159,7 @@ public class JobClusterTest {
     public void testGetLastSubmittedJobSubjectWithWrongClusterNameFails() {
         TestKit probe = new TestKit(system);
         String clusterName = "testGetLastSubmittedJobSubjectWithWrongClusterNameFails";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -2197,7 +2202,7 @@ public class JobClusterTest {
     public void testListArchivedWorkers() {
         TestKit probe = new TestKit(system);
         String clusterName = "testListArchivedWorkers";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
 
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -2253,11 +2258,13 @@ public class JobClusterTest {
     public void testZombieWorkerKilledOnMessage() {
         String clusterName = "testZombieWorkerKilledOnMessage";
         TestKit probe = new TestKit(system);
+        MantisSchedulerFactory schedulerMockFactory = mock(MantisSchedulerFactory.class);
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        when(schedulerMockFactory.forJob(any())).thenReturn(schedulerMock);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMockFactory, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -2282,11 +2289,13 @@ public class JobClusterTest {
     public void testZombieWorkerTerminateEventIgnored() {
         TestKit probe = new TestKit(system);
         String clusterName = "testZombieWorkerTerminateEventIgnored";
+        MantisSchedulerFactory schedulerMockFactory = mock(MantisSchedulerFactory.class);
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        when(schedulerMockFactory.forJob(any())).thenReturn(schedulerMock);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMockFactory, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
@@ -2307,7 +2316,7 @@ public class JobClusterTest {
     public void testResubmitWorker() {
         TestKit probe = new TestKit(system);
         String clusterName = "testResubmitWorker";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -2364,12 +2373,14 @@ public class JobClusterTest {
         TestKit probe = new TestKit(system);
         try {
             String clusterName = "testScaleStage";
+            MantisSchedulerFactory schedulerMockFactory = mock(MantisSchedulerFactory.class);
             MantisScheduler schedulerMock = mock(MantisScheduler.class);
+            when(schedulerMockFactory.forJob(any())).thenReturn(schedulerMock);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
             final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
 
-            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMockFactory, eventPublisher));
             jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
             JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
             assertEquals(SUCCESS, createResp.responseCode);
@@ -2429,7 +2440,7 @@ public class JobClusterTest {
     public void testGetJobDetailsForArchivedJob() {
         TestKit probe = new TestKit(system);
         String clusterName = "testGetJobDetailsForArchivedJob";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
@@ -2482,7 +2493,7 @@ public class JobClusterTest {
     public void testListJobIdsForCluster() throws InvalidJobException {
         TestKit probe = new TestKit(system);
         String clusterName = "testListJobsForCluster";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -2587,7 +2598,7 @@ public class JobClusterTest {
     public void testListJobsForCluster() throws InvalidJobException, InterruptedException {
         TestKit probe = new TestKit(system);
         String clusterName = "testListJobsForCluster";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -2760,7 +2771,7 @@ public class JobClusterTest {
         TestKit probe = new TestKit(system);
         String clusterName = "testListJobWithLabelMatch";
         try {
-            MantisScheduler schedulerMock = mock(MantisScheduler.class);
+            MantisSchedulerFactory schedulerMock = mock(MantisSchedulerFactory.class);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
             final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
             ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
@@ -2850,12 +2861,14 @@ public class JobClusterTest {
 
         TestKit probe = new TestKit(system);
         String clusterName = "testLostWorkerGetsReplaced";
+        MantisSchedulerFactory schedulerMockFactory = mock(MantisSchedulerFactory.class);
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        when(schedulerMockFactory.forJob(any())).thenReturn(schedulerMock);
         //MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         MantisJobStore jobStoreSpied = Mockito.spy(jobStore);
 
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreSpied, schedulerMock, eventPublisher));
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreSpied, schedulerMockFactory, eventPublisher));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
@@ -2790,7 +2790,7 @@ public class JobClusterTest {
             MantisScheduler schedulerMock = mock(MantisScheduler.class);
             MantisJobStore jobStoreMock = mock(MantisJobStore.class);
             final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, schedulerMock, eventPublisher));
+            ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher));
             jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
             JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
             assertEquals(SUCCESS, createResp.responseCode);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobManagerTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobManagerTest.java
@@ -34,7 +34,6 @@ import io.mantisrx.server.master.domain.JobClusterDefinitionImpl;
 import io.mantisrx.server.master.domain.JobDefinition;
 import io.mantisrx.server.master.domain.JobId;
 import io.mantisrx.server.master.persistence.MantisJobStore;
-import io.mantisrx.server.master.scheduler.MantisScheduler;
 import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import java.io.IOException;
 import java.time.Instant;

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobManagerTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobManagerTest.java
@@ -35,6 +35,7 @@ import io.mantisrx.server.master.domain.JobDefinition;
 import io.mantisrx.server.master.domain.JobId;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -46,13 +47,13 @@ public class JobManagerTest {
 
     private static MantisJobStore jobStore;
     private static AbstractActor.ActorContext context;
-    private static MantisScheduler scheduler;
+    private static MantisSchedulerFactory schedulerFactory;
     private static LifecycleEventPublisher publisher;
     @BeforeClass
     public static void setup() {
         jobStore = mock(MantisJobStore.class);
 		context = mock(AbstractActor.ActorContext.class);
-		scheduler = mock(MantisScheduler.class);
+        schedulerFactory = mock(MantisSchedulerFactory.class);
 		publisher = mock(LifecycleEventPublisher.class);
 
 		JobTestHelper.createDirsIfRequired();
@@ -62,7 +63,7 @@ public class JobManagerTest {
 	@Test
 	public void acceptedToActive() {
 
-		JobClusterActor.JobManager jm =  new JobManager("name", context, scheduler, publisher, jobStore);
+		JobClusterActor.JobManager jm =  new JobManager("name", context, schedulerFactory, publisher, jobStore);
 		JobId jId1 = new JobId("name",1);
 		JobInfo jInfo1 = new JobInfo(jId1, null, 0, null, JobState.Accepted, "nj");
 
@@ -80,7 +81,7 @@ public class JobManagerTest {
 
 	@Test
 	public void acceptedToCompleted() {
-		JobClusterActor.JobManager jm =  new JobManager("name", context, scheduler, publisher, jobStore);
+		JobClusterActor.JobManager jm =  new JobManager("name", context, schedulerFactory, publisher, jobStore);
 		JobId jId1 = new JobId("name",1);
 		JobInfo jInfo1 = new JobInfo(jId1, null, 0, null, JobState.Accepted, "nj");
 
@@ -108,7 +109,7 @@ public class JobManagerTest {
 
 	@Test
 	public void acceptedToTerminating() {
-		JobClusterActor.JobManager jm =  new JobManager("name", context, scheduler, publisher, jobStore);
+		JobClusterActor.JobManager jm =  new JobManager("name", context, schedulerFactory, publisher, jobStore);
 		JobId jId1 = new JobId("name",1);
 		JobInfo jInfo1 = new JobInfo(jId1, null, 0, null, JobState.Accepted, "nj");
 
@@ -132,7 +133,7 @@ public class JobManagerTest {
 
 	@Test
 	public void terminatingToActiveIsIgnored() {
-		JobClusterActor.JobManager jm =  new JobManager("name", context, scheduler, publisher, jobStore);
+		JobClusterActor.JobManager jm =  new JobManager("name", context, schedulerFactory, publisher, jobStore);
 		JobId jId1 = new JobId("name",1);
 		JobDefinition jdMock = mock(JobDefinition.class);
 		JobInfo jInfo1 = new JobInfo(jId1, jdMock, 0, null, JobState.Accepted, "nj");
@@ -156,7 +157,7 @@ public class JobManagerTest {
 
 	@Test
 	public void activeToAcceptedFails() {
-		JobClusterActor.JobManager jm =  new JobManager("name", context, scheduler, publisher, jobStore);
+		JobClusterActor.JobManager jm =  new JobManager("name", context, schedulerFactory, publisher, jobStore);
 		JobId jId1 = new JobId("name",1);
 		JobInfo jInfo1 = new JobInfo(jId1, null, 0, null, JobState.Accepted, "nj");
 
@@ -172,7 +173,7 @@ public class JobManagerTest {
 	}
 	@Test
 	public void testGetAcceptedJobList() {
-		JobClusterActor.JobManager jm =  new JobManager("name", context, scheduler, publisher, jobStore);
+		JobClusterActor.JobManager jm =  new JobManager("name", context, schedulerFactory, publisher, jobStore);
 		JobId jId1 = new JobId("name",1);
 		JobInfo jInfo1 = new JobInfo(jId1, null, 0, null, JobState.Accepted, "nj");
 
@@ -201,7 +202,7 @@ public class JobManagerTest {
 
 	@Test
 	public void testGetActiveJobList() {
-		JobClusterActor.JobManager jm =  new JobManager("name", context, scheduler, publisher, jobStore);
+		JobClusterActor.JobManager jm =  new JobManager("name", context, schedulerFactory, publisher, jobStore);
 		JobId jId1 = new JobId("name",1);
 		JobInfo jInfo1 = new JobInfo(jId1, null, 0, null, JobState.Accepted, "nj");
 
@@ -234,7 +235,7 @@ public class JobManagerTest {
 	public void testPurgeOldJobs() {
         String clusterName = "testPurgeOldJobs";
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
-        JobClusterActor.JobManager jm = new JobManager(clusterName, context, scheduler, publisher, jobStoreMock);
+        JobClusterActor.JobManager jm = new JobManager(clusterName, context, schedulerFactory, publisher, jobStoreMock);
 
         JobId jId1 = new JobId(clusterName,1);
         JobInfo jInfo1 = new JobInfo(jId1, null, 0, null, JobState.Accepted, "nj");
@@ -284,7 +285,7 @@ public class JobManagerTest {
     public void testJobListSortedCorrectly() {
         String clusterName = "testJobListSortedCorrectly";
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
-        JobClusterActor.JobManager jm = new JobManager(clusterName, context, scheduler, publisher, jobStoreMock);
+        JobClusterActor.JobManager jm = new JobManager(clusterName, context, schedulerFactory, publisher, jobStoreMock);
 
         JobId jId1 = new JobId(clusterName,1);
         JobInfo jInfo1 = new JobInfo(jId1, null, 0, null, JobState.Accepted, "nj");

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobClusterManagerTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobClusterManagerTest.java
@@ -96,6 +96,7 @@ import io.mantisrx.server.master.domain.SLA;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.MantisStorageProviderAdapter;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.server.master.scheduler.WorkerEvent;
 import io.mantisrx.server.master.scheduler.WorkerLaunched;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
@@ -121,6 +122,7 @@ public class JobClusterManagerTest {
 
     private static MantisJobStore jobStoreMock;
     private static ActorRef jobClusterManagerActor;
+    private static MantisSchedulerFactory schedulerMockFactory;
     private static MantisScheduler schedulerMock;
     private static LifecycleEventPublisher eventPublisher = new LifecycleEventPublisherImpl(
             new AuditEventSubscriberLoggingImpl(),
@@ -145,12 +147,14 @@ public class JobClusterManagerTest {
 
         TestHelpers.setupMasterConfig();
         jobStoreMock = mock(MantisJobStore.class);
+        schedulerMockFactory = mock(MantisSchedulerFactory.class);
         schedulerMock = mock(MantisScheduler.class);
+        when(schedulerMockFactory.forJob(any())).thenReturn(schedulerMock);
         jobClusterManagerActor = system.actorOf(JobClustersManagerActor.props(
                 jobStoreMock,
                 eventPublisher));
         jobClusterManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                schedulerMock,
+            schedulerMockFactory,
                 true), ActorRef.noSender());
     }
 
@@ -285,12 +289,12 @@ public class JobClusterManagerTest {
                 new io.mantisrx.server.master.store.SimpleCachedFileStorageProvider(rootDir.getRoot()),
                 eventPublisher));
         MantisJobStore jobStoreSpied = Mockito.spy(jobStore);
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+//        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         ActorRef jobClusterManagerActor = system.actorOf(JobClustersManagerActor.props(
                 jobStoreSpied,
                 eventPublisher));
         jobClusterManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                schedulerMock,
+                schedulerMockFactory,
                 true), probe.getRef());
         JobClustersManagerInitializeResponse iResponse = probe.expectMsgClass(Duration.of(
                 10,
@@ -310,7 +314,7 @@ public class JobClusterManagerTest {
                 eventPublisher));
         // initialize it
         jobClusterManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                schedulerMock,
+                schedulerMockFactory,
                 true), probe.getRef());
 
         //JobClusterManagerProto.JobClustersManagerInitializeResponse initializeResponse = probe.expectMsgClass(JobClusterManagerProto.JobClustersManagerInitializeResponse.class);
@@ -361,12 +365,12 @@ public class JobClusterManagerTest {
                 "StorageException"));
         MantisJobStore jobStore = new MantisJobStore(storageProviderAdapter);
         MantisJobStore jobStoreSpied = Mockito.spy(jobStore);
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+//        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         ActorRef jobClusterManagerActor = system.actorOf(JobClustersManagerActor.props(
                 jobStoreSpied,
                 eventPublisher));
         jobClusterManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                schedulerMock,
+                schedulerMockFactory,
                 true), probe.getRef());
         JobClustersManagerInitializeResponse iResponse = probe.expectMsgClass(Duration.of(
                 10,
@@ -387,12 +391,12 @@ public class JobClusterManagerTest {
                 new io.mantisrx.server.master.store.SimpleCachedFileStorageProvider(rootDir.getRoot()),
                 eventPublisher));
         MantisJobStore jobStoreSpied = Mockito.spy(jobStore);
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+//        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         ActorRef jobClusterManagerActor = system.actorOf(JobClustersManagerActor.props(
                 jobStoreSpied,
                 eventPublisher));
         jobClusterManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                schedulerMock,
+                schedulerMockFactory,
                 false), probe.getRef());
         JobClustersManagerInitializeResponse iResponse = probe.expectMsgClass(Duration.of(
                 10,
@@ -496,7 +500,7 @@ public class JobClusterManagerTest {
                 eventPublisher));
         // initialize it
         jobClusterManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                schedulerMock,
+                schedulerMockFactory,
                 true), probe.getRef());
 
         JobClustersManagerInitializeResponse initializeResponse = probe.expectMsgClass(
@@ -634,12 +638,12 @@ public class JobClusterManagerTest {
                 new io.mantisrx.server.master.store.SimpleCachedFileStorageProvider(rootDir.getRoot()),
                 eventPublisher));
         MantisJobStore jobStoreSpied = Mockito.spy(jobStore);
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+//        MantisScheduler schedulerMock = mock(MantisScheduler.class);
         ActorRef jobClusterManagerActor = system.actorOf(JobClustersManagerActor.props(
                 jobStoreSpied,
                 eventPublisher));
         jobClusterManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                schedulerMock,
+                schedulerMockFactory,
                 false), probe.getRef());
         probe.expectMsgClass(Duration.of(
                 10,
@@ -715,7 +719,7 @@ public class JobClusterManagerTest {
                 eventPublisher));
         // initialize it
         jobClusterManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                schedulerMock,
+                schedulerMockFactory,
                 true), probe.getRef());
 
         JobClustersManagerInitializeResponse initializeResponse = probe.expectMsgClass(


### PR DESCRIPTION
### Context

This integrates the new federated scheduler factory that can schedule jobs on both mesos and the new task executors with the mantis master. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
