### PR TITLE
Adding serialverisonuids to all transitive data-structures

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/WorkerPorts.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/WorkerPorts.java
@@ -38,6 +38,8 @@ import lombok.ToString;
 @ToString
 public class WorkerPorts implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final int metricsPort;
     private final int debugPort;
     private final int consolePort;

--- a/mantis-common/src/main/java/io/mantisrx/runtime/MachineDefinition.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/MachineDefinition.java
@@ -23,6 +23,8 @@ import java.io.Serializable;
 
 public class MachineDefinition implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private static final double defaultMbps = 128.0;
     private static final int minPorts = 1;
     private final double cpuCores;

--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/SchedulingInfo.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/SchedulingInfo.java
@@ -34,6 +34,7 @@ import lombok.ToString;
 @ToString
 public class SchedulingInfo implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private Map<Integer, StageSchedulingInfo> stages = new HashMap<>();
 
     @JsonCreator

--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageScalingPolicy.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageScalingPolicy.java
@@ -21,13 +21,15 @@ import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 
-public class StageScalingPolicy {
+public class StageScalingPolicy implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private final int stage;
     private final int min;
     private final int max;
@@ -183,8 +185,9 @@ public class StageScalingPolicy {
         SourceJobDrop
     }
 
-    public static class RollingCount {
+    public static class RollingCount implements Serializable {
 
+        private static final long serialVersionUID = 1L;
         private final int count;
         private final int of;
 
@@ -211,8 +214,9 @@ public class StageScalingPolicy {
         }
     }
 
-    public static class Strategy {
+    public static class Strategy implements Serializable {
 
+        private static final long serialVersionUID = 1L;
         private final ScalingReason reason;
         private final double scaleDownBelowPct;
         private final double scaleUpAbovePct;

--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageSchedulingInfo.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageSchedulingInfo.java
@@ -32,7 +32,7 @@ import lombok.Singular;
 public class StageSchedulingInfo implements Serializable {
 
     private static final long serialVersionUID = 1L;
-    
+
     private final int numberOfInstances;
     private final MachineDefinition machineDefinition;
     @Singular(ignoreNullCollections = true) private final List<JobConstraints> hardConstraints;

--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageSchedulingInfo.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageSchedulingInfo.java
@@ -31,6 +31,8 @@ import lombok.Singular;
 @Builder(toBuilder = true)
 public class StageSchedulingInfo implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+    
     private final int numberOfInstances;
     private final MachineDefinition machineDefinition;
     @Singular(ignoreNullCollections = true) private final List<JobConstraints> hardConstraints;

--- a/mantis-common/src/main/java/io/mantisrx/runtime/parameter/Parameter.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/parameter/Parameter.java
@@ -26,6 +26,8 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode
 public class Parameter implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     private final String name;
     private final String value;
 


### PR DESCRIPTION
### Context

I had forgotten to add serial version uids to all transitive data structures in the previous PR https://github.com/Netflix/mantis/pull/219. This diff addresses that.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
