### PR TITLE
Making sure there's a distinction between metrics publisher and metrics publisher's publish frequency

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CoreConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CoreConfiguration.java
@@ -54,15 +54,11 @@ public interface CoreConfiguration {
     @Default("true")
     boolean isLocalMode();
 
-    @Config("mantis.metricsPublisher")
+    @Config("mantis.metricsPublisher.class")
     @Default("io.mantisrx.common.metrics.MetricsPublisherNoOp")
     MetricsPublisher getMetricsPublisher();
 
     @Config("mantis.metricsPublisher.publishFrequencyInSeconds")
     @Default("15")
     int getMetricsPublisherFrequencyInSeconds();
-
-    @Config("mantis.metricsPublisher.config.prefix")
-    @Default("")
-    String getMetricsPublisherConfigPrefix();
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -198,8 +198,9 @@ public class MasterMain implements Service {
                     ConfigurationProvider.getConfig().getActiveSlaveAttributeName());
 
             // start serving metrics
-            if (config.getMasterMetricsPort() > 0)
+            if (config.getMasterMetricsPort() > 0) {
                 new MetricsServerService(config.getMasterMetricsPort(), 1, Collections.emptyMap()).start();
+            }
             new MetricsPublisherService(config.getMetricsPublisher(), config.getMetricsPublisherFrequencyInSeconds(),
                     new HashMap<>()).start();
 


### PR DESCRIPTION
### Context

One of these properties is a prefix of the other. This works when defined in properties file but it doesn't when we want the props to be expressed in another DSL such as YAML.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
