### PR TITLE
Add resource cluster containers upgrade API

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandler.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandler.java
@@ -28,6 +28,8 @@ import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.Ge
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.GetResourceClusterScaleRulesResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import java.util.concurrent.CompletionStage;
 
 public interface ResourceClusterRouteHandler {
@@ -40,6 +42,8 @@ public interface ResourceClusterRouteHandler {
     CompletionStage<GetResourceClusterResponse> get(final GetResourceClusterSpecRequest request);
 
     CompletionStage<ScaleResourceResponse> scale(final ScaleResourceRequest request);
+
+    CompletionStage<UpgradeClusterContainersResponse> upgrade(final UpgradeClusterContainersRequest request);
 
     CompletionStage<GetResourceClusterScaleRulesResponse> createSingleScaleRule(
         CreateResourceClusterScaleRuleRequest request);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandlerAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandlerAkkaImpl.java
@@ -32,6 +32,8 @@ import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.Ge
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.GetResourceClusterScaleRulesResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import java.time.Duration;
 import java.util.Optional;
@@ -91,6 +93,14 @@ public class ResourceClusterRouteHandlerAkkaImpl implements ResourceClusterRoute
         CompletionStage<ScaleResourceResponse> response =
                 ask(this.resourceClustersHostManagerActor, request, timeout)
                         .thenApply(ScaleResourceResponse.class::cast);
+        return response;
+    }
+
+    @Override
+    public CompletionStage<UpgradeClusterContainersResponse> upgrade(UpgradeClusterContainersRequest request) {
+        CompletionStage<UpgradeClusterContainersResponse> response =
+            ask(this.resourceClustersHostManagerActor, request, timeout)
+                .thenApply(UpgradeClusterContainersResponse.class::cast);
         return response;
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActor.java
@@ -36,6 +36,7 @@ import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.Ge
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.GetResourceClusterScaleRulesResponse;
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleSpec;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
 import io.mantisrx.master.resourcecluster.resourceprovider.InMemoryOnlyResourceClusterStorageProvider;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProvider;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterStorageProvider;
@@ -95,6 +96,9 @@ public class ResourceClustersHostManagerActor extends AbstractActorWithTimers {
             .match(CreateResourceClusterScaleRuleRequest.class, this::onCreateResourceClusterScaleRuleRequest)
             .match(GetResourceClusterScaleRulesRequest.class, this::onGetResourceClusterScaleRulesRequest)
             .match(ScaleResourceRequest.class, this::onScaleResourceClusterRequest)
+
+            // Upgrade section
+            .match(UpgradeClusterContainersRequest.class, this::onUpgradeClusterContainersRequest)
 
             .build();
     }
@@ -313,5 +317,14 @@ public class ResourceClustersHostManagerActor extends AbstractActorWithTimers {
         // FOr scaling-down the decision requires getting idle hosts first.
 
         pipe(this.resourceClusterProvider.scaleResource(req), getContext().dispatcher()).to(getSender());
+    }
+
+    private void onUpgradeClusterContainersRequest(UpgradeClusterContainersRequest req) {
+        log.info("Entering onScaleResourceClusterRequest: " + req);
+        // [Notes] for scaling-up the request can go straight into provider to increase desire size.
+        // FOr scaling-down the decision requires getting idle hosts first.
+
+        pipe(this.resourceClusterProvider.upgradeContainerResource(req), getContext().dispatcher()).to(getSender());
+
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.resourcecluster.proto;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class UpgradeClusterContainersRequest {
+    String clusterId;
+
+    String region;
+
+    String optionalSkuId;
+
+    MantisResourceClusterEnvType optionalEnvType;
+
+    int optionalBatchMaxSize;
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersResponse.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.resourcecluster.proto;
+
+import io.mantisrx.master.jobcluster.proto.BaseResponse;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+public class UpgradeClusterContainersResponse extends BaseResponse {
+    String clusterId;
+
+    String region;
+
+    String optionalSkuId;
+
+    MantisResourceClusterEnvType optionalEnvType;
+
+    @Builder
+    @JsonCreator
+    public UpgradeClusterContainersResponse(
+        @JsonProperty("requestId") final long requestId,
+        @JsonProperty("responseCode") final ResponseCode responseCode,
+        @JsonProperty("message") final String message,
+        @JsonProperty("clusterId") final String clusterId,
+        @JsonProperty("region") final String region,
+        @JsonProperty("optionalSkuId") String optionalSkuId,
+        @JsonProperty("optionalEnvType") MantisResourceClusterEnvType optionalEnvType) {
+        super(requestId, responseCode, message);
+        this.clusterId = clusterId;
+        this.optionalSkuId = optionalSkuId;
+        this.region = region;
+        this.optionalEnvType = optionalEnvType;
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/NoopResourceClusterProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/NoopResourceClusterProvider.java
@@ -20,6 +20,8 @@ import io.mantisrx.master.resourcecluster.proto.ProvisionResourceClusterRequest;
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterProvisionSubmissionResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -34,6 +36,11 @@ public class NoopResourceClusterProvider implements ResourceClusterProvider {
 
     @Override
     public CompletionStage<ScaleResourceResponse> scaleResource(ScaleResourceRequest scaleRequest) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<UpgradeClusterContainersResponse> upgradeContainerResource(UpgradeClusterContainersRequest request) {
         return CompletableFuture.completedFuture(null);
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProvider.java
@@ -20,6 +20,8 @@ import io.mantisrx.master.resourcecluster.proto.ProvisionResourceClusterRequest;
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterProvisionSubmissionResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -49,6 +51,15 @@ public interface ResourceClusterProvider {
     * every nodes.
     */
     CompletionStage<ScaleResourceResponse> scaleResource(ScaleResourceRequest scaleRequest);
+
+    /**
+     * To upgrade cluster containers: each container running task executor is using docker image tag based image version.
+     * In regular case the upgrade is to refresh the container to re-deploy with latest digest associated with the image
+     * tag (e.g. latest).
+     * If multiple image digest versions need to be ran/hosted at the same time, it is recommended to create a separate
+     * sku id in addition to the existing sku(s).
+     */
+    CompletionStage<UpgradeClusterContainersResponse> upgradeContainerResource(UpgradeClusterContainersRequest request);
 
     ResourceClusterResponseHandler getResponseHandler();
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProviderAdapter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProviderAdapter.java
@@ -21,6 +21,8 @@ import io.mantisrx.master.resourcecluster.proto.ProvisionResourceClusterRequest;
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterProvisionSubmissionResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import java.util.concurrent.CompletionStage;
 import lombok.extern.slf4j.Slf4j;
 
@@ -70,6 +72,12 @@ public class ResourceClusterProviderAdapter implements ResourceClusterProvider {
     @Override
     public CompletionStage<ScaleResourceResponse> scaleResource(ScaleResourceRequest scaleRequest) {
         return providerImpl.scaleResource(scaleRequest);
+    }
+
+    @Override
+    public CompletionStage<UpgradeClusterContainersResponse> upgradeContainerResource(
+        UpgradeClusterContainersRequest request) {
+        return providerImpl.upgradeContainerResource(request);
     }
 
     @Override


### PR DESCRIPTION
### Context

Add API to support trigger container upgrade to a resource cluster.
See notes in API code for upgrade support details.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
