### PR TITLE
Use the same subject returned by the mesos callback handler

### DIFF
--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
@@ -125,7 +125,7 @@ public class MantisWorker extends BaseService {
                         .first()
                         .subscribe(wrappedRequest -> {
                             task = new Task(
-                                    wrappedRequest.getRequest(),
+                                    wrappedRequest,
                                     config,
                                     gateway,
                                     ClassLoaderHandle.fixed(getClass().getClassLoader()),

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
@@ -64,6 +64,7 @@ import org.apache.flink.runtime.rpc.RpcServiceUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import rx.Subscription;
 import rx.schedulers.Schedulers;
+import rx.subjects.PublishSubject;
 
 /**
  * TaskExecutor implements the task executor gateway which provides capabilities to
@@ -409,8 +410,14 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             }
         }
 
+        // todo(sundaram): rethink on how this needs to be handled better.
+        // The publishsubject is today used to communicate the failure to start the request in a timely fashion.
+        // Seems very convoluted.
+        WrappedExecuteStageRequest wrappedRequest =
+            new WrappedExecuteStageRequest(PublishSubject.create(), request);
+
         Task task = new Task(
-            request,
+            wrappedRequest,
             workerConfiguration,
             masterMonitor,
             classLoaderHandle,


### PR DESCRIPTION
### Context

In the new model, we don't use the publish subject that's created by the Mesos callback handler. However, this is required in the old model. Thus, this diff fixes the issue. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
