### PR TITLE
Making sure zookeeper master monitor doesn't need a seed value for master description

### DIFF
--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
@@ -57,7 +57,7 @@ public class HighAvailabilityServicesUtil {
     private final AtomicInteger rmConnections = new AtomicInteger(0);
 
     public ZkHighAvailabilityServices(CoreConfiguration configuration) {
-      curatorService = new CuratorService(configuration, null);
+      curatorService = new CuratorService(configuration);
     }
 
     @Override

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/TestGetMasterMonitor.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/TestGetMasterMonitor.java
@@ -56,7 +56,7 @@ public class TestGetMasterMonitor {
         final CountDownLatch latch = new CountDownLatch(5);
         StaticPropertiesConfigurationFactory configurationFactory = new StaticPropertiesConfigurationFactory(properties);
         CoreConfiguration config = configurationFactory.getConfig();
-        final CuratorService curatorService = new CuratorService(config, null);
+        final CuratorService curatorService = new CuratorService(config);
         MasterMonitor masterMonitor = curatorService.getMasterMonitor();
         masterMonitor.getMasterObservable()
                 .filter(new Func1<MasterDescription, Boolean>() {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -213,7 +213,7 @@ public class MasterMain implements Service {
                 mantisServices.addService(new MasterApiAkkaService(new LocalMasterMonitor(leadershipManager.getDescription()), leadershipManager.getDescription(), jobClusterManagerActor, statusEventBrokerActor,
                        resourceClusters, config.getApiPort(), storageProvider, schedulingService, lifecycleEventPublisher, leadershipManager, agentClusterOps));
             } else {
-                curatorService = new CuratorService(this.config, leadershipManager.getDescription());
+                curatorService = new CuratorService(this.config);
                 curatorService.start();
                 mantisServices.addService(createLeaderElector(curatorService, leadershipManager));
                 mantisServices.addService(new MasterApiAkkaService(curatorService.getMasterMonitor(), leadershipManager.getDescription(), jobClusterManagerActor, statusEventBrokerActor,


### PR DESCRIPTION
### Context

There's no need for the master description value to be seeded given that it can be obtained directly from the zookeeper. That's what this diff does. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
