### PR TITLE
Using first instead of single in Mantis Worker

### DIFF
--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
@@ -101,7 +101,7 @@ public class MantisWorker extends BaseService {
             public void start() {
                 executeStageSubject
                         .asObservable()
-                        .single()
+                        .first()
                         .subscribe(wrappedRequest -> {
                             task = new Task(
                                     wrappedRequest.getRequest(),


### PR DESCRIPTION
### Context

Explain context and other details for this pull request.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
