### PR TITLE
Ensure there is only 1 subscription in PushTrigger

### DIFF
--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/ObservableTrigger.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/ObservableTrigger.java
@@ -66,8 +66,8 @@ public final class ObservableTrigger {
                         logger.info("Subscription is INACTIVE for observable trigger with name: " + name);
                         subscriptionActive.decrement();
                     })
-                    .subscribe((T data) -> queue.write(data)
-                        ,
+                    .subscribe(
+                        (T data) -> queue.write(data),
                         (Throwable e) -> {
                             logger.warn("Observable used to push data errored, on server with name: " + name, e);
                             if (doOnError != null) {
@@ -122,20 +122,20 @@ public final class ObservableTrigger {
                             logger.info("Subscription is INACTIVE for observable trigger with name: " + name);
                             subscriptionActive.decrement();
                         })
-                        .subscribe((T data) -> queue.write(data)
-                                ,
-                                (Throwable e) -> {
-                                    logger.warn("Observable used to push data errored, on server with name: " + name, e);
-                                    if (doOnError != null) {
-                                        doOnError.call(e);
-                                    }
-                                },
-                                () -> {
-                                    logger.info("Observable used to push data completed, on server with name: " + name);
-                                    if (doOnComplete != null) {
-                                        doOnComplete.call();
-                                    }
+                        .subscribe(
+                            (T data) -> queue.write(data),
+                            (Throwable e) -> {
+                                logger.warn("Observable used to push data errored, on server with name: " + name, e);
+                                if (doOnError != null) {
+                                    doOnError.call(e);
                                 }
+                            },
+                            () -> {
+                                logger.info("Observable used to push data completed, on server with name: " + name);
+                                if (doOnComplete != null) {
+                                    doOnComplete.call();
+                                }
+                            }
                         )
         );
 
@@ -194,7 +194,8 @@ public final class ObservableTrigger {
                                     );
                         }
                     )
-                    .subscribe((List<KeyValuePair<K, V>> list) -> {
+                    .subscribe(
+                        (List<KeyValuePair<K, V>> list) -> {
                             for (KeyValuePair<K, V> data : list) {
                                 queue.write(data);
                             }
@@ -211,8 +212,8 @@ public final class ObservableTrigger {
                                 doOnComplete.call();
                             }
                         }
-
-                    ));
+                    )
+            );
             if (oldSub != null) {
                 logger.info("A new subscription is ACTIVE. " +
                     "Unsubscribe from previous subscription observable trigger with name: " + name);
@@ -262,23 +263,21 @@ public final class ObservableTrigger {
                     })
 
                     .subscribe(
-                        (KeyValuePair<K, V> data) -> {
-                            queue.write(data);
-                        },
+                        (KeyValuePair<K, V> data) -> queue.write(data),
                         (Throwable e) -> {
                             logger.warn("Observable used to push data errored, on server with name: " + name, e);
                             if (doOnError != null) {
                                 doOnError.call(e);
                             }
-                        }
-                        ,
+                        },
                         () -> {
                             logger.info("Observable used to push data completed, on server with name: " + name);
                             if (doOnComplete != null) {
                                 doOnComplete.call();
                             }
                         }
-                    ));
+                    )
+            );
             if (oldSub != null) {
                 logger.info("A new subscription is ACTIVE. " +
                     "Unsubscribe from previous subscription observable trigger with name: " + name);

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/ObservableTrigger.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/ObservableTrigger.java
@@ -54,33 +54,40 @@ public final class ObservableTrigger {
 
         subscriptionActive = metrics.getGauge("subscriptionActive");
 
-        Action1<MonitoredQueue<T>> doOnStart = queue -> subRef.set(
+        Action1<MonitoredQueue<T>> doOnStart = queue -> {
+            Subscription oldSub = subRef.getAndSet(
                 o
-                        .filter((T t1) -> t1 != null)
-                        .doOnSubscribe(() -> {
-                            logger.info("Subscription is ACTIVE for observable trigger with name: " + name);
-                            subscriptionActive.set(1);
-                        })
-                        .doOnUnsubscribe(() -> {
-                            logger.info("Subscription is INACTIVE for observable trigger with name: " + name);
-                            subscriptionActive.set(0);
-                        })
-                        .subscribe((T data) -> queue.write(data)
-                                ,
-                                (Throwable e) -> {
-                                    logger.warn("Observable used to push data errored, on server with name: " + name, e);
-                                    if (doOnError != null) {
-                                        doOnError.call(e);
-                                    }
-                                },
-                                () -> {
-                                    logger.info("Observable used to push data completed, on server with name: " + name);
-                                    if (doOnComplete != null) {
-                                        doOnComplete.call();
-                                    }
-                                }
-                        )
-        );
+                    .filter((T t1) -> t1 != null)
+                    .doOnSubscribe(() -> {
+                        logger.info("Subscription is ACTIVE for observable trigger with name: " + name);
+                        subscriptionActive.increment();
+                    })
+                    .doOnUnsubscribe(() -> {
+                        logger.info("Subscription is INACTIVE for observable trigger with name: " + name);
+                        subscriptionActive.decrement();
+                    })
+                    .subscribe((T data) -> queue.write(data)
+                        ,
+                        (Throwable e) -> {
+                            logger.warn("Observable used to push data errored, on server with name: " + name, e);
+                            if (doOnError != null) {
+                                doOnError.call(e);
+                            }
+                        },
+                        () -> {
+                            logger.info("Observable used to push data completed, on server with name: " + name);
+                            if (doOnComplete != null) {
+                                doOnComplete.call();
+                            }
+                        }
+                    )
+            );
+            if (oldSub != null) {
+                logger.info("A new subscription is ACTIVE. " +
+                    "Unsubscribe from previous subscription observable trigger with name: " + name);
+                oldSub.unsubscribe();
+            }
+        };
 
         Action1<MonitoredQueue<T>> doOnStop = t1 -> {
             if (subRef.get() != null) {
@@ -109,11 +116,11 @@ public final class ObservableTrigger {
                         .filter((T t1) -> t1 != null)
                         .doOnSubscribe(() -> {
                             logger.info("Subscription is ACTIVE for observable trigger with name: " + name);
-                            subscriptionActive.set(1);
+                            subscriptionActive.increment();
                         })
                         .doOnUnsubscribe(() -> {
                             logger.info("Subscription is INACTIVE for observable trigger with name: " + name);
-                            subscriptionActive.set(0);
+                            subscriptionActive.decrement();
                         })
                         .subscribe((T data) -> queue.write(data)
                                 ,
@@ -155,60 +162,68 @@ public final class ObservableTrigger {
 
         subscriptionActive = metrics.getGauge("subscriptionActive");
 
-        Action1<MonitoredQueue<KeyValuePair<K, V>>> doOnStart = queue -> subRef.set(
+        Action1<MonitoredQueue<KeyValuePair<K, V>>> doOnStart = queue -> {
+            Subscription oldSub = subRef.getAndSet(
                 o
-                        // decouple from calling thread
-                        .observeOn(Schedulers.computation())
-                        .doOnSubscribe(() -> {
-                            logger.info("Subscription is ACTIVE for observable trigger with name: " + name);
-                            subscriptionActive.set(1);
-                        })
-                        .doOnUnsubscribe(() -> {
-                            logger.info("Subscription is INACTIVE for observable trigger with name: " + name);
-                            subscriptionActive.set(0);
-                        })
-                        .flatMap((final GroupedObservable<K, V> group) -> {
-                                    final byte[] keyBytes = keyEncoder.call(group.getKey());
-                                    final long keyBytesHashed = hashFunction.computeHash(keyBytes);
-                                    return
-                                            group
-                                                    .timeout(groupExpirySeconds, TimeUnit.SECONDS, Observable.empty())
-                                                    .lift(new DisableBackPressureOperator<V>())
-                                                    .buffer(250, TimeUnit.MILLISECONDS)
-                                                    .filter((List<V> t1) -> t1 != null && !t1.isEmpty())
-                                                    .map((List<V> list) -> {
-                                                                List<KeyValuePair<K, V>> keyPairList = new ArrayList<>(list.size());
-                                                                for (V data : list) {
-                                                                    keyPairList.add(new KeyValuePair<>(keyBytesHashed, keyBytes, data));
-                                                                }
-                                                                return keyPairList;
-                                                            }
-                                                    );
-                                }
-                        )
-                        .subscribe((List<KeyValuePair<K, V>> list) -> {
-                                    for (KeyValuePair<K, V> data : list) {
-                                        queue.write(data);
-                                    }
-                                },
-                                (Throwable e) -> {
-                                    logger.warn("Observable used to push data errored, on server with name: " + name, e);
-                                    if (doOnError != null) {
-                                        doOnError.call(e);
-                                    }
-                                },
-                                () -> {
-                                    logger.info("Observable used to push data completed, on server with name: " + name);
-                                    if (doOnComplete != null) {
-                                        doOnComplete.call();
-                                    }
-                                }
+                    // decouple from calling thread
+                    .observeOn(Schedulers.computation())
+                    .doOnSubscribe(() -> {
+                        logger.info("Subscription is ACTIVE for observable trigger with name: " + name);
+                        subscriptionActive.increment();
+                    })
+                    .doOnUnsubscribe(() -> {
+                        logger.info("Subscription is INACTIVE for observable trigger with name: " + name);
+                        subscriptionActive.decrement();
+                    })
+                    .flatMap((final GroupedObservable<K, V> group) -> {
+                            final byte[] keyBytes = keyEncoder.call(group.getKey());
+                            final long keyBytesHashed = hashFunction.computeHash(keyBytes);
+                            return
+                                group
+                                    .timeout(groupExpirySeconds, TimeUnit.SECONDS, Observable.empty())
+                                    .lift(new DisableBackPressureOperator<V>())
+                                    .buffer(250, TimeUnit.MILLISECONDS)
+                                    .filter((List<V> t1) -> t1 != null && !t1.isEmpty())
+                                    .map((List<V> list) -> {
+                                            List<KeyValuePair<K, V>> keyPairList = new ArrayList<>(list.size());
+                                            for (V data : list) {
+                                                keyPairList.add(new KeyValuePair<>(keyBytesHashed, keyBytes, data));
+                                            }
+                                            return keyPairList;
+                                        }
+                                    );
+                        }
+                    )
+                    .subscribe((List<KeyValuePair<K, V>> list) -> {
+                            for (KeyValuePair<K, V> data : list) {
+                                queue.write(data);
+                            }
+                        },
+                        (Throwable e) -> {
+                            logger.warn("Observable used to push data errored, on server with name: " + name, e);
+                            if (doOnError != null) {
+                                doOnError.call(e);
+                            }
+                        },
+                        () -> {
+                            logger.info("Observable used to push data completed, on server with name: " + name);
+                            if (doOnComplete != null) {
+                                doOnComplete.call();
+                            }
+                        }
 
-                        ));
+                    ));
+            if (oldSub != null) {
+                logger.info("A new subscription is ACTIVE. " +
+                    "Unsubscribe from previous subscription observable trigger with name: " + name);
+                oldSub.unsubscribe();
+            }
+        };
 
         Action1<MonitoredQueue<KeyValuePair<K, V>>> doOnStop = t1 -> {
             if (subRef.get() != null) {
-                logger.warn("Connections from next stage has dropped to 0. Do not propagate unsubscribe");
+                logger.warn("Connections from next stage has dropped to 0. " +
+                    "Do not propagate unsubscribe until a new connection is made.");
                 //subRef.get().unsubscribe();
             }
         };
@@ -229,44 +244,52 @@ public final class ObservableTrigger {
 
         subscriptionActive = metrics.getGauge("subscriptionActive");
 
-        Action1<MonitoredQueue<KeyValuePair<K, V>>> doOnStart = queue -> subRef.set(
+        Action1<MonitoredQueue<KeyValuePair<K, V>>> doOnStart = queue -> {
+            Subscription oldSub = subRef.getAndSet(
                 o
-                        .doOnSubscribe(() -> {
-                            logger.info("Subscription is ACTIVE for observable trigger with name: " + name);
-                            subscriptionActive.set(1);
-                        })
-                        .doOnUnsubscribe(() -> {
-                            logger.info("Subscription is INACTIVE for observable trigger with name: " + name);
-                            subscriptionActive.set(0);
-                        })
-                        .map((MantisGroup<K, V> data) -> {
-                            final byte[] keyBytes = keyEncoder.call(data.getKeyValue());
-                            final long keyBytesHashed = hashFunction.computeHash(keyBytes);
-                            return (new KeyValuePair<K, V>(keyBytesHashed, keyBytes, data.getValue()));
-                        })
+                    .doOnSubscribe(() -> {
+                        logger.info("Subscription is ACTIVE for observable trigger with name: " + name);
+                        subscriptionActive.increment();
+                    })
+                    .doOnUnsubscribe(() -> {
+                        logger.info("Subscription is INACTIVE for observable trigger with name: " + name);
+                        subscriptionActive.decrement();
+                    })
+                    .map((MantisGroup<K, V> data) -> {
+                        final byte[] keyBytes = keyEncoder.call(data.getKeyValue());
+                        final long keyBytesHashed = hashFunction.computeHash(keyBytes);
+                        return (new KeyValuePair<K, V>(keyBytesHashed, keyBytes, data.getValue()));
+                    })
 
-                        .subscribe(
-                                (KeyValuePair<K, V> data) -> {
-                                    queue.write(data);
-                                },
-                                (Throwable e) -> {
-                                    logger.warn("Observable used to push data errored, on server with name: " + name, e);
-                                    if (doOnError != null) {
-                                        doOnError.call(e);
-                                    }
-                                }
-                                ,
-                                () -> {
-                                    logger.info("Observable used to push data completed, on server with name: " + name);
-                                    if (doOnComplete != null) {
-                                        doOnComplete.call();
-                                    }
-                                }
-                        ));
+                    .subscribe(
+                        (KeyValuePair<K, V> data) -> {
+                            queue.write(data);
+                        },
+                        (Throwable e) -> {
+                            logger.warn("Observable used to push data errored, on server with name: " + name, e);
+                            if (doOnError != null) {
+                                doOnError.call(e);
+                            }
+                        }
+                        ,
+                        () -> {
+                            logger.info("Observable used to push data completed, on server with name: " + name);
+                            if (doOnComplete != null) {
+                                doOnComplete.call();
+                            }
+                        }
+                    ));
+            if (oldSub != null) {
+                logger.info("A new subscription is ACTIVE. " +
+                    "Unsubscribe from previous subscription observable trigger with name: " + name);
+                oldSub.unsubscribe();
+            }
+        };
 
         Action1<MonitoredQueue<KeyValuePair<K, V>>> doOnStop = t1 -> {
             if (subRef.get() != null) {
-                logger.warn("Connections from next stage has dropped to 0. Do not propagate unsubscribe");
+                logger.warn("Connections from next stage has dropped to 0. " +
+                    "Do not propagate unsubscribe until a new connection is made.");
                 //	subRef.get().unsubscribe();
             }
         };


### PR DESCRIPTION
### Context

There is an implicit assumption that subscription should be 1. Before, the subscriptionActive gauge is always set to 1 whenever there is at least 1 subscription. I change that to increment/decrement on subscribe/unsubscribe to more accurately reflect the number of subscriptions. Before, the unsubscribe was purposely commented out. Clearly, this can lead to multiple subscription, which violates the assumption. With this change, we will unsubscribe the old subscription when a new subscription is created. This should correct keep active subscription at 1.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
