### PR TITLE
Add extra dependency for mantis-shaded

### DIFF
--- a/mantis-shaded/build.gradle
+++ b/mantis-shaded/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     shaded "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     shaded "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     shaded "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
+    shaded "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
     shaded "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
     shaded "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:$jacksonVersion"
     shaded libraries.vavrJackson


### PR DESCRIPTION
### Context

I need the DateTime Module for Jackson as I would prefer to have a consistent way to serialize/deserialize these types. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
