### PR TITLE
Add container definition id for resource cluster scaler.

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
@@ -18,4 +18,5 @@ package io.mantisrx.common;
 
 public class WorkerConstants {
     public static final String WORKER_CONTAINER_DEFINITION_ID = "MANTIS_WORKER_CONTAINER_DEFINITION_ID";
+    public static final String WORKER_TASK_ATTRIBUTE_ENV_KEY = "MANTIS_WORKER_CONTAINER_ATTRIBUTE";
 }

--- a/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
@@ -14,20 +14,8 @@
  * limitations under the License.
  */
 
-package io.mantisrx.runtime;
+package io.mantisrx.common;
 
-import lombok.Builder;
-import lombok.Value;
-
-/**
- * Wrapper class for {@link MachineDefinition} with definition id.
- * This is used in resource cluster stack only.
- */
-@Value
-@Builder
-public class MachineDefinitionWrapper {
-    public static final String MachineDefinitionIdKey = "machinedefinitionid";
-
-    String definitionId;
-    MachineDefinition machineDefinition;
+public class WorkerConstants {
+    public static final String WORKER_CONTAINER_DEFINITION_ID = "MANTIS_WORKER_CONTAINER_DEFINITION_ID";
 }

--- a/mantis-common/src/main/java/io/mantisrx/runtime/MachineDefinitionWrapper.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/MachineDefinitionWrapper.java
@@ -14,28 +14,20 @@
  * limitations under the License.
  */
 
-package io.mantisrx.master.resourcecluster.proto;
+package io.mantisrx.runtime;
 
-import io.mantisrx.runtime.MachineDefinitionWrapper;
-import io.mantisrx.server.master.resourcecluster.ClusterID;
-import java.util.List;
 import lombok.Builder;
-import lombok.Singular;
 import lombok.Value;
 
+/**
+ * Wrapper class for {@link MachineDefinition} with definition id.
+ * This is used in resource cluster stack only.
+ */
 @Value
 @Builder
-public class GetClusterUsageResponse {
-    ClusterID clusterID;
+public class MachineDefinitionWrapper {
+    public static final String MachineDefinitionIdKey = "machinedefinitionid";
 
-    @Singular
-    List<UsageByMachineDefinition> usages;
-
-    @Value
-    @Builder
-    public static class UsageByMachineDefinition {
-        MachineDefinitionWrapper def;
-        int idleCount;
-        int totalCount;
-    }
+    String definitionId;
+    MachineDefinition machineDefinition;
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ContainerSkuID.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ContainerSkuID.java
@@ -1,2 +1,29 @@
-package io.mantisrx.server.master.resourcecluster;public class ContainerSkuId {
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.master.resourcecluster;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+/**
+ * Represents the container sku ID that the task executor's host container belongs to.
+ */
+@RequiredArgsConstructor(staticName="of")
+@Value
+public class ContainerSkuID {
+    String resourceID;
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ContainerSkuID.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ContainerSkuID.java
@@ -1,0 +1,2 @@
+package io.mantisrx.server.master.resourcecluster;public class ContainerSkuId {
+}

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -77,6 +77,8 @@ public interface ResourceCluster extends ResourceClusterGateway {
 
     CompletableFuture<TaskExecutorStatus> getTaskExecutorState(TaskExecutorID taskExecutorID);
 
+    CompletableFuture<Ack> requestClusterScalerRuleSetRefresh();
+
     class NoResourceAvailableException extends Exception {
 
         public NoResourceAvailableException(String message) {

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -77,7 +77,10 @@ public interface ResourceCluster extends ResourceClusterGateway {
 
     CompletableFuture<TaskExecutorStatus> getTaskExecutorState(TaskExecutorID taskExecutorID);
 
-    CompletableFuture<Ack> requestClusterScalerRuleSetRefresh();
+    /**
+     * Trigger a request to this resource cluster's ResourceClusterScalerActor to refresh the local scale rule set.
+     */
+    CompletableFuture<Ack> refreshClusterScalerRuleSet();
 
     class NoResourceAvailableException extends Exception {
 

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
@@ -16,7 +16,10 @@
 package io.mantisrx.server.master.resourcecluster;
 
 import io.mantisrx.common.WorkerPorts;
+import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.runtime.MachineDefinitionWrapper;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 
 /**
@@ -24,6 +27,8 @@ import lombok.Value;
  * Different fields help identify the task executor in different dimensions.
  */
 @Value
+@Builder
+@AllArgsConstructor
 public class TaskExecutorRegistration {
   TaskExecutorID taskExecutorID;
 
@@ -39,5 +44,8 @@ public class TaskExecutorRegistration {
   WorkerPorts workerPorts;
 
   // machine information identifies the cpu/mem/disk/network resources of the task executor.
+  // machineDefinitionWrapper below should eventually replace legacyMachineDefinition once all TMs are updated to
+  // include the new runtime supporting legacyMachineDefinition.
+  MachineDefinition machineDefinition; // legacy machine definition.
   MachineDefinitionWrapper machineDefinitionWrapper;
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
@@ -15,9 +15,11 @@
  */
 package io.mantisrx.server.master.resourcecluster;
 
+import io.mantisrx.common.WorkerConstants;
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.runtime.MachineDefinition;
-import io.mantisrx.runtime.MachineDefinitionWrapper;
+import java.util.Map;
+import java.util.Optional;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
@@ -44,8 +46,13 @@ public class TaskExecutorRegistration {
   WorkerPorts workerPorts;
 
   // machine information identifies the cpu/mem/disk/network resources of the task executor.
-  // machineDefinitionWrapper below should eventually replace legacyMachineDefinition once all TMs are updated to
-  // include the new runtime supporting legacyMachineDefinition.
-  MachineDefinition machineDefinition; // legacy machine definition.
-  MachineDefinitionWrapper machineDefinitionWrapper;
+  MachineDefinition machineDefinition;
+
+  // custom attributes describing the task executor
+  Map<String, String> taskExecutorAttributes;
+
+  public Optional<String> getTaskExecutorContainerDefinitionId() {
+      return Optional.ofNullable(this.getTaskExecutorAttributes() == null ? null : this.getTaskExecutorAttributes()
+              .getOrDefault(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID, null));
+  }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
@@ -57,8 +57,11 @@ public class TaskExecutorRegistration {
   // TODO make this field non-null once no back-compat required.
   Map<String, String> taskExecutorAttributes;
 
-  public Optional<String> getTaskExecutorContainerDefinitionId() {
-      return Optional.ofNullable(this.getTaskExecutorAttributes() == null ? null : this.getTaskExecutorAttributes()
-              .getOrDefault(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID, null));
+  public Optional<ContainerSkuID> getTaskExecutorContainerDefinitionId() {
+      return Optional.ofNullable(
+          this.getTaskExecutorAttributes() == null ||
+              !this.getTaskExecutorAttributes().containsKey(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID) ?
+              null :
+              ContainerSkuID.of(this.getTaskExecutorAttributes().get(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID)));
   }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
@@ -16,7 +16,7 @@
 package io.mantisrx.server.master.resourcecluster;
 
 import io.mantisrx.common.WorkerPorts;
-import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.MachineDefinitionWrapper;
 import lombok.Value;
 
 /**
@@ -39,5 +39,5 @@ public class TaskExecutorRegistration {
   WorkerPorts workerPorts;
 
   // machine information identifies the cpu/mem/disk/network resources of the task executor.
-  MachineDefinition machineDefinition;
+  MachineDefinitionWrapper machineDefinitionWrapper;
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
@@ -20,8 +20,8 @@ import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.runtime.MachineDefinition;
 import java.util.Map;
 import java.util.Optional;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.NonNull;
 import lombok.Value;
 
 /**
@@ -30,25 +30,31 @@ import lombok.Value;
  */
 @Value
 @Builder
-@AllArgsConstructor
 public class TaskExecutorRegistration {
+    @NonNull
   TaskExecutorID taskExecutorID;
 
+    @NonNull
   ClusterID clusterID;
 
   // RPC address that's used to talk to the task executor
+  @NonNull
   String taskExecutorAddress;
 
   // host name of the task executor
+  @NonNull
   String hostname;
 
   // ports used by the task executor for various purposes.
+  @NonNull
   WorkerPorts workerPorts;
 
   // machine information identifies the cpu/mem/disk/network resources of the task executor.
+  @NonNull
   MachineDefinition machineDefinition;
 
   // custom attributes describing the task executor
+  @NonNull
   Map<String, String> taskExecutorAttributes;
 
   public Optional<String> getTaskExecutorContainerDefinitionId() {

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
@@ -31,10 +31,10 @@ import lombok.Value;
 @Value
 @Builder
 public class TaskExecutorRegistration {
-    @NonNull
+  @NonNull
   TaskExecutorID taskExecutorID;
 
-    @NonNull
+  @NonNull
   ClusterID clusterID;
 
   // RPC address that's used to talk to the task executor
@@ -54,7 +54,7 @@ public class TaskExecutorRegistration {
   MachineDefinition machineDefinition;
 
   // custom attributes describing the task executor
-  @NonNull
+  // TODO make this field non-null once no back-compat required.
   Map<String, String> taskExecutorAttributes;
 
   public Optional<String> getTaskExecutorContainerDefinitionId() {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandler.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandler.java
@@ -30,6 +30,7 @@ import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import java.util.concurrent.CompletionStage;
 
 public interface ResourceClusterRouteHandler {
@@ -37,7 +38,7 @@ public interface ResourceClusterRouteHandler {
 
     CompletionStage<GetResourceClusterResponse> create(final ProvisionResourceClusterRequest request);
 
-    CompletionStage<DeleteResourceClusterResponse> delete(final String clusterId);
+    CompletionStage<DeleteResourceClusterResponse> delete(final ClusterID clusterId);
 
     CompletionStage<GetResourceClusterResponse> get(final GetResourceClusterSpecRequest request);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandlerAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandlerAkkaImpl.java
@@ -35,6 +35,7 @@ import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import io.mantisrx.server.master.config.ConfigurationProvider;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
@@ -71,7 +72,7 @@ public class ResourceClusterRouteHandlerAkkaImpl implements ResourceClusterRoute
     }
 
     @Override
-    public CompletionStage<DeleteResourceClusterResponse> delete(String clusterId) {
+    public CompletionStage<DeleteResourceClusterResponse> delete(ClusterID clusterId) {
         CompletionStage<DeleteResourceClusterResponse> response =
             ask(this.resourceClustersHostManagerActor,
                 DeleteResourceClusterRequest.builder().clusterId(clusterId).build(),

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
@@ -365,7 +365,9 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
                 this.resourceClusterRouteHandler.createAllScaleRule(scaleRuleReq);
 
             return completeAsync(
-                response,
+                response.thenCombineAsync(
+                    this.gateway.getClusterFor(getClusterID(clusterName)).requestClusterScalerRuleSetRefresh(),
+                    (createResp, dontCare) -> createResp),
                 resp -> complete(
                     StatusCodes.ACCEPTED,
                     resp,

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
@@ -384,7 +384,7 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
             alwaysCache(routeResultCache, getRequestUriKeyer, () -> extractUri(
                 uri -> completeAsync(
                     this.resourceClusterRouteHandler.getClusterScaleRules(
-                        GetResourceClusterScaleRulesRequest.builder().clusterId(clusterName).build()),
+                        GetResourceClusterScaleRulesRequest.builder().clusterId(getClusterID(clusterName)).build()),
                     resp -> completeOK(
                         resp,
                         Jackson.marshaller()),

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
@@ -366,7 +366,7 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
 
             return completeAsync(
                 response.thenCombineAsync(
-                    this.gateway.getClusterFor(getClusterID(clusterName)).requestClusterScalerRuleSetRefresh(),
+                    this.gateway.getClusterFor(getClusterID(clusterName)).refreshClusterScalerRuleSet(),
                     (createResp, dontCare) -> createResp),
                 resp -> complete(
                     StatusCodes.ACCEPTED,

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
@@ -251,7 +251,7 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
             alwaysCache(routeResultCache, getRequestUriKeyer, () -> extractUri(
                 uri -> completeAsync(
                     this.resourceClusterRouteHandler.get(
-                        GetResourceClusterSpecRequest.builder().id(clusterId).build()),
+                        GetResourceClusterSpecRequest.builder().id(ClusterID.of(clusterId)).build()),
                     resp -> completeOK(
                         resp,
                         Jackson.marshaller()),
@@ -295,7 +295,7 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
     private Route deleteResourceClusterInstanceRoute(String clusterId) {
         log.info("DELETE api/v1/resourceClusters/{}", clusterId);
         return completeAsync(
-            this.resourceClusterRouteHandler.delete(clusterId),
+            this.resourceClusterRouteHandler.delete(ClusterID.of(clusterId)),
             resp -> completeOK(
                 resp,
                 Jackson.marshaller()),
@@ -303,9 +303,9 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
             HttpVerb.DELETE);
     }
 
-    private Route scaleClusterSku(String clusterName) {
+    private Route scaleClusterSku(String clusterId) {
         return entity(Jackson.unmarshaller(ScaleResourceRequest.class), skuScaleRequest -> {
-            log.info("POST api/v1/resourceClusters/{}/scaleSku {}", clusterName, skuScaleRequest);
+            log.info("POST api/v1/resourceClusters/{}/scaleSku {}", clusterId, skuScaleRequest);
             final CompletionStage<ScaleResourceResponse> response =
                 this.resourceClusterRouteHandler.scale(skuScaleRequest);
 
@@ -322,9 +322,9 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
     }
 
 
-    private Route upgradeCluster(String clusterName) {
+    private Route upgradeCluster(String clusterId) {
         return entity(Jackson.unmarshaller(UpgradeClusterContainersRequest.class), upgradeRequest -> {
-            log.info("POST api/v1/resourceClusters/{}/upgrade {}", clusterName, upgradeRequest);
+            log.info("POST api/v1/resourceClusters/{}/upgrade {}", clusterId, upgradeRequest);
             final CompletionStage<UpgradeClusterContainersResponse> response =
                 this.resourceClusterRouteHandler.upgrade(upgradeRequest);
 
@@ -340,9 +340,9 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
         });
     }
 
-    private Route createSingleScaleRule(String clusterName) {
+    private Route createSingleScaleRule(String clusterId) {
         return entity(Jackson.unmarshaller(CreateResourceClusterScaleRuleRequest.class), scaleRuleReq -> {
-            log.info("POST api/v1/resourceClusters/{}/scaleRule {}", clusterName, scaleRuleReq);
+            log.info("POST api/v1/resourceClusters/{}/scaleRule {}", clusterId, scaleRuleReq);
             final CompletionStage<GetResourceClusterScaleRulesResponse> response =
                 this.resourceClusterRouteHandler.createSingleScaleRule(scaleRuleReq);
 
@@ -358,15 +358,15 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
         });
     }
 
-    private Route createAllScaleRules(String clusterName) {
+    private Route createAllScaleRules(String clusterId) {
         return entity(Jackson.unmarshaller(CreateAllResourceClusterScaleRulesRequest.class), scaleRuleReq -> {
-            log.info("POST api/v1/resourceClusters/{}/scaleRules {}", clusterName, scaleRuleReq);
+            log.info("POST api/v1/resourceClusters/{}/scaleRules {}", clusterId, scaleRuleReq);
             final CompletionStage<GetResourceClusterScaleRulesResponse> response =
                 this.resourceClusterRouteHandler.createAllScaleRule(scaleRuleReq);
 
             return completeAsync(
                 response.thenCombineAsync(
-                    this.gateway.getClusterFor(getClusterID(clusterName)).refreshClusterScalerRuleSet(),
+                    this.gateway.getClusterFor(getClusterID(clusterId)).refreshClusterScalerRuleSet(),
                     (createResp, dontCare) -> createResp),
                 resp -> complete(
                     StatusCodes.ACCEPTED,
@@ -378,13 +378,13 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
         });
     }
 
-    private Route getScaleRules(String clusterName) {
-        log.info("GET /api/v1/resourceClusters/{}/scaleRules called", clusterName);
+    private Route getScaleRules(String clusterId) {
+        log.info("GET /api/v1/resourceClusters/{}/scaleRules called", clusterId);
         return parameterMap(param ->
             alwaysCache(routeResultCache, getRequestUriKeyer, () -> extractUri(
                 uri -> completeAsync(
                     this.resourceClusterRouteHandler.getClusterScaleRules(
-                        GetResourceClusterScaleRulesRequest.builder().clusterId(getClusterID(clusterName)).build()),
+                        GetResourceClusterScaleRulesRequest.builder().clusterId(getClusterID(clusterId)).build()),
                     resp -> completeOK(
                         resp,
                         Jackson.marshaller()),

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -156,11 +156,16 @@ class ResourceClusterActor extends AbstractActorWithTimers {
                 Pair<Integer, Integer> kvState = new Pair<>(
                     kv.getValue().isAvailable() ? 1 : 0,
                     kv.getValue().isRegistered() ? 1 : 0);
-                MachineDefinitionWrapper mDef = kv.getValue().getRegistration().getMachineDefinitionWrapper();
-                if (mDef == null) {
-                    log.debug("MachineDefinitionWrapper not supported: {}", this.clusterID);
+
+                if (kv.getValue() == null ||
+                    kv.getValue().getRegistration() == null ||
+                    kv.getValue().getRegistration().getMachineDefinitionWrapper() == null) {
+                    log.debug("MachineDefinitionWrapper is empty: {}", this.clusterID);
+                    return;
                 }
-                else if (usageByMachineDef.containsKey(mDef)) {
+
+                MachineDefinitionWrapper mDef = kv.getValue().getRegistration().getMachineDefinitionWrapper();
+                if (usageByMachineDef.containsKey(mDef)) {
                     Pair<Integer, Integer> prevState = usageByMachineDef.get(mDef);
                     usageByMachineDef.put(mDef,
                         new Pair<>(kvState.first() + prevState.first(), kvState.second() + prevState.second()));

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -153,16 +153,16 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         Map<MachineDefinitionWrapper, Pair<Integer, Integer>> usageByMachineDef = new HashMap<>();
         taskExecutorStateMap.entrySet().stream()
             .forEach(kv -> {
-                Pair<Integer, Integer> kvState = new Pair<>(
-                    kv.getValue().isAvailable() ? 1 : 0,
-                    kv.getValue().isRegistered() ? 1 : 0);
-
                 if (kv.getValue() == null ||
                     kv.getValue().getRegistration() == null ||
                     kv.getValue().getRegistration().getMachineDefinitionWrapper() == null) {
-                    log.debug("MachineDefinitionWrapper is empty: {}", this.clusterID);
+                    log.info("MachineDefinitionWrapper is empty: {}, {}", this.clusterID, kv.getKey());
                     return;
                 }
+
+                Pair<Integer, Integer> kvState = new Pair<>(
+                    kv.getValue().isAvailable() ? 1 : 0,
+                    kv.getValue().isRegistered() ? 1 : 0);
 
                 MachineDefinitionWrapper mDef = kv.getValue().getRegistration().getMachineDefinitionWrapper();
                 if (usageByMachineDef.containsKey(mDef)) {
@@ -277,7 +277,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
 
     private void onTaskExecutorRegistration(TaskExecutorRegistration registration) {
         setupTaskExecutorStateIfNecessary(registration.getTaskExecutorID());
-        log.info("Request for registering {} with the resource cluster {}", registration.getTaskExecutorID(), this);
+        log.info("Request for registering on resource cluster {}: {}.", this, registration);
         try {
             final TaskExecutorID taskExecutorID = registration.getTaskExecutorID();
             final TaskExecutorState state = taskExecutorStateMap.get(taskExecutorID);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -30,6 +30,7 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssig
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorInfoRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorsList;
+import io.mantisrx.master.resourcecluster.ResourceClusterScalerActor.TriggerClusterRuleRefreshRequest;
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
@@ -169,5 +170,16 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
                 .ask(resourceClusterManagerActor, new GetTaskExecutorStatusRequest(taskExecutorID, clusterID), askTimeout)
                 .thenApply(TaskExecutorStatus.class::cast)
                 .toCompletableFuture();
+    }
+
+    @Override
+    public CompletableFuture<Ack> requestClusterScalerRuleSetRefresh() {
+        return Patterns
+            .ask(
+                resourceClusterManagerActor,
+                TriggerClusterRuleRefreshRequest.builder().clusterID(this.clusterID).build(),
+                askTimeout)
+            .thenApply(Ack.class::cast)
+            .toCompletableFuture();
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -173,7 +173,7 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
     }
 
     @Override
-    public CompletableFuture<Ack> requestClusterScalerRuleSetRefresh() {
+    public CompletableFuture<Ack> refreshClusterScalerRuleSet() {
         return Patterns
             .ask(
                 resourceClusterManagerActor,

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -264,7 +264,7 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
 
     private void fetchRuleSet() {
         CompletionStage<GetRuleSetResponse> fetchFut =
-            this.storageProvider.getResourceClusterScaleRules(this.clusterId.getResourceID())
+            this.storageProvider.getResourceClusterScaleRules(this.clusterId)
                 .thenApply(rules -> {
                     Set<String> removedKeys = new HashSet<>(this.skuToRuleMap.keySet());
                     removedKeys.removeAll(rules.getScaleRules().keySet());

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -259,7 +259,7 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
 
     private void fetchRuleSet() {
         CompletionStage<GetRuleSetResponse> fetchFut =
-            this.storageProvider.getResourceClusterScaleRules(this.clusterId.toString())
+            this.storageProvider.getResourceClusterScaleRules(this.clusterId.getResourceID())
                 .thenApply(rules -> {
                     Set<String> removedKeys = new HashSet<>(this.skuToRuleMap.keySet());
                     removedKeys.removeAll(rules.getScaleRules().keySet());

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -175,6 +175,11 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
         // 3 translate between decision to scale request. (inline for now)
 
         usageResponse.getUsages().forEach(usage -> {
+            if (usage.getDef() == null) {
+                log.debug("Legacy machine definition not supported: ", usage);
+                return;
+            }
+
             Optional<String> skuIdO = Optional.ofNullable(usage.getDef().getDefinitionId());
 
             if (skuIdO.isPresent() && this.skuToRuleMap.containsKey(skuIdO.get())) {
@@ -189,7 +194,7 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                                 GetClusterIdleInstancesRequest.builder()
                                     .clusterID(this.clusterId)
                                     .skuId(skuIdO.get())
-                                    .machineDefinition(usage.getDef().getMachineDefinition())
+                                    .machineDefinitionWrapper(usage.getDef())
                                     .desireSize(decisionO.get().getDesireSize())
                                     .maxInstanceCount(
                                         Math.max(0, usage.getTotalCount() - decisionO.get().getDesireSize()))

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -240,11 +240,15 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
 
     private void onTriggerClusterUsageRequest(TriggerClusterUsageRequest req) {
         log.trace("Requesting cluster usage: {}", this.clusterId);
+        if (this.skuToRuleMap.isEmpty()) {
+            log.info("{} scaler is disabled due to no rules", this.clusterId);
+            return;
+        }
         this.resourceClusterActor.tell(new GetClusterUsageRequest(this.clusterId), self());
     }
 
     private void onTriggerClusterRuleRefreshRequest(TriggerClusterRuleRefreshRequest req) {
-        log.info("Requesting cluster rule refresh");
+        log.info("{}: Requesting cluster rule refresh", this.clusterId);
         this.fetchRuleSet();
     }
 
@@ -258,7 +262,7 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                 rules
                     .getScaleRules().values()
                     .forEach(rule -> {
-                        log.info("Adding scaleRule: {}", rule);
+                        log.info("Cluster [{}]: Adding scaleRule: {}",this.clusterId, rule);
                         this.skuToRuleMap.put(
                             rule.getSkuId(),
                             new ClusterAvailabilityRule(rule, this.clock));

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActor.java
@@ -130,7 +130,7 @@ public class ResourceClustersHostManagerActor extends AbstractActorWithTimers {
         pipe(this.resourceClusterStorageProvider.getResourceClusterScaleRules(req.getClusterId())
                 .thenApply(this::toGetResourceClusterScaleRulesResponse)
                 .exceptionally(err -> {
-                    log.error("Error from getResourceClusterScaleRules: {}, {}", err.getMessage(), req);
+                    log.error("Error from getResourceClusterScaleRules: {}, {}", err, req);
                     return GetResourceClusterScaleRulesResponse.builder()
                         .message(err.getMessage())
                         .responseCode(ResponseCode.SERVER_ERROR).build();
@@ -157,7 +157,7 @@ public class ResourceClustersHostManagerActor extends AbstractActorWithTimers {
         pipe(this.resourceClusterStorageProvider.registerResourceClusterScaleRule(rulesBuilder.build())
             .thenApply(this::toGetResourceClusterScaleRulesResponse)
                 .exceptionally(err -> {
-                    log.error("Error from registerResourceClusterScaleRule: {}, {}", err.getMessage(), req);
+                    log.error("Error from registerResourceClusterScaleRule: {}, {}", err, req);
                     return GetResourceClusterScaleRulesResponse.builder()
                         .message(err.getMessage())
                         .responseCode(ResponseCode.SERVER_ERROR).build();

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActor.java
@@ -143,7 +143,7 @@ public class ResourceClustersHostManagerActor extends AbstractActorWithTimers {
         ResourceClusterScaleRulesWritableBuilder rulesBuilder = ResourceClusterScaleRulesWritable.builder()
             .clusterId(req.getClusterId());
         req.getRules().forEach(r -> rulesBuilder.scaleRule(
-            r.getSkuId(),
+            r.getSkuId().getResourceID(),
             ResourceClusterScaleSpec.builder()
                 .maxSize(r.getMaxSize())
                 .minSize(r.getMinSize())

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -153,6 +153,7 @@ class ResourceClustersManagerActor extends AbstractActor {
                     clusterID,
                     clock,
                     Duration.ofSeconds(masterConfiguration.getScalerTriggerThresholdInSecs()),
+                    Duration.ofSeconds(masterConfiguration.getScalerRuleSetRefreshThresholdInSecs()),
                     this.resourceStorageProvider,
                     this.resourceClusterHostActor,
                     rcActor

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
@@ -16,7 +16,6 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
-import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import lombok.Builder;
 import lombok.Value;
@@ -24,7 +23,6 @@ import lombok.Value;
 @Value
 @Builder
 public class GetClusterIdleInstancesRequest {
-    MachineDefinitionWrapper machineDefinitionWrapper;
     ClusterID clusterID;
     String skuId;
     int maxInstanceCount;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
@@ -17,6 +17,7 @@
 package io.mantisrx.master.resourcecluster.proto;
 
 import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import lombok.Builder;
 import lombok.Value;
 
@@ -24,7 +25,8 @@ import lombok.Value;
 @Builder
 public class GetClusterIdleInstancesRequest {
     ClusterID clusterID;
-    String skuId;
+    ContainerSkuID skuId;
+
     int maxInstanceCount;
     int desireSize;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
@@ -16,7 +16,7 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
-import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import lombok.Builder;
 import lombok.Value;
@@ -24,7 +24,7 @@ import lombok.Value;
 @Value
 @Builder
 public class GetClusterIdleInstancesRequest {
-    MachineDefinition machineDefinition;
+    MachineDefinitionWrapper machineDefinitionWrapper;
     ClusterID clusterID;
     String skuId;
     int maxInstanceCount;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesResponse.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesResponse.java
@@ -16,6 +16,8 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
 import java.util.List;
 import lombok.Builder;
@@ -25,8 +27,8 @@ import lombok.Value;
 @Value
 @Builder
 public class GetClusterIdleInstancesResponse {
-    String clusterId;
-    String skuId;
+    ClusterID clusterId;
+    ContainerSkuID skuId;
 
     @Singular
     List<TaskExecutorID> instanceIds;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterUsageResponse.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterUsageResponse.java
@@ -28,12 +28,12 @@ public class GetClusterUsageResponse {
     ClusterID clusterID;
 
     @Singular
-    List<UsageByMachineDefinition> usages;
+    List<UsageByGroupKey> usages;
 
     @Value
     @Builder
-    public static class UsageByMachineDefinition {
-        String containerDefinitionId;
+    public static class UsageByGroupKey {
+        String usageGroupKey;
         int idleCount;
         int totalCount;
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterUsageResponse.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterUsageResponse.java
@@ -16,7 +16,6 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
-import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import java.util.List;
 import lombok.Builder;
@@ -34,7 +33,7 @@ public class GetClusterUsageResponse {
     @Value
     @Builder
     public static class UsageByMachineDefinition {
-        MachineDefinitionWrapper def;
+        String containerDefinitionId;
         int idleCount;
         int totalCount;
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetResourceClusterSpecRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetResourceClusterSpecRequest.java
@@ -16,11 +16,12 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import lombok.Builder;
 import lombok.Value;
 
 @Builder
 @Value
 public class GetResourceClusterSpecRequest {
-    String id;
+    ClusterID id;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/MantisResourceClusterSpec.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/MantisResourceClusterSpec.java
@@ -17,6 +17,8 @@
 package io.mantisrx.master.resourcecluster.proto;
 
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProvider;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
@@ -41,7 +43,7 @@ public class MantisResourceClusterSpec {
     /**
      * ID fields maps to cluster name or spinnaker app name.
      */
-    String id;
+    ClusterID id;
 
     String ownerName;
 
@@ -61,7 +63,7 @@ public class MantisResourceClusterSpec {
     @JsonCreator
     public MantisResourceClusterSpec(
             @JsonProperty("name") final String name,
-            @JsonProperty("id") final String id,
+            @JsonProperty("id") final ClusterID id,
             @JsonProperty("ownerName") final String ownerName,
             @JsonProperty("ownerEmail") final String ownerEmail,
             @JsonProperty("envType") final MantisResourceClusterEnvType envType,
@@ -81,7 +83,7 @@ public class MantisResourceClusterSpec {
     @EqualsAndHashCode(onlyExplicitlyIncluded = true)
     public static class SkuTypeSpec {
         @EqualsAndHashCode.Include
-        String skuId;
+        ContainerSkuID skuId;
 
         SkuCapacity capacity;
 
@@ -100,7 +102,7 @@ public class MantisResourceClusterSpec {
 
         @JsonCreator
         public SkuTypeSpec(
-                @JsonProperty("skuId") final String skuId,
+                @JsonProperty("skuId") final ContainerSkuID skuId,
                 @JsonProperty("capacity") final SkuCapacity capacity,
                 @JsonProperty("imageId") final String imageId,
                 @JsonProperty("cpuCoreCount") final int cpuCoreCount,
@@ -126,7 +128,7 @@ public class MantisResourceClusterSpec {
     @Builder
     @Value
     public static class SkuCapacity {
-        String skuId;
+        ContainerSkuID skuId;
 
         int minSize;
 
@@ -136,7 +138,7 @@ public class MantisResourceClusterSpec {
 
         @JsonCreator
         public SkuCapacity(
-                @JsonProperty("skuId") final String skuId,
+                @JsonProperty("skuId") final ContainerSkuID skuId,
                 @JsonProperty("minSize") final int minSize,
                 @JsonProperty("maxSize") final int maxSize,
                 @JsonProperty("desireSize") final int desireSize

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ProvisionResourceClusterRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ProvisionResourceClusterRequest.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import lombok.Builder;
 import lombok.Value;
 
@@ -25,7 +26,7 @@ import lombok.Value;
 @Builder
 @Value
 public class ProvisionResourceClusterRequest {
-    String clusterId;
+    ClusterID clusterId;
 
     MantisResourceClusterSpec clusterSpec;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterAPIProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterAPIProto.java
@@ -17,6 +17,7 @@
 package io.mantisrx.master.resourcecluster.proto;
 
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
@@ -50,12 +51,12 @@ public class ResourceClusterAPIProto {
         @Value
         @Builder
         public static class RegisteredResourceCluster {
-            String id;
+            ClusterID id;
             String version;
 
             @JsonCreator
             public RegisteredResourceCluster(
-                @JsonProperty("id") final String id,
+                @JsonProperty("id") final ClusterID id,
                 @JsonProperty("version") final String version) {
                 this.id = id;
                 this.version = version;
@@ -95,6 +96,6 @@ public class ResourceClusterAPIProto {
     @Builder
     @Value
     public static class DeleteResourceClusterRequest {
-        String clusterId;
+        ClusterID clusterId;
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterScaleRuleProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterScaleRuleProto.java
@@ -18,6 +18,7 @@ package io.mantisrx.master.resourcecluster.proto;
 
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
@@ -37,7 +38,7 @@ public class ResourceClusterScaleRuleProto {
 
     @Value
     public static class GetResourceClusterScaleRulesResponse extends BaseResponse {
-        String clusterId;
+        ClusterID clusterId;
 
         @Singular
         List<ResourceClusterScaleRule> rules;
@@ -48,7 +49,7 @@ public class ResourceClusterScaleRuleProto {
             @JsonProperty("requestId") final long requestId,
             @JsonProperty("responseCode") final ResponseCode responseCode,
             @JsonProperty("message") final String message,
-            @JsonProperty("clusterId") final String clusterId,
+            @JsonProperty("clusterId") final ClusterID clusterId,
             @JsonProperty("rules") final List<ResourceClusterScaleRule> rules) {
             super(requestId, responseCode, message);
             this.rules = rules;
@@ -59,7 +60,7 @@ public class ResourceClusterScaleRuleProto {
     @Builder
     @Value
     public static class CreateResourceClusterScaleRuleRequest {
-        String clusterId;
+        ClusterID clusterId;
         ResourceClusterScaleRule rule;
     }
 
@@ -69,7 +70,7 @@ public class ResourceClusterScaleRuleProto {
     @Builder
     @Value
     public static class CreateAllResourceClusterScaleRulesRequest {
-        String clusterId;
+        ClusterID clusterId;
 
         @Singular
         @NonNull
@@ -79,8 +80,8 @@ public class ResourceClusterScaleRuleProto {
     @Value
     @Builder
     public static class ResourceClusterScaleRule {
-        String clusterId;
-        String skuId;
+        ClusterID clusterId;
+        ContainerSkuID skuId;
         int minIdleToKeep;
         int minSize;
         int maxIdleToKeep;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterScaleRuleProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterScaleRuleProto.java
@@ -17,6 +17,7 @@
 package io.mantisrx.master.resourcecluster.proto;
 
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
@@ -31,7 +32,7 @@ public class ResourceClusterScaleRuleProto {
     @Builder
     @Value
     public static class GetResourceClusterScaleRulesRequest {
-        String clusterId;
+        ClusterID clusterId;
     }
 
     @Value

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterScaleSpec.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterScaleSpec.java
@@ -16,6 +16,8 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -24,8 +26,8 @@ import lombok.Value;
 @Value
 @Builder
 public class ResourceClusterScaleSpec {
-    String clusterId;
-    String skuId;
+    ClusterID clusterId;
+    ContainerSkuID skuId;
     int minIdleToKeep;
     int minSize;
     int maxIdleToKeep;
@@ -34,8 +36,8 @@ public class ResourceClusterScaleSpec {
 
     @JsonCreator
     public ResourceClusterScaleSpec(
-        @JsonProperty("clusterId") final String clusterId,
-        @JsonProperty("skuId") final String skuId,
+        @JsonProperty("clusterId") final ClusterID clusterId,
+        @JsonProperty("skuId") final ContainerSkuID skuId,
         @JsonProperty("minIdleToKeep") final int minIdleToKeep,
         @JsonProperty("minSize") final int minSize,
         @JsonProperty("maxIdleToKeep") final int maxIdleToKeep,

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
@@ -45,8 +45,8 @@ public class ScaleResourceRequest {
     public String getScaleRequestId() {
         return Joiner.on('-').join(
             this.clusterId.getResourceID(),
-            this.region,
-            this.envType.isPresent() ? this.getEnvType().get().name() : "",
+            this.region == null ? "" : this.region,
+            this.envType != null && this.envType.isPresent() ? this.getEnvType().get().name() : "",
             this.skuId.getResourceID(),
             this.desireSize);
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
@@ -19,6 +19,7 @@ package io.mantisrx.master.resourcecluster.proto;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
 import io.mantisrx.shaded.com.google.common.base.Joiner;
 import java.util.List;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Singular;
 import lombok.Value;
@@ -32,7 +33,7 @@ public class ScaleResourceRequest {
 
     String region;
 
-    MantisResourceClusterEnvType envType;
+    Optional<MantisResourceClusterEnvType> envType;
 
     int desireSize;
 
@@ -40,7 +41,12 @@ public class ScaleResourceRequest {
     List<TaskExecutorID> idleInstances;
 
     public String getScaleRequestId() {
-        return Joiner.on('-').join(this.clusterId, this.region, this.envType.name(), this.skuId, this.desireSize);
+        return Joiner.on('-').join(
+            this.clusterId,
+            this.region,
+            this.envType.isPresent() ? this.getEnvType().get().name() : "",
+            this.skuId,
+            this.desireSize);
     }
 
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
@@ -16,6 +16,8 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
 import io.mantisrx.shaded.com.google.common.base.Joiner;
 import java.util.List;
@@ -27,9 +29,9 @@ import lombok.Value;
 @Builder
 @Value
 public class ScaleResourceRequest {
-    String clusterId;
+    ClusterID clusterId;
 
-    String skuId;
+    ContainerSkuID skuId;
 
     String region;
 
@@ -42,10 +44,10 @@ public class ScaleResourceRequest {
 
     public String getScaleRequestId() {
         return Joiner.on('-').join(
-            this.clusterId,
+            this.clusterId.getResourceID(),
             this.region,
             this.envType.isPresent() ? this.getEnvType().get().name() : "",
-            this.skuId,
+            this.skuId.getResourceID(),
             this.desireSize);
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceResponse.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceResponse.java
@@ -17,6 +17,8 @@
 package io.mantisrx.master.resourcecluster.proto;
 
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -24,9 +26,9 @@ import lombok.Value;
 
 @Value
 public class ScaleResourceResponse extends BaseResponse {
-    String clusterId;
+    ClusterID clusterId;
 
-    String skuId;
+    ContainerSkuID skuId;
 
     String region;
 
@@ -40,8 +42,8 @@ public class ScaleResourceResponse extends BaseResponse {
             @JsonProperty("requestId") final long requestId,
             @JsonProperty("responseCode") final ResponseCode responseCode,
             @JsonProperty("message") final String message,
-            @JsonProperty("clusterId") final String clusterId,
-            @JsonProperty("skuId") String skuId,
+            @JsonProperty("clusterId") final ClusterID clusterId,
+            @JsonProperty("skuId") ContainerSkuID skuId,
             @JsonProperty("region") String region,
             @JsonProperty("envType") MantisResourceClusterEnvType envType,
             @JsonProperty("desireSize") int desireSize) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
@@ -16,13 +16,14 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import lombok.Builder;
 import lombok.Value;
 
 @Value
 @Builder
 public class UpgradeClusterContainersRequest {
-    String clusterId;
+    ClusterID clusterId;
 
     String region;
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersResponse.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersResponse.java
@@ -17,6 +17,7 @@
 package io.mantisrx.master.resourcecluster.proto;
 
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -24,7 +25,7 @@ import lombok.Value;
 
 @Value
 public class UpgradeClusterContainersResponse extends BaseResponse {
-    String clusterId;
+    ClusterID clusterId;
 
     String region;
 
@@ -38,7 +39,7 @@ public class UpgradeClusterContainersResponse extends BaseResponse {
         @JsonProperty("requestId") final long requestId,
         @JsonProperty("responseCode") final ResponseCode responseCode,
         @JsonProperty("message") final String message,
-        @JsonProperty("clusterId") final String clusterId,
+        @JsonProperty("clusterId") final ClusterID clusterId,
         @JsonProperty("region") final String region,
         @JsonProperty("optionalSkuId") String optionalSkuId,
         @JsonProperty("optionalEnvType") MantisResourceClusterEnvType optionalEnvType) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/InMemoryOnlyResourceClusterStorageProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/InMemoryOnlyResourceClusterStorageProvider.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * [Test only] Store resource storage data in memory only for testing.
  */
 public class InMemoryOnlyResourceClusterStorageProvider implements ResourceClusterStorageProvider {
-    Map<String, ResourceClusterSpecWritable> clusters = new ConcurrentHashMap<>();
+    Map<ClusterID, ResourceClusterSpecWritable> clusters = new ConcurrentHashMap<>();
     Map<ClusterID, ResourceClusterScaleRulesWritable> clusterRules = new ConcurrentHashMap<>();
 
     @Override
@@ -40,7 +40,7 @@ public class InMemoryOnlyResourceClusterStorageProvider implements ResourceClust
     }
 
     @Override
-    public CompletionStage<RegisteredResourceClustersWritable> deregisterCluster(String clusterId) {
+    public CompletionStage<RegisteredResourceClustersWritable> deregisterCluster(ClusterID clusterId) {
         this.clusters.remove(clusterId);
         return getRegisteredResourceClustersWritable();
     }
@@ -52,7 +52,7 @@ public class InMemoryOnlyResourceClusterStorageProvider implements ResourceClust
 
         this.clusters.forEach((key, value) ->
             builder.cluster(
-                key,
+                key.getResourceID(),
                 RegisteredResourceClustersWritable.ClusterRegistration.builder()
                     .clusterId(key).version(value.getVersion()).build()));
 
@@ -60,7 +60,7 @@ public class InMemoryOnlyResourceClusterStorageProvider implements ResourceClust
     }
 
     @Override
-    public CompletionStage<ResourceClusterSpecWritable> getResourceClusterSpecWritable(String id) {
+    public CompletionStage<ResourceClusterSpecWritable> getResourceClusterSpecWritable(ClusterID id) {
         return CompletableFuture.completedFuture(this.clusters.getOrDefault(id, null));
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/InMemoryOnlyResourceClusterStorageProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/InMemoryOnlyResourceClusterStorageProvider.java
@@ -20,6 +20,7 @@ import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleSpec;
 import io.mantisrx.master.resourcecluster.writable.RegisteredResourceClustersWritable;
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterScaleRulesWritable;
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterSpecWritable;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -64,11 +65,11 @@ public class InMemoryOnlyResourceClusterStorageProvider implements ResourceClust
     }
 
     @Override
-    public CompletionStage<ResourceClusterScaleRulesWritable> getResourceClusterScaleRules(String clusterId) {
+    public CompletionStage<ResourceClusterScaleRulesWritable> getResourceClusterScaleRules(ClusterID clusterId) {
         return CompletableFuture.completedFuture(
             this.clusterRules.getOrDefault(
-                clusterId,
-                ResourceClusterScaleRulesWritable.builder().clusterId(clusterId).build()));
+                clusterId.getResourceID(),
+                ResourceClusterScaleRulesWritable.builder().clusterId(clusterId.getResourceID()).build()));
     }
 
     @Override

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterStorageProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterStorageProvider.java
@@ -34,11 +34,11 @@ public interface ResourceClusterStorageProvider {
      */
     CompletionStage<ResourceClusterSpecWritable> registerAndUpdateClusterSpec(ResourceClusterSpecWritable spec);
 
-    CompletionStage<RegisteredResourceClustersWritable> deregisterCluster(String clusterId);
+    CompletionStage<RegisteredResourceClustersWritable> deregisterCluster(ClusterID clusterId);
 
     CompletionStage<RegisteredResourceClustersWritable> getRegisteredResourceClustersWritable();
 
-    CompletionStage<ResourceClusterSpecWritable> getResourceClusterSpecWritable(String id);
+    CompletionStage<ResourceClusterSpecWritable> getResourceClusterSpecWritable(ClusterID id);
 
     CompletionStage<ResourceClusterScaleRulesWritable> getResourceClusterScaleRules(ClusterID clusterId);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterStorageProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterStorageProvider.java
@@ -20,6 +20,7 @@ import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleSpec;
 import io.mantisrx.master.resourcecluster.writable.RegisteredResourceClustersWritable;
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterScaleRulesWritable;
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterSpecWritable;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import java.util.concurrent.CompletionStage;
 
 /**
@@ -39,7 +40,7 @@ public interface ResourceClusterStorageProvider {
 
     CompletionStage<ResourceClusterSpecWritable> getResourceClusterSpecWritable(String id);
 
-    CompletionStage<ResourceClusterScaleRulesWritable> getResourceClusterScaleRules(String clusterId);
+    CompletionStage<ResourceClusterScaleRulesWritable> getResourceClusterScaleRules(ClusterID clusterId);
 
     CompletionStage<ResourceClusterScaleRulesWritable> registerResourceClusterScaleRule(
         ResourceClusterScaleRulesWritable ruleSpec);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterStorageProviderAdapter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterStorageProviderAdapter.java
@@ -69,7 +69,7 @@ public class ResourceClusterStorageProviderAdapter implements ResourceClusterSto
     }
 
     @Override
-    public CompletionStage<RegisteredResourceClustersWritable> deregisterCluster(String clusterId) {
+    public CompletionStage<RegisteredResourceClustersWritable> deregisterCluster(ClusterID clusterId) {
         return this.providerImpl.deregisterCluster(clusterId);
     }
 
@@ -79,7 +79,7 @@ public class ResourceClusterStorageProviderAdapter implements ResourceClusterSto
     }
 
     @Override
-    public CompletionStage<ResourceClusterSpecWritable> getResourceClusterSpecWritable(String id) {
+    public CompletionStage<ResourceClusterSpecWritable> getResourceClusterSpecWritable(ClusterID id) {
         return this.providerImpl.getResourceClusterSpecWritable(id);
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterStorageProviderAdapter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterStorageProviderAdapter.java
@@ -21,6 +21,7 @@ import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleSpec;
 import io.mantisrx.master.resourcecluster.writable.RegisteredResourceClustersWritable;
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterScaleRulesWritable;
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterSpecWritable;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import java.util.concurrent.CompletionStage;
 import lombok.extern.slf4j.Slf4j;
 
@@ -83,7 +84,7 @@ public class ResourceClusterStorageProviderAdapter implements ResourceClusterSto
     }
 
     @Override
-    public CompletionStage<ResourceClusterScaleRulesWritable> getResourceClusterScaleRules(String clusterId) {
+    public CompletionStage<ResourceClusterScaleRulesWritable> getResourceClusterScaleRules(ClusterID clusterId) {
         return this.providerImpl.getResourceClusterScaleRules(clusterId);
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/writable/RegisteredResourceClustersWritable.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/writable/RegisteredResourceClustersWritable.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.resourcecluster.writable;
 
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
@@ -41,7 +42,7 @@ public class RegisteredResourceClustersWritable {
     @Value
     @Builder
     public static class ClusterRegistration {
-        String clusterId;
+        ClusterID clusterId;
 
         String version;
 
@@ -50,7 +51,7 @@ public class RegisteredResourceClustersWritable {
          */
         @JsonCreator
         public ClusterRegistration(
-                @JsonProperty("clusterId") final String clusterId,
+                @JsonProperty("clusterId") final ClusterID clusterId,
                 @JsonProperty("version") final String version) {
             this.clusterId = clusterId;
             this.version = version;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/writable/ResourceClusterScaleRulesWritable.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/writable/ResourceClusterScaleRulesWritable.java
@@ -17,6 +17,7 @@
 package io.mantisrx.master.resourcecluster.writable;
 
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleSpec;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
@@ -27,15 +28,20 @@ import lombok.Value;
 @Value
 @Builder(toBuilder = true)
 public class ResourceClusterScaleRulesWritable {
-    String clusterId;
+    ClusterID clusterId;
     String version;
 
+    /**
+     * [Note] Using composite type as key will cause a bug during ser/deser where key object's toString is invoked
+     * instead of using the ser result and this will cause unexpected behavior (key=(object string from toString())
+     * during deser. Thus using plain string (e.g. resourceID) instead.
+     */
     @Singular
     Map<String, ResourceClusterScaleSpec> scaleRules;
 
     @JsonCreator
     public ResourceClusterScaleRulesWritable(
-        @JsonProperty("clusterId") final String clusterId,
+        @JsonProperty("clusterId") final ClusterID clusterId,
         @JsonProperty("version") final String version,
         @JsonProperty("rules") final Map<String, ResourceClusterScaleSpec> scaleRules) {
         this.clusterId = clusterId;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/writable/ResourceClusterSpecWritable.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/writable/ResourceClusterSpecWritable.java
@@ -17,6 +17,7 @@
 package io.mantisrx.master.resourcecluster.writable;
 
 import io.mantisrx.master.resourcecluster.proto.MantisResourceClusterSpec;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
@@ -30,7 +31,7 @@ import lombok.Value;
 public class ResourceClusterSpecWritable {
     String version;
 
-    String id;
+    ClusterID id;
 
     MantisResourceClusterSpec clusterSpec;
 
@@ -40,7 +41,7 @@ public class ResourceClusterSpecWritable {
     @JsonCreator
     public ResourceClusterSpecWritable(
             @JsonProperty("version") final String version,
-            @JsonProperty("id") final String id,
+            @JsonProperty("id") final ClusterID id,
             @JsonProperty("clusterSpec") final MantisResourceClusterSpec clusterSpec) {
         this.version = version;
         this.id = id;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -331,6 +331,10 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("60")
     int getScalerTriggerThresholdInSecs();
 
+    @Config("mantis.job.master.resource.cluster.scaler.ruleset.refresh.secs")
+    @Default("180")
+    int getScalerRuleSetRefreshThresholdInSecs();
+
     @Config("mantis.agent.assignment.interval.ms")
     @Default("60000") // 1 minute
     int getAssignmentIntervalInMs();

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -327,10 +327,18 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("300000") // 5 minutes
     int getHeartbeatIntervalInMs();
 
+    /**
+     * Config value for each {@link io.mantisrx.master.resourcecluster.ResourceClusterScalerActor}'s timer to trigger
+     * check on current cluster usage.
+     */
     @Config("mantis.job.master.resource.cluster.scaler.interval.secs")
     @Default("60")
     int getScalerTriggerThresholdInSecs();
 
+    /**
+     * Config value for each {@link io.mantisrx.master.resourcecluster.ResourceClusterScalerActor}'s timer to refresh
+     * its cached scale rules.
+     */
     @Config("mantis.job.master.resource.cluster.scaler.ruleset.refresh.secs")
     @Default("180")
     int getScalerRuleSetRefreshThresholdInSecs();

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/payloads/ResourceClustersPayloads.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/payloads/ResourceClustersPayloads.java
@@ -35,6 +35,8 @@ public class ResourceClustersPayloads {
     public static final String RESOURCE_CLUSTER_SCALE_RULES_RESULT =
         PayloadUtils.getStringFromResource("testpayloads/ResourceClusterScaleRulesResult.json");
 
-    public static final String RESOURCE_CLUSTER_SKU_SCALE = "{\"clusterId\":\"mantisResourceClusterUT1\","
-            + "\"skuId\":\"small\",\"region\":\"us-east-1\",\"envType\":\"Prod\",\"desireSize\":11}\n";
+    public static final String RESOURCE_CLUSTER_SKU_SCALE = "{\"clusterId\":{\"resourceID\": "
+        + "\"mantisResourceClusterUT1\"},"
+            + "\"skuId\":{\"resourceID\": \"small\"},\"region\":\"us-east-1\",\"envType\":\"Prod\","
+        + "\"desireSize\":11}\n";
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -64,6 +64,7 @@ import io.mantisrx.server.master.resourcecluster.ResourceCluster.TaskExecutorSta
 import io.mantisrx.server.master.resourcecluster.ResourceClusters;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorRegistration;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
@@ -121,6 +122,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
                 .hostname("hostName")
                 .workerPorts(new WorkerPorts(1, 2, 3, 4, 5))
                 .machineDefinition(new MachineDefinition(1, 1, 1, 1, 1))
+                .taskExecutorAttributes(ImmutableMap.of())
                 .build();
 
         TaskExecutorStatus status =

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -57,7 +57,6 @@ import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProvid
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterResponseHandler;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterStorageProviderAdapter;
 import io.mantisrx.runtime.MachineDefinition;
-import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster;
@@ -121,9 +120,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
                 .taskExecutorAddress("taskExecutorAddress")
                 .hostname("hostName")
                 .workerPorts(new WorkerPorts(1, 2, 3, 4, 5))
-                .machineDefinitionWrapper(MachineDefinitionWrapper.builder().machineDefinition(
-                    new MachineDefinition(1, 1, 1, 1, 1))
-                    .build())
+                .machineDefinition(new MachineDefinition(1, 1, 1, 1, 1))
                 .build();
 
         TaskExecutorStatus status =
@@ -388,7 +385,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
                     .region(scaleRequest.getRegion())
                     .skuId(scaleRequest.getSkuId())
                     .clusterId(scaleRequest.getClusterId())
-                    .envType(scaleRequest.getEnvType())
+                    .envType(scaleRequest.getEnvType().get())
                     .desireSize(scaleRequest.getDesireSize())
                     .responseCode(ResponseCode.SUCCESS)
                     .build());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -18,6 +18,7 @@ package io.mantisrx.master.api.akka.route.v1;
 
 import static io.mantisrx.master.api.akka.payloads.ResourceClustersPayloads.CLUSTER_ID;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import akka.actor.ActorRef;
@@ -29,6 +30,7 @@ import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.testkit.JUnitRouteTest;
 import akka.http.javadsl.testkit.TestRoute;
 import com.netflix.mantis.master.scheduler.TestHelpers;
+import io.mantisrx.common.Ack;
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.master.api.akka.payloads.ResourceClustersPayloads;
 import io.mantisrx.master.api.akka.route.Jackson;
@@ -241,6 +243,11 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
 
     @Test
     public void testResourceClusterScaleRulesRoutes() throws IOException {
+        ResourceCluster resourceCluster = mock(ResourceCluster.class);
+        when(resourceCluster.requestClusterScalerRuleSetRefresh())
+            .thenReturn(CompletableFuture.completedFuture(Ack.getInstance()));
+        when(resourceClusters.getClusterFor(ClusterID.of(CLUSTER_ID))).thenReturn(resourceCluster);
+
         // test get empty cluster rule.
         testRoute.run(HttpRequest.GET(getResourceClusterScaleRulesEndpoint(CLUSTER_ID)))
             .assertStatusCode(StatusCodes.OK)
@@ -296,6 +303,8 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
                 Jackson.fromJSON(
                     ResourceClustersPayloads.RESOURCE_CLUSTER_SCALE_RULES_RESULT,
                     GetResourceClusterScaleRulesResponse.class));
+
+        verify(resourceCluster).requestClusterScalerRuleSetRefresh();
     }
 
     @Test

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -244,7 +244,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
     @Test
     public void testResourceClusterScaleRulesRoutes() throws IOException {
         ResourceCluster resourceCluster = mock(ResourceCluster.class);
-        when(resourceCluster.requestClusterScalerRuleSetRefresh())
+        when(resourceCluster.refreshClusterScalerRuleSet())
             .thenReturn(CompletableFuture.completedFuture(Ack.getInstance()));
         when(resourceClusters.getClusterFor(ClusterID.of(CLUSTER_ID))).thenReturn(resourceCluster);
 
@@ -254,7 +254,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
             .assertEntityAs(Jackson.unmarshaller(GetResourceClusterScaleRulesResponse.class),
                 GetResourceClusterScaleRulesResponse.builder()
                     .responseCode(ResponseCode.SUCCESS)
-                    .clusterId(CLUSTER_ID)
+                    .clusterId(ClusterID.of(CLUSTER_ID))
                     .rules(Collections.emptyList())
                     .build());
 
@@ -272,7 +272,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
             .assertEntityAs(Jackson.unmarshaller(GetResourceClusterScaleRulesResponse.class),
                 GetResourceClusterScaleRulesResponse.builder()
                     .responseCode(ResponseCode.SUCCESS)
-                    .clusterId(CLUSTER_ID)
+                    .clusterId(ClusterID.of(CLUSTER_ID))
                     .rules(createRuleReq1.getRules())
                     .build());
 
@@ -282,7 +282,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
             .assertEntityAs(Jackson.unmarshaller(GetResourceClusterScaleRulesResponse.class),
                 GetResourceClusterScaleRulesResponse.builder()
                     .responseCode(ResponseCode.SUCCESS)
-                    .clusterId(CLUSTER_ID)
+                    .clusterId(ClusterID.of(CLUSTER_ID))
                     .rules(createRuleReq1.getRules())
                     .build());
 
@@ -304,7 +304,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
                     ResourceClustersPayloads.RESOURCE_CLUSTER_SCALE_RULES_RESULT,
                     GetResourceClusterScaleRulesResponse.class));
 
-        verify(resourceCluster).requestClusterScalerRuleSetRefresh();
+        verify(resourceCluster).refreshClusterScalerRuleSet();
     }
 
     @Test

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -57,6 +57,7 @@ import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProvid
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterResponseHandler;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterStorageProviderAdapter;
 import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster;
@@ -119,7 +120,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
             "taskExecutorAddress",
             "hostName",
             new WorkerPorts(1, 2, 3, 4, 5),
-            new MachineDefinition(1, 1, 1, 1, 1));
+            MachineDefinitionWrapper.builder().machineDefinition(new MachineDefinition(1, 1, 1, 1, 1)).build());
         TaskExecutorStatus status =
             new TaskExecutorStatus(registration, true, true, true, null, Instant.now().toEpochMilli());
         ResourceCluster resourceCluster = mock(ResourceCluster.class);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -114,13 +114,18 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
 
     @Test
     public void testGetTaskExecutorState() {
-        TaskExecutorRegistration registration = new TaskExecutorRegistration(
-            TaskExecutorID.of("myExecutor"),
-            ClusterID.of("myCluster"),
-            "taskExecutorAddress",
-            "hostName",
-            new WorkerPorts(1, 2, 3, 4, 5),
-            MachineDefinitionWrapper.builder().machineDefinition(new MachineDefinition(1, 1, 1, 1, 1)).build());
+        TaskExecutorRegistration registration =
+            TaskExecutorRegistration.builder()
+                .taskExecutorID(TaskExecutorID.of("myExecutor"))
+                .clusterID(ClusterID.of("myCluster"))
+                .taskExecutorAddress("taskExecutorAddress")
+                .hostname("hostName")
+                .workerPorts(new WorkerPorts(1, 2, 3, 4, 5))
+                .machineDefinitionWrapper(MachineDefinitionWrapper.builder().machineDefinition(
+                    new MachineDefinition(1, 1, 1, 1, 1))
+                    .build())
+                .build();
+
         TaskExecutorStatus status =
             new TaskExecutorStatus(registration, true, true, true, null, Instant.now().toEpochMilli());
         ResourceCluster resourceCluster = mock(ResourceCluster.class);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -194,7 +194,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
                     .responseCode(ResponseCode.SUCCESS)
                     .registeredResourceClusters(
                         Arrays.asList(RegisteredResourceCluster.builder()
-                            .id(CLUSTER_ID).version("").build()))
+                            .id(ClusterID.of(CLUSTER_ID)).version("").build()))
                     .build());
 
         // test get registered cluster spec
@@ -310,7 +310,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
     @Test
     public void testResourceClusterUpgradeRoutes() throws IOException {
         UpgradeClusterContainersRequest createRuleReq1 = UpgradeClusterContainersRequest.builder()
-            .clusterId(CLUSTER_ID)
+            .clusterId(ClusterID.of(CLUSTER_ID))
             .region("us-east-1")
             .optionalBatchMaxSize(50)
             .optionalSkuId("large")

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -64,40 +64,48 @@ public class ResourceClusterActorTest {
     private static final String HOST_NAME = "hostname";
     private static final WorkerPorts WORKER_PORTS = new WorkerPorts(1, 2, 3, 4, 5);
     private static final MachineDefinitionWrapper MACHINE_DEFINITION =
-        MachineDefinitionWrapper.builder().machineDefinition(
-            new MachineDefinition(2f, 2014, 128.0, 1024, 1))
+        MachineDefinitionWrapper.builder()
+            .definitionId("small")
+            .machineDefinition(
+                new MachineDefinition(2f, 2014, 128.0, 1024, 1))
             .build();
 
     private static final MachineDefinitionWrapper MACHINE_DEFINITION_2 =
-        MachineDefinitionWrapper.builder().machineDefinition(
+        MachineDefinitionWrapper.builder()
+            .definitionId("medium")
+            .machineDefinition(
                 new MachineDefinition(4f, 4028, 128.0, 1024, 1))
             .build();
     private static final TaskExecutorRegistration TASK_EXECUTOR_REGISTRATION =
-        new TaskExecutorRegistration(
-            TASK_EXECUTOR_ID,
-            CLUSTER_ID,
-            TASK_EXECUTOR_ADDRESS,
-            HOST_NAME,
-            WORKER_PORTS,
-            MACHINE_DEFINITION);
+        TaskExecutorRegistration.builder()
+            .taskExecutorID(TASK_EXECUTOR_ID)
+            .clusterID(CLUSTER_ID)
+            .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+            .hostname(HOST_NAME)
+            .workerPorts(WORKER_PORTS)
+            .machineDefinitionWrapper(MACHINE_DEFINITION)
+            .build();
 
     private static final TaskExecutorRegistration TASK_EXECUTOR_REGISTRATION_2 =
-        new TaskExecutorRegistration(
-            TASK_EXECUTOR_ID_2,
-            CLUSTER_ID,
-            TASK_EXECUTOR_ADDRESS,
-            HOST_NAME,
-            WORKER_PORTS,
-            MACHINE_DEFINITION_2);
+        TaskExecutorRegistration.builder()
+            .taskExecutorID(TASK_EXECUTOR_ID_2)
+            .clusterID(CLUSTER_ID)
+            .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+            .hostname(HOST_NAME)
+            .workerPorts(WORKER_PORTS)
+            .machineDefinitionWrapper(MACHINE_DEFINITION_2)
+            .build();
 
     private static final TaskExecutorRegistration TASK_EXECUTOR_REGISTRATION_3 =
-        new TaskExecutorRegistration(
-            TASK_EXECUTOR_ID_3,
-            CLUSTER_ID,
-            TASK_EXECUTOR_ADDRESS,
-            HOST_NAME,
-            WORKER_PORTS,
-            MACHINE_DEFINITION_2);
+        TaskExecutorRegistration.builder()
+            .taskExecutorID(TASK_EXECUTOR_ID_3)
+            .clusterID(CLUSTER_ID)
+            .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+            .hostname(HOST_NAME)
+            .workerPorts(WORKER_PORTS)
+            .machineDefinitionWrapper(MACHINE_DEFINITION_2)
+            .build();
+
     private static final WorkerId WORKER_ID =
         WorkerId.fromIdUnsafe("late-sine-function-tutorial-1-worker-0-1");
 
@@ -232,14 +240,14 @@ public class ResourceClusterActorTest {
             GetClusterIdleInstancesRequest.builder()
                 .clusterID(CLUSTER_ID)
                 .maxInstanceCount(2)
-                .machineDefinition(MACHINE_DEFINITION_2.getMachineDefinition())
-                .skuId("sku1")
+                .machineDefinitionWrapper(MACHINE_DEFINITION_2)
+                .skuId("medium")
                 .build(),
             probe.getRef());
         GetClusterIdleInstancesResponse idleInstancesResponse =
             probe.expectMsgClass(GetClusterIdleInstancesResponse.class);
         assertEquals(ImmutableList.of(TASK_EXECUTOR_ID_3, TASK_EXECUTOR_ID_2), idleInstancesResponse.getInstanceIds());
-        assertEquals("sku1", idleInstancesResponse.getSkuId());
+        assertEquals("medium", idleInstancesResponse.getSkuId());
 
         assertEquals(
             TASK_EXECUTOR_ID_3,
@@ -263,7 +271,7 @@ public class ResourceClusterActorTest {
             GetClusterIdleInstancesRequest.builder()
                 .clusterID(CLUSTER_ID)
                 .maxInstanceCount(2)
-                .machineDefinition(MACHINE_DEFINITION_2.getMachineDefinition())
+                .machineDefinitionWrapper(MACHINE_DEFINITION_2)
                 .skuId("sku1")
                 .build(),
             probe.getRef());
@@ -288,7 +296,7 @@ public class ResourceClusterActorTest {
             GetClusterIdleInstancesRequest.builder()
                 .clusterID(CLUSTER_ID)
                 .maxInstanceCount(2)
-                .machineDefinition(MACHINE_DEFINITION.getMachineDefinition())
+                .machineDefinitionWrapper(MACHINE_DEFINITION)
                 .skuId("sku1")
                 .build(),
             probe.getRef());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -32,6 +32,7 @@ import io.mantisrx.master.resourcecluster.proto.GetClusterIdleInstancesResponse;
 import io.mantisrx.master.resourcecluster.proto.GetClusterUsageResponse;
 import io.mantisrx.master.resourcecluster.proto.GetClusterUsageResponse.UsageByMachineDefinition;
 import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.core.TestingRpcService;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.persistence.MantisJobStore;
@@ -62,11 +63,15 @@ public class ResourceClusterActorTest {
     private static final Duration assignmentTimeout = Duration.ofSeconds(1);
     private static final String HOST_NAME = "hostname";
     private static final WorkerPorts WORKER_PORTS = new WorkerPorts(1, 2, 3, 4, 5);
-    private static final MachineDefinition MACHINE_DEFINITION =
-        new MachineDefinition(2f, 2014, 128.0, 1024, 1);
+    private static final MachineDefinitionWrapper MACHINE_DEFINITION =
+        MachineDefinitionWrapper.builder().machineDefinition(
+            new MachineDefinition(2f, 2014, 128.0, 1024, 1))
+            .build();
 
-    private static final MachineDefinition MACHINE_DEFINITION_2 =
-        new MachineDefinition(4f, 4028, 128.0, 1024, 1);
+    private static final MachineDefinitionWrapper MACHINE_DEFINITION_2 =
+        MachineDefinitionWrapper.builder().machineDefinition(
+                new MachineDefinition(4f, 4028, 128.0, 1024, 1))
+            .build();
     private static final TaskExecutorRegistration TASK_EXECUTOR_REGISTRATION =
         new TaskExecutorRegistration(
             TASK_EXECUTOR_ID,
@@ -169,7 +174,9 @@ public class ResourceClusterActorTest {
                         TASK_EXECUTOR_ID,
                         CLUSTER_ID,
                         TaskExecutorReport.available())).get());
-        assertEquals(TASK_EXECUTOR_ID, resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION, WORKER_ID).get());
+        assertEquals(
+            TASK_EXECUTOR_ID,
+            resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION.getMachineDefinition(), WORKER_ID).get());
         assertEquals(ImmutableList.of(), resourceCluster.getAvailableTaskExecutors().get());
         assertEquals(ImmutableList.of(TASK_EXECUTOR_ID), resourceCluster.getRegisteredTaskExecutors().get());
     }
@@ -225,7 +232,7 @@ public class ResourceClusterActorTest {
             GetClusterIdleInstancesRequest.builder()
                 .clusterID(CLUSTER_ID)
                 .maxInstanceCount(2)
-                .machineDefinition(MACHINE_DEFINITION_2)
+                .machineDefinition(MACHINE_DEFINITION_2.getMachineDefinition())
                 .skuId("sku1")
                 .build(),
             probe.getRef());
@@ -234,7 +241,9 @@ public class ResourceClusterActorTest {
         assertEquals(ImmutableList.of(TASK_EXECUTOR_ID_3, TASK_EXECUTOR_ID_2), idleInstancesResponse.getInstanceIds());
         assertEquals("sku1", idleInstancesResponse.getSkuId());
 
-        assertEquals(TASK_EXECUTOR_ID_3, resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION_2, WORKER_ID).get());
+        assertEquals(
+            TASK_EXECUTOR_ID_3,
+            resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION_2.getMachineDefinition(), WORKER_ID).get());
 
         probe = new TestKit(actorSystem);
         resourceClusterActor.tell(new GetClusterUsageRequest(CLUSTER_ID), probe.getRef());
@@ -254,7 +263,7 @@ public class ResourceClusterActorTest {
             GetClusterIdleInstancesRequest.builder()
                 .clusterID(CLUSTER_ID)
                 .maxInstanceCount(2)
-                .machineDefinition(MACHINE_DEFINITION_2)
+                .machineDefinition(MACHINE_DEFINITION_2.getMachineDefinition())
                 .skuId("sku1")
                 .build(),
             probe.getRef());
@@ -263,7 +272,9 @@ public class ResourceClusterActorTest {
         assertEquals(ImmutableList.of(TASK_EXECUTOR_ID_2), idleInstancesResponse.getInstanceIds());
         assertEquals("sku1", idleInstancesResponse.getSkuId());
 
-        assertEquals(TASK_EXECUTOR_ID_2, resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION_2, WORKER_ID).get());
+        assertEquals(
+            TASK_EXECUTOR_ID_2,
+            resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION_2.getMachineDefinition(), WORKER_ID).get());
         probe = new TestKit(actorSystem);
         resourceClusterActor.tell(new GetClusterUsageRequest(CLUSTER_ID), probe.getRef());
         usageRes = probe.expectMsgClass(GetClusterUsageResponse.class);
@@ -277,7 +288,7 @@ public class ResourceClusterActorTest {
             GetClusterIdleInstancesRequest.builder()
                 .clusterID(CLUSTER_ID)
                 .maxInstanceCount(2)
-                .machineDefinition(MACHINE_DEFINITION)
+                .machineDefinition(MACHINE_DEFINITION.getMachineDefinition())
                 .skuId("sku1")
                 .build(),
             probe.getRef());
@@ -302,10 +313,14 @@ public class ResourceClusterActorTest {
                         TASK_EXECUTOR_ID,
                         CLUSTER_ID,
                         TaskExecutorReport.available())).get());
-        assertEquals(TASK_EXECUTOR_ID, resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION, WORKER_ID).get());
+        assertEquals(
+            TASK_EXECUTOR_ID,
+            resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION.getMachineDefinition(), WORKER_ID).get());
         assertEquals(ImmutableList.of(), resourceCluster.getAvailableTaskExecutors().get());
         Thread.sleep(2000);
         assertEquals(ImmutableList.of(TASK_EXECUTOR_ID), resourceCluster.getAvailableTaskExecutors().get());
-        assertEquals(TASK_EXECUTOR_ID, resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION, WORKER_ID).get());
+        assertEquals(
+            TASK_EXECUTOR_ID,
+            resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION.getMachineDefinition(), WORKER_ID).get());
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -219,7 +219,9 @@ public class ResourceClusterActorTest {
 
         // Test get cluster usage
         TestKit probe = new TestKit(actorSystem);
-        resourceClusterActor.tell(new GetClusterUsageRequest(CLUSTER_ID), probe.getRef());
+        resourceClusterActor.tell(new GetClusterUsageRequest(
+            CLUSTER_ID, ResourceClusterScalerActor.groupKeyFromTaskExecutorDefinitionIdFunc),
+            probe.getRef());
         GetClusterUsageResponse usageRes = probe.expectMsgClass(GetClusterUsageResponse.class);
         assertEquals(2, usageRes.getUsages().size());
         assertEquals(1, usageRes.getUsages().stream()
@@ -256,7 +258,9 @@ public class ResourceClusterActorTest {
             resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION_2, WORKER_ID).get());
 
         probe = new TestKit(actorSystem);
-        resourceClusterActor.tell(new GetClusterUsageRequest(CLUSTER_ID), probe.getRef());
+        resourceClusterActor.tell(new GetClusterUsageRequest(
+                CLUSTER_ID, ResourceClusterScalerActor.groupKeyFromTaskExecutorDefinitionIdFunc),
+            probe.getRef());
         usageRes = probe.expectMsgClass(GetClusterUsageResponse.class);
         usage1 =
             usageRes.getUsages().stream()
@@ -287,7 +291,10 @@ public class ResourceClusterActorTest {
             TASK_EXECUTOR_ID_2,
             resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION_2, WORKER_ID).get());
         probe = new TestKit(actorSystem);
-        resourceClusterActor.tell(new GetClusterUsageRequest(CLUSTER_ID), probe.getRef());
+        resourceClusterActor.tell(new GetClusterUsageRequest(
+                CLUSTER_ID, ResourceClusterScalerActor.groupKeyFromTaskExecutorDefinitionIdFunc),
+            probe.getRef());
+
         usageRes = probe.expectMsgClass(GetClusterUsageResponse.class);
         usage1 =
             usageRes.getUsages().stream()

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActorTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActorTests.java
@@ -58,7 +58,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.mockito.ArgumentMatchers;
 
 public class ResourceClusterScalerActorTests {
     private static final ClusterID CLUSTER_ID = ClusterID.of("clusterId");
@@ -95,7 +94,7 @@ public class ResourceClusterScalerActorTests {
         hostActorProbe = new TestKit(actorSystem);
         this.storageProvider = mock(ResourceClusterStorageProvider.class);
 
-        when(this.storageProvider.getResourceClusterScaleRules(CLUSTER_ID.getResourceID()))
+        when(this.storageProvider.getResourceClusterScaleRules(CLUSTER_ID))
             .thenReturn(CompletableFuture.completedFuture(
                 ResourceClusterScaleRulesWritable.builder()
                     .scaleRule(skuSmall, ResourceClusterScaleSpec.builder()
@@ -215,7 +214,7 @@ public class ResourceClusterScalerActorTests {
         GetRuleSetResponse rules = clusterActorProbe.expectMsgClass(GetRuleSetResponse.class);
         assertEquals(2, rules.getRules().size());
 
-        when(this.storageProvider.getResourceClusterScaleRules(ArgumentMatchers.anyString()))
+        when(this.storageProvider.getResourceClusterScaleRules(CLUSTER_ID))
             .thenReturn(CompletableFuture.completedFuture(
                 ResourceClusterScaleRulesWritable.builder()
                     .scaleRule(skuMedium, ResourceClusterScaleSpec.builder()

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActorTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActorTests.java
@@ -277,6 +277,19 @@ public class ResourceClusterScalerActorTests {
     }
 
     @Test
+    public void testScaleResourceRequestToRequestName() {
+
+        ScaleResourceRequest r1 =
+            ScaleResourceRequest.builder()
+                .idleInstance(TaskExecutorID.of("t1"))
+                .clusterId(CLUSTER_ID)
+                .skuId(skuLarge)
+                .build();
+
+        assertEquals("clusterId---large-0", r1.getScaleRequestId());
+    }
+
+    @Test
     public void testRuleFinishCoolDown() throws InterruptedException {
         String skuId = "small";
         ClusterAvailabilityRule rule = new ClusterAvailabilityRule(

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActorTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActorTests.java
@@ -99,7 +99,7 @@ public class ResourceClusterScalerActorTests {
         hostActorProbe = new TestKit(actorSystem);
         this.storageProvider = mock(ResourceClusterStorageProvider.class);
 
-        when(this.storageProvider.getResourceClusterScaleRules(ArgumentMatchers.anyString()))
+        when(this.storageProvider.getResourceClusterScaleRules(CLUSTER_ID.getResourceID()))
             .thenReturn(CompletableFuture.completedFuture(
                 ResourceClusterScaleRulesWritable.builder()
                     .scaleRule(skuSmall, ResourceClusterScaleSpec.builder()

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActorTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActorTests.java
@@ -156,7 +156,7 @@ public class ResourceClusterScalerActorTests {
         assertEquals(
             GetClusterIdleInstancesRequest.builder()
                 .skuId(skuLarge)
-                .machineDefinition(MACHINE_DEFINITION_L.getMachineDefinition())
+                .machineDefinitionWrapper(MACHINE_DEFINITION_L)
                 .clusterID(CLUSTER_ID)
                 .desireSize(15)
                 .maxInstanceCount(1)

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActorTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActorTests.java
@@ -44,6 +44,8 @@ import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProvider;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterResponseHandler;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterStorageProvider;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -238,7 +240,7 @@ public class ResourceClustersHostManagerActorTests {
             ResourceClustersHostManagerActor.props(resProvider, resStorageProvider));
 
         UpgradeClusterContainersRequest request = UpgradeClusterContainersRequest.builder()
-            .clusterId("mantisTestResCluster1")
+            .clusterId(ClusterID.of("mantisTestResCluster1"))
             .build();
 
         resourceClusterActor.tell(request, probe.getRef());
@@ -256,17 +258,17 @@ public class ResourceClustersHostManagerActorTests {
 
     private ProvisionResourceClusterRequest buildProvisionRequest(String id, String user) {
         ProvisionResourceClusterRequest request = ProvisionResourceClusterRequest.builder()
-                .clusterId(id)
+                .clusterId(ClusterID.of(id))
                 .clusterSpec(MantisResourceClusterSpec.builder()
-                        .id(id)
+                        .id(ClusterID.of(id))
                         .name(id)
                         .envType(MantisResourceClusterEnvType.Prod)
                         .ownerEmail(user)
                         .ownerName(user)
                         .skuSpec(MantisResourceClusterSpec.SkuTypeSpec.builder()
-                                .skuId("small")
+                                .skuId(ContainerSkuID.of("small"))
                                 .capacity(MantisResourceClusterSpec.SkuCapacity.builder()
-                                        .skuId("small")
+                                        .skuId(ContainerSkuID.of("small"))
                                         .desireSize(2)
                                         .maxSize(3)
                                         .minSize(1)

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
@@ -29,6 +29,7 @@ import io.mantisrx.master.resourcecluster.resourceprovider.SimpleFileResourceClu
 import io.mantisrx.master.resourcecluster.writable.RegisteredResourceClustersWritable;
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterScaleRulesWritable;
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterSpecWritable;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -58,11 +59,11 @@ public class SimpleFileResourceStorageProviderTests {
 
     @Test
     public void testResourceClusterRules() throws ExecutionException, InterruptedException, IOException {
-        final String clusterId = "mantisRCMTest2";
+        final ClusterID clusterId = ClusterID.of("mantisRCMTest2");
         SimpleFileResourceClusterStorageProvider prov = new SimpleFileResourceClusterStorageProvider(system);
 
         ResourceClusterScaleSpec rule1 = ResourceClusterScaleSpec.builder()
-            .clusterId(clusterId)
+            .clusterId(clusterId.getResourceID())
             .skuId("small")
             .coolDownSecs(5)
             .maxIdleToKeep(10)
@@ -76,11 +77,11 @@ public class SimpleFileResourceStorageProviderTests {
         CompletionStage<ResourceClusterScaleRulesWritable> rulesFut = prov.getResourceClusterScaleRules(clusterId);
         ResourceClusterScaleRulesWritable rules = rulesFut.toCompletableFuture().get();
         assertEquals(1, rules.getScaleRules().size());
-        assertEquals(clusterId, rules.getClusterId());
+        assertEquals(clusterId.getResourceID(), rules.getClusterId());
         assertEquals(rule1, rules.getScaleRules().get("small"));
 
         ResourceClusterScaleSpec rule2 = ResourceClusterScaleSpec.builder()
-            .clusterId(clusterId)
+            .clusterId(clusterId.getResourceID())
             .skuId("large")
             .coolDownSecs(9)
             .maxIdleToKeep(99)
@@ -94,12 +95,12 @@ public class SimpleFileResourceStorageProviderTests {
         CompletionStage<ResourceClusterScaleRulesWritable> rulesFut2 = prov.getResourceClusterScaleRules(clusterId);
         rules = rulesFut2.toCompletableFuture().get();
         assertEquals(2, rules.getScaleRules().size());
-        assertEquals(clusterId, rules.getClusterId());
+        assertEquals(clusterId.getResourceID(), rules.getClusterId());
         assertEquals(rule1, rules.getScaleRules().get("small"));
         assertEquals(rule2, rules.getScaleRules().get("large"));
 
         ResourceClusterScaleSpec rule3 = ResourceClusterScaleSpec.builder()
-            .clusterId(clusterId)
+            .clusterId(clusterId.getResourceID())
             .skuId("small")
             .coolDownSecs(999)
             .maxIdleToKeep(123)
@@ -113,7 +114,7 @@ public class SimpleFileResourceStorageProviderTests {
         CompletionStage<ResourceClusterScaleRulesWritable> rulesFut3 = prov.getResourceClusterScaleRules(clusterId);
         rules = rulesFut3.toCompletableFuture().get();
         assertEquals(2, rules.getScaleRules().size());
-        assertEquals(clusterId, rules.getClusterId());
+        assertEquals(clusterId.getResourceID(), rules.getClusterId());
         assertEquals(rule3, rules.getScaleRules().get("small"));
         assertEquals(rule2, rules.getScaleRules().get("large"));
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
@@ -126,15 +126,15 @@ public class SimpleFileResourceStorageProviderTests {
         final String clusterId = "mantisRCMTest2";
 
         MantisResourceClusterSpec spec = MantisResourceClusterSpec.builder()
-                .id(clusterId)
+                .id(ClusterID.of(clusterId))
                 .name(clusterId)
                 .envType(MantisResourceClusterEnvType.Prod)
                 .ownerEmail("andyz@netflix.com")
                 .ownerName("andyz@netflix.com")
                 .skuSpec(MantisResourceClusterSpec.SkuTypeSpec.builder()
-                        .skuId("small")
+                        .skuId(ContainerSkuID.of("small"))
                         .capacity(MantisResourceClusterSpec.SkuCapacity.builder()
-                                .skuId("small")
+                                .skuId(ContainerSkuID.of("small"))
                                 .desireSize(2)
                                 .maxSize(3)
                                 .minSize(1)
@@ -172,13 +172,15 @@ public class SimpleFileResourceStorageProviderTests {
 
         System.out.println(Files.readAllLines(clusterFilePath).stream().collect(Collectors.joining()));
 
-        assertEquals("{\"clusters\":{\"mantisRCMTest2\":{\"clusterId\":\"mantisRCMTest2\",\"version\":\"v1\"}}}",
+        assertEquals("{\"clusters\":{\"mantisRCMTest2\":{\"clusterId\":{\"resourceID\":\"mantisRCMTest2\"},"
+                + "\"version\":\"v1\"}}}",
                 Files.readAllLines(regFilePath).stream().collect(Collectors.joining()));
 
         assertEquals(
-                "{\"version\":\"v1\",\"id\":\"mantisRCMTest2\",\"clusterSpec\":{\"name\":\"mantisRCMTest2\"," +
-                        "\"id\":\"mantisRCMTest2\",\"ownerName\":\"andyz@netflix.com\",\"ownerEmail\":\"andyz@netflix.com\"," +
-                        "\"envType\":\"Prod\",\"skuSpecs\":[{\"skuId\":\"small\",\"capacity\":{\"skuId\":\"small\"," +
+                "{\"version\":\"v1\",\"id\":{\"resourceID\":\"mantisRCMTest2\"},\"clusterSpec\":{\"name\":\"mantisRCMTest2\"," +
+                        "\"id\":{\"resourceID\":\"mantisRCMTest2\"},\"ownerName\":\"andyz@netflix.com\",\"ownerEmail\":\"andyz@netflix.com\"," +
+                        "\"envType\":\"Prod\",\"skuSpecs\":[{\"skuId\":{\"resourceID\":\"small\"},"
+                    + "\"capacity\":{\"skuId\":{\"resourceID\":\"small\"}," +
                         "\"minSize\":1,\"maxSize\":3,\"desireSize\":2},\"imageId\":\"mantistaskexecutor:main"
                         + ".latest\"," +
                         "\"cpuCoreCount\":5,\"memorySizeInBytes\":16384,\"networkMbps\":700,\"diskSizeInBytes\":81920," +
@@ -190,15 +192,15 @@ public class SimpleFileResourceStorageProviderTests {
         //// Test register second cluster.
         String clusterId2 = "clusterApp2";
         MantisResourceClusterSpec spec2 = MantisResourceClusterSpec.builder()
-                .id(clusterId2)
+                .id(ClusterID.of(clusterId2))
                 .name(clusterId2)
                 .envType(MantisResourceClusterEnvType.Prod)
                 .ownerEmail("mantisrx@netflix.com")
                 .ownerName("mantisrx@netflix.com")
                 .skuSpec(MantisResourceClusterSpec.SkuTypeSpec.builder()
-                        .skuId("large")
+                        .skuId(ContainerSkuID.of("large"))
                         .capacity(MantisResourceClusterSpec.SkuCapacity.builder()
-                                .skuId("large")
+                                .skuId(ContainerSkuID.of("large"))
                                 .desireSize(3)
                                 .maxSize(4)
                                 .minSize(1)
@@ -231,15 +233,17 @@ public class SimpleFileResourceStorageProviderTests {
         assertTrue(Files.exists(clusterFilePath2));
 
         assertEquals(
-                "{\"clusters\":{\"mantisRCMTest2\":{\"clusterId\":\"mantisRCMTest2\",\"version\":\"v1\"},"
-                        + "\"clusterApp2\":{\"clusterId\":\"clusterApp2\",\"version\":\"v2\"}}}",
+                "{\"clusters\":{\"mantisRCMTest2\":{\"clusterId\":{\"resourceID\":\"mantisRCMTest2\"},\"version\":\"v1\"},"
+                        + "\"clusterApp2\":{\"clusterId\":{\"resourceID\":\"clusterApp2\"},\"version\":\"v2\"}}}",
                 Files.readAllLines(regFilePath).stream().collect(Collectors.joining()));
 
         assertEquals(
-                "{\"version\":\"v2\",\"id\":\"clusterApp2\",\"clusterSpec\":{\"name\":\"clusterApp2\","
-                        + "\"id\":\"clusterApp2\",\"ownerName\":\"mantisrx@netflix.com\",\"ownerEmail\":"
-                        + "\"mantisrx@netflix.com\",\"envType\":\"Prod\",\"skuSpecs\":[{\"skuId\":\"large\","
-                        + "\"capacity\":{\"skuId\":\"large\",\"minSize\":1,\"maxSize\":4,\"desireSize\":3},\"imageId\""
+                "{\"version\":\"v2\",\"id\":{\"resourceID\":\"clusterApp2\"},\"clusterSpec\":{\"name\":\"clusterApp2\","
+                        + "\"id\":{\"resourceID\":\"clusterApp2\"},\"ownerName\":\"mantisrx@netflix.com\",\"ownerEmail\":"
+                        + "\"mantisrx@netflix.com\",\"envType\":\"Prod\","
+                    + "\"skuSpecs\":[{\"skuId\":{\"resourceID\":\"large\"},"
+                        + "\"capacity\":{\"skuId\":{\"resourceID\":\"large\"},\"minSize\":1,\"maxSize\":4,"
+                    + "\"desireSize\":3},\"imageId\""
                         + ":\"dev/mantistaskexecutor:main.2\",\"cpuCoreCount\":19,\"memorySizeInBytes\":54321,"
                         + "\"networkMbps\":3300,\"diskSizeInBytes\":998877,\"skuMetadataFields\":"
                         + "{\"skuKey\":\"us-east-1\",\"sgKey\":\"sg-1, sg-2, sg-3, sg-4\"}}],"
@@ -250,13 +254,13 @@ public class SimpleFileResourceStorageProviderTests {
                 .toCompletableFuture().get();
         assertEquals(2, clusters.getClusters().size());
 
-        assertTrue(clusters.getClusters().containsKey(spec.getId()));
-        assertEquals(spec.getId(), clusters.getClusters().get(spec.getId()).getClusterId());
-        assertEquals(specWritable.getVersion(), clusters.getClusters().get(spec.getId()).getVersion());
+        assertTrue(clusters.getClusters().containsKey(spec.getId().getResourceID()));
+        assertEquals(spec.getId(), clusters.getClusters().get(spec.getId().getResourceID()).getClusterId());
+        assertEquals(specWritable.getVersion(), clusters.getClusters().get(spec.getId().getResourceID()).getVersion());
 
-        assertTrue(clusters.getClusters().containsKey(spec2.getId()));
-        assertEquals(spec2.getId(), clusters.getClusters().get(spec2.getId()).getClusterId());
-        assertEquals(specWritable2.getVersion(), clusters.getClusters().get(spec2.getId()).getVersion());
+        assertTrue(clusters.getClusters().containsKey(spec2.getId().getResourceID()));
+        assertEquals(spec2.getId(), clusters.getClusters().get(spec2.getId().getResourceID()).getClusterId());
+        assertEquals(specWritable2.getVersion(), clusters.getClusters().get(spec2.getId().getResourceID()).getVersion());
 
         CompletionStage<ResourceClusterSpecWritable> clusterSpecFut1 =
                 prov.getResourceClusterSpecWritable(spec.getId());
@@ -270,7 +274,8 @@ public class SimpleFileResourceStorageProviderTests {
 
         assertEquals(specWritable2, specResp2);
 
-        CompletionStage<RegisteredResourceClustersWritable> deregisterFut = prov.deregisterCluster(clusterId2);
+        CompletionStage<RegisteredResourceClustersWritable> deregisterFut =
+            prov.deregisterCluster(ClusterID.of(clusterId2));
         RegisteredResourceClustersWritable resClusters = deregisterFut.toCompletableFuture().get();
 
         assertEquals(1, resClusters.getClusters().size());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
@@ -30,6 +30,7 @@ import io.mantisrx.master.resourcecluster.writable.RegisteredResourceClustersWri
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterScaleRulesWritable;
 import io.mantisrx.master.resourcecluster.writable.ResourceClusterSpecWritable;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -60,11 +61,12 @@ public class SimpleFileResourceStorageProviderTests {
     @Test
     public void testResourceClusterRules() throws ExecutionException, InterruptedException, IOException {
         final ClusterID clusterId = ClusterID.of("mantisRCMTest2");
+        final ContainerSkuID smallSkuId = ContainerSkuID.of("small");
         SimpleFileResourceClusterStorageProvider prov = new SimpleFileResourceClusterStorageProvider(system);
 
         ResourceClusterScaleSpec rule1 = ResourceClusterScaleSpec.builder()
-            .clusterId(clusterId.getResourceID())
-            .skuId("small")
+            .clusterId(clusterId)
+            .skuId(smallSkuId)
             .coolDownSecs(5)
             .maxIdleToKeep(10)
             .minIdleToKeep(5)
@@ -77,12 +79,12 @@ public class SimpleFileResourceStorageProviderTests {
         CompletionStage<ResourceClusterScaleRulesWritable> rulesFut = prov.getResourceClusterScaleRules(clusterId);
         ResourceClusterScaleRulesWritable rules = rulesFut.toCompletableFuture().get();
         assertEquals(1, rules.getScaleRules().size());
-        assertEquals(clusterId.getResourceID(), rules.getClusterId());
-        assertEquals(rule1, rules.getScaleRules().get("small"));
+        assertEquals(clusterId, rules.getClusterId());
+        assertEquals(rule1, rules.getScaleRules().get(smallSkuId.getResourceID()));
 
         ResourceClusterScaleSpec rule2 = ResourceClusterScaleSpec.builder()
-            .clusterId(clusterId.getResourceID())
-            .skuId("large")
+            .clusterId(clusterId)
+            .skuId(ContainerSkuID.of("large"))
             .coolDownSecs(9)
             .maxIdleToKeep(99)
             .minIdleToKeep(5)
@@ -95,13 +97,13 @@ public class SimpleFileResourceStorageProviderTests {
         CompletionStage<ResourceClusterScaleRulesWritable> rulesFut2 = prov.getResourceClusterScaleRules(clusterId);
         rules = rulesFut2.toCompletableFuture().get();
         assertEquals(2, rules.getScaleRules().size());
-        assertEquals(clusterId.getResourceID(), rules.getClusterId());
-        assertEquals(rule1, rules.getScaleRules().get("small"));
+        assertEquals(clusterId, rules.getClusterId());
+        assertEquals(rule1, rules.getScaleRules().get(smallSkuId.getResourceID()));
         assertEquals(rule2, rules.getScaleRules().get("large"));
 
         ResourceClusterScaleSpec rule3 = ResourceClusterScaleSpec.builder()
-            .clusterId(clusterId.getResourceID())
-            .skuId("small")
+            .clusterId(clusterId)
+            .skuId(smallSkuId)
             .coolDownSecs(999)
             .maxIdleToKeep(123)
             .minIdleToKeep(2)
@@ -114,8 +116,8 @@ public class SimpleFileResourceStorageProviderTests {
         CompletionStage<ResourceClusterScaleRulesWritable> rulesFut3 = prov.getResourceClusterScaleRules(clusterId);
         rules = rulesFut3.toCompletableFuture().get();
         assertEquals(2, rules.getScaleRules().size());
-        assertEquals(clusterId.getResourceID(), rules.getClusterId());
-        assertEquals(rule3, rules.getScaleRules().get("small"));
+        assertEquals(clusterId, rules.getClusterId());
+        assertEquals(rule3, rules.getScaleRules().get(smallSkuId.getResourceID()));
         assertEquals(rule2, rules.getScaleRules().get("large"));
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
@@ -25,7 +25,6 @@ import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.common.util.DelegateClock;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorState;
 import io.mantisrx.runtime.MachineDefinition;
-import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.core.TestingRpcService;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
@@ -60,10 +59,8 @@ public class TaskExecutorStateTest {
     private static final String TASK_EXECUTOR_ADDRESS = "127.0.0.1";
     private static final String HOST_NAME = "hostName";
     private static final WorkerPorts WORKER_PORTS = new WorkerPorts(ImmutableList.of(1, 2, 3, 4, 5));
-    private static final MachineDefinitionWrapper MACHINE_DEFINITION =
-        MachineDefinitionWrapper.builder().machineDefinition(
-            new MachineDefinition(1.0, 2.0, 3.0, 4.0, 5))
-            .build();
+    private static final MachineDefinition MACHINE_DEFINITION =
+            new MachineDefinition(1.0, 2.0, 3.0, 4.0, 5);
     private static final WorkerId WORKER_ID = WorkerId.fromIdUnsafe("late-sine-function-tutorial-1-worker-0-1");
 
     @Before
@@ -82,7 +79,7 @@ public class TaskExecutorStateTest {
                 .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
                 .hostname(HOST_NAME)
                 .workerPorts(WORKER_PORTS)
-                .machineDefinitionWrapper(MACHINE_DEFINITION)
+                .machineDefinition(MACHINE_DEFINITION)
                 .build()));
         assertTrue(state.isRegistered());
         assertFalse(state.isDisconnected());
@@ -137,7 +134,7 @@ public class TaskExecutorStateTest {
             .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
             .hostname(HOST_NAME)
             .workerPorts(WORKER_PORTS)
-            .machineDefinitionWrapper(MACHINE_DEFINITION)
+            .machineDefinition(MACHINE_DEFINITION)
             .build()));
         assertTrue(state.isRegistered());
         assertFalse(state.isDisconnected());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
@@ -75,7 +75,15 @@ public class TaskExecutorStateTest {
     public void testRegularLifecycle() {
         Instant currentTime;
         // Registration
-        assertTrue(state.onRegistration(new TaskExecutorRegistration(TASK_EXECUTOR_ID, CLUSTER_ID, TASK_EXECUTOR_ADDRESS, HOST_NAME, WORKER_PORTS, MACHINE_DEFINITION)));
+        assertTrue(state.onRegistration(
+            TaskExecutorRegistration.builder()
+                .taskExecutorID(TASK_EXECUTOR_ID)
+                .clusterID(CLUSTER_ID)
+                .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+                .hostname(HOST_NAME)
+                .workerPorts(WORKER_PORTS)
+                .machineDefinitionWrapper(MACHINE_DEFINITION)
+                .build()));
         assertTrue(state.isRegistered());
         assertFalse(state.isDisconnected());
 
@@ -123,7 +131,14 @@ public class TaskExecutorStateTest {
     public void testInitializationLifecycle() {
         Instant currentTime;
         // Registration
-        assertTrue(state.onRegistration(new TaskExecutorRegistration(TASK_EXECUTOR_ID, CLUSTER_ID, TASK_EXECUTOR_ADDRESS, HOST_NAME, WORKER_PORTS, MACHINE_DEFINITION)));
+        assertTrue(state.onRegistration(TaskExecutorRegistration.builder()
+            .taskExecutorID(TASK_EXECUTOR_ID)
+            .clusterID(CLUSTER_ID)
+            .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+            .hostname(HOST_NAME)
+            .workerPorts(WORKER_PORTS)
+            .machineDefinitionWrapper(MACHINE_DEFINITION)
+            .build()));
         assertTrue(state.isRegistered());
         assertFalse(state.isDisconnected());
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
@@ -61,7 +61,7 @@ public class TaskExecutorStateTest {
     private static final String HOST_NAME = "hostName";
     private static final WorkerPorts WORKER_PORTS = new WorkerPorts(ImmutableList.of(1, 2, 3, 4, 5));
     private static final MachineDefinition MACHINE_DEFINITION =
-            new MachineDefinition(1.0, 2.0, 3.0, 4.0, 5);
+        new MachineDefinition(1.0, 2.0, 3.0, 4.0, 5);
     private static final WorkerId WORKER_ID = WorkerId.fromIdUnsafe("late-sine-function-tutorial-1-worker-0-1");
 
     @Before

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
@@ -25,6 +25,7 @@ import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.common.util.DelegateClock;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorState;
 import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.core.TestingRpcService;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
@@ -59,8 +60,10 @@ public class TaskExecutorStateTest {
     private static final String TASK_EXECUTOR_ADDRESS = "127.0.0.1";
     private static final String HOST_NAME = "hostName";
     private static final WorkerPorts WORKER_PORTS = new WorkerPorts(ImmutableList.of(1, 2, 3, 4, 5));
-    private static final MachineDefinition MACHINE_DEFINITION =
-        new MachineDefinition(1.0, 2.0, 3.0, 4.0, 5);
+    private static final MachineDefinitionWrapper MACHINE_DEFINITION =
+        MachineDefinitionWrapper.builder().machineDefinition(
+            new MachineDefinition(1.0, 2.0, 3.0, 4.0, 5))
+            .build();
     private static final WorkerId WORKER_ID = WorkerId.fromIdUnsafe("late-sine-function-tutorial-1-worker-0-1");
 
     @Before

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
@@ -35,6 +35,7 @@ import io.mantisrx.server.master.resourcecluster.TaskExecutorReport;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorStatusChange;
 import io.mantisrx.server.worker.TaskExecutorGateway;
 import io.mantisrx.shaded.com.google.common.collect.ImmutableList;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -80,6 +81,7 @@ public class TaskExecutorStateTest {
                 .hostname(HOST_NAME)
                 .workerPorts(WORKER_PORTS)
                 .machineDefinition(MACHINE_DEFINITION)
+                .taskExecutorAttributes(ImmutableMap.of())
                 .build()));
         assertTrue(state.isRegistered());
         assertFalse(state.isDisconnected());
@@ -135,6 +137,7 @@ public class TaskExecutorStateTest {
             .hostname(HOST_NAME)
             .workerPorts(WORKER_PORTS)
             .machineDefinition(MACHINE_DEFINITION)
+            .taskExecutorAttributes(ImmutableMap.of())
             .build()));
         assertTrue(state.isRegistered());
         assertFalse(state.isDisconnected());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterCreate.json
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterCreate.json
@@ -1,16 +1,16 @@
 {
-    "clusterId": "mantisResourceClusterUT1",
+    "clusterId": {"resourceID": "mantisResourceClusterUT1"},
     "clusterSpec": {
         "name": "mantisResourceClusterUT1",
-        "id": "mantisResourceClusterUT1",
+        "id": {"resourceID": "mantisResourceClusterUT1"},
         "ownerName": "mantisrx@netflix.com",
         "ownerEmail": "mantisrx@netflix.com",
         "envType": "Prod",
         "skuSpecs": [
             {
-                "skuId": "small",
+                "skuId": {"resourceID": "small"},
                 "capacity": {
-                    "skuId": "small",
+                    "skuId": {"resourceID": "small"},
                     "minSize": 1,
                     "maxSize": 3,
                     "desireSize": 2

--- a/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterScaleResult.json
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterScaleResult.json
@@ -1,6 +1,6 @@
 {
-    "clusterId": "mantisResourceClusterUT1",
-    "skuId": "small",
+    "clusterId": {"resourceID": "mantisResourceClusterUT1"},
+    "skuId": {"resourceID": "small"},
     "region": "us-east-1",
     "envType": "Prod",
     "desireSize": 11,

--- a/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterScaleRuleCreate.json
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterScaleRuleCreate.json
@@ -1,9 +1,9 @@
 {
-    "clusterId": "mantisResourceClusterUT1",
+    "clusterId": {"resourceID": "mantisResourceClusterUT1"},
     "rule":
     {
-        "clusterId": "mantisResourceClusterUT1",
-        "skuId": "small",
+        "clusterId": {"resourceID": "mantisResourceClusterUT1"},
+        "skuId": {"resourceID": "small"},
         "minIdleToKeep": 1,
         "minSize": 1,
         "maxIdleToKeep": 1,

--- a/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterScaleRulesCreate.json
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterScaleRulesCreate.json
@@ -1,9 +1,9 @@
 {
-    "clusterId": "mantisResourceClusterUT1",
+    "clusterId": {"resourceID": "mantisResourceClusterUT1"},
     "rules": [
         {
-            "clusterId": "mantisResourceClusterUT1",
-            "skuId": "small",
+            "clusterId": {"resourceID": "mantisResourceClusterUT1"},
+            "skuId": {"resourceID": "small"},
             "minIdleToKeep": 10,
             "minSize": 10,
             "maxIdleToKeep": 20,
@@ -11,8 +11,8 @@
             "coolDownSecs": 30
         },
         {
-            "clusterId": "mantisResourceClusterUT1",
-            "skuId": "large",
+            "clusterId": {"resourceID": "mantisResourceClusterUT1"},
+            "skuId": {"resourceID": "large"},
             "minIdleToKeep": 5,
             "minSize": 2,
             "maxIdleToKeep": 10,

--- a/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterScaleRulesResult.json
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/resources/testpayloads/ResourceClusterScaleRulesResult.json
@@ -1,10 +1,10 @@
 {
-    "clusterId": "mantisResourceClusterUT1",
+    "clusterId": {"resourceID": "mantisResourceClusterUT1"},
     "responseCode": "SUCCESS",
     "rules": [
         {
-            "clusterId": "mantisResourceClusterUT1",
-            "skuId": "small",
+            "clusterId": {"resourceID": "mantisResourceClusterUT1"},
+            "skuId": {"resourceID": "small"},
             "minIdleToKeep": 1,
             "minSize": 1,
             "maxIdleToKeep": 1,
@@ -12,8 +12,8 @@
             "coolDownSecs": 90
         },
         {
-            "clusterId": "mantisResourceClusterUT1",
-            "skuId": "large",
+            "clusterId": {"resourceID": "mantisResourceClusterUT1"},
+            "skuId": {"resourceID": "large"},
             "minIdleToKeep": 5,
             "minSize": 2,
             "maxIdleToKeep": 10,

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MachineDefinitionUtils.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MachineDefinitionUtils.java
@@ -17,7 +17,6 @@ package io.mantisrx.server.worker;
 
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.runtime.MachineDefinition;
-import io.mantisrx.runtime.MachineDefinitionWrapper;
 
 public class MachineDefinitionUtils {
     public static MachineDefinition sys(WorkerPorts workerPorts, double networkBandwidthInMB) {
@@ -27,12 +26,5 @@ public class MachineDefinitionUtils {
             networkBandwidthInMB,
             Hardware.getSizeOfDisk(),
             workerPorts.getNumberOfPorts());
-    }
-
-    public static MachineDefinitionWrapper wrap(MachineDefinition mDef) {
-        return MachineDefinitionWrapper.builder()
-            .machineDefinition(mDef)
-            .definitionId(System.getenv(MachineDefinitionWrapper.MachineDefinitionIdKey))
-            .build();
     }
 }

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MachineDefinitionUtils.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MachineDefinitionUtils.java
@@ -17,6 +17,7 @@ package io.mantisrx.server.worker;
 
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.MachineDefinitionWrapper;
 
 public class MachineDefinitionUtils {
     public static MachineDefinition sys(WorkerPorts workerPorts, double networkBandwidthInMB) {
@@ -26,5 +27,12 @@ public class MachineDefinitionUtils {
             networkBandwidthInMB,
             Hardware.getSizeOfDisk(),
             workerPorts.getNumberOfPorts());
+    }
+
+    public static MachineDefinitionWrapper wrap(MachineDefinition mDef) {
+        return MachineDefinitionWrapper.builder()
+            .machineDefinition(mDef)
+            .definitionId(System.getenv(MachineDefinitionWrapper.MachineDefinitionIdKey))
+            .build();
     }
 }

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskAttributeUtils.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskAttributeUtils.java
@@ -1,0 +1,2 @@
+package io.mantisrx.server.worker;public class TaskAttributeUtils {
+}

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskAttributeUtils.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskAttributeUtils.java
@@ -1,2 +1,44 @@
-package io.mantisrx.server.worker;public class TaskAttributeUtils {
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.worker;
+
+import io.mantisrx.common.WorkerConstants;
+import io.mantisrx.shaded.com.google.common.base.Splitter;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+public class TaskAttributeUtils {
+    public static Map<String, String> getTaskExecutorAttributes(String input) {
+        if (input == null || input.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        return Splitter.on(",").withKeyValueSeparator(':').split(input);
+    }
+
+    /**
+     * Convert system env attribute (e.g. "k1:v1,k2:v2") to map.
+     */
+    public static Map<String, String> getTaskExecutorAttributes() {
+        String envStr = System.getenv(WorkerConstants.WORKER_TASK_ATTRIBUTE_ENV_KEY);
+        if (envStr == null || envStr.isEmpty()) {
+            return ImmutableMap.of();
+        }
+
+        return getTaskExecutorAttributes(envStr);
+    }
 }

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
@@ -136,6 +136,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                 .taskExecutorAddress(getAddress())
                 .workerPorts(workerPorts)
                 .build();
+        log.info("Starting executor registration: {}", this.taskExecutorRegistration);
+
         this.ioExecutor =
             Executors.newFixedThreadPool(
                 Hardware.getNumberCPUCores(),

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
@@ -130,9 +130,10 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         MachineDefinition machineDefinition =
             MachineDefinitionUtils.sys(workerPorts, workerConfiguration.getNetworkBandwidthInMB());
         String hostName = workerConfiguration.getExternalAddress();
-        Map<String, String> envMap = new HashMap<>(System.getenv());
+
+        Map<String, String> attributeMap = new HashMap<>(TaskAttributeUtils.getTaskExecutorAttributes());
         // Adding a default id for back-compat support.
-        envMap.putIfAbsent(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID, "defaultContainerId");
+        attributeMap.putIfAbsent(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID, "defaultContainerId");
 
         this.taskExecutorRegistration =
             TaskExecutorRegistration.builder()
@@ -142,7 +143,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                 .hostname(hostName)
                 .taskExecutorAddress(getAddress())
                 .workerPorts(workerPorts)
-                .taskExecutorAttributes(ImmutableMap.copyOf(envMap))
+                .taskExecutorAttributes(ImmutableMap.copyOf(attributeMap))
                 .build();
         log.info("Starting executor registration: {}", this.taskExecutorRegistration);
 

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
@@ -126,9 +126,11 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         MachineDefinition machineDefinition =
             MachineDefinitionUtils.sys(workerPorts, workerConfiguration.getNetworkBandwidthInMB());
         String hostName = workerConfiguration.getExternalAddress();
+
         this.taskExecutorRegistration =
             new TaskExecutorRegistration(
-                taskExecutorID, clusterID, getAddress(), hostName, workerPorts, machineDefinition);
+                taskExecutorID, clusterID, getAddress(), hostName, workerPorts,
+                MachineDefinitionUtils.wrap(machineDefinition));
         this.ioExecutor =
             Executors.newFixedThreadPool(
                 Hardware.getNumberCPUCores(),

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
@@ -19,6 +19,7 @@ import com.mantisrx.common.utils.ListenerCallQueue;
 import com.mantisrx.common.utils.Services;
 import com.spotify.futures.CompletableFutures;
 import io.mantisrx.common.Ack;
+import io.mantisrx.common.WorkerConstants;
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.common.metrics.netty.MantisNettyEventsListenerFactory;
 import io.mantisrx.runtime.MachineDefinition;
@@ -40,6 +41,7 @@ import io.mantisrx.server.master.resourcecluster.TaskExecutorStatusChange;
 import io.mantisrx.server.worker.SinkSubscriptionStateHandler.Factory;
 import io.mantisrx.server.worker.config.WorkerConfiguration;
 import io.mantisrx.shaded.com.google.common.base.Preconditions;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import io.mantisrx.shaded.com.google.common.util.concurrent.AbstractScheduledService;
 import io.mantisrx.shaded.com.google.common.util.concurrent.Service;
 import io.mantisrx.shaded.com.google.common.util.concurrent.Service.State;
@@ -126,15 +128,19 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         MachineDefinition machineDefinition =
             MachineDefinitionUtils.sys(workerPorts, workerConfiguration.getNetworkBandwidthInMB());
         String hostName = workerConfiguration.getExternalAddress();
+        String containerDefinitionId = System.getenv(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID);
 
         this.taskExecutorRegistration =
             TaskExecutorRegistration.builder()
-                .machineDefinitionWrapper(MachineDefinitionUtils.wrap(machineDefinition))
+                .machineDefinition(machineDefinition)
                 .taskExecutorID(taskExecutorID)
                 .clusterID(clusterID)
                 .hostname(hostName)
                 .taskExecutorAddress(getAddress())
                 .workerPorts(workerPorts)
+                .taskExecutorAttributes(ImmutableMap.of(
+                    WorkerConstants.WORKER_CONTAINER_DEFINITION_ID,
+                    containerDefinitionId == null ? "defaultContainerId" : containerDefinitionId))
                 .build();
         log.info("Starting executor registration: {}", this.taskExecutorRegistration);
 

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/TaskExecutor.java
@@ -128,9 +128,14 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         String hostName = workerConfiguration.getExternalAddress();
 
         this.taskExecutorRegistration =
-            new TaskExecutorRegistration(
-                taskExecutorID, clusterID, getAddress(), hostName, workerPorts,
-                MachineDefinitionUtils.wrap(machineDefinition));
+            TaskExecutorRegistration.builder()
+                .machineDefinitionWrapper(MachineDefinitionUtils.wrap(machineDefinition))
+                .taskExecutorID(taskExecutorID)
+                .clusterID(clusterID)
+                .hostname(hostName)
+                .taskExecutorAddress(getAddress())
+                .workerPorts(workerPorts)
+                .build();
         this.ioExecutor =
             Executors.newFixedThreadPool(
                 Hardware.getNumberCPUCores(),

--- a/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/ResourceManagerGatewayCxnTest.java
+++ b/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/ResourceManagerGatewayCxnTest.java
@@ -27,7 +27,6 @@ import com.mantisrx.common.utils.Services;
 import com.spotify.futures.CompletableFutures;
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.runtime.MachineDefinition;
-import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ResourceClusterGateway;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorDisconnection;
@@ -67,9 +66,7 @@ public class ResourceManagerGatewayCxnTest {
                 .hostname("host")
                 .taskExecutorAddress("localhost")
                 .workerPorts(workerPorts)
-                .machineDefinitionWrapper(MachineDefinitionWrapper.builder().machineDefinition(
-                        new MachineDefinition(1, 1, 1, 1, 5))
-                    .build())
+                .machineDefinition(new MachineDefinition(1, 1, 1, 1, 5))
                 .build();
 
         disconnection = new TaskExecutorDisconnection(taskExecutorID, clusterID);

--- a/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/ResourceManagerGatewayCxnTest.java
+++ b/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/ResourceManagerGatewayCxnTest.java
@@ -60,15 +60,18 @@ public class ResourceManagerGatewayCxnTest {
         WorkerPorts workerPorts = new WorkerPorts(100, 101, 102, 103, 104);
         TaskExecutorID taskExecutorID = TaskExecutorID.of("taskExecutor");
         ClusterID clusterID = ClusterID.of("cluster");
-        registration = new TaskExecutorRegistration(
-            taskExecutorID,
-            clusterID,
-            "localhost",
-            "host",
-            workerPorts,
-            MachineDefinitionWrapper.builder().machineDefinition(
-                new MachineDefinition(1, 1, 1, 1, 5))
-                .build());
+        registration =
+            TaskExecutorRegistration.builder()
+                .taskExecutorID(taskExecutorID)
+                .clusterID(clusterID)
+                .hostname("host")
+                .taskExecutorAddress("localhost")
+                .workerPorts(workerPorts)
+                .machineDefinitionWrapper(MachineDefinitionWrapper.builder().machineDefinition(
+                        new MachineDefinition(1, 1, 1, 1, 5))
+                    .build())
+                .build();
+
         disconnection = new TaskExecutorDisconnection(taskExecutorID, clusterID);
         gateway = mock(ResourceClusterGateway.class);
         report = TaskExecutorReport.available();

--- a/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/ResourceManagerGatewayCxnTest.java
+++ b/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/ResourceManagerGatewayCxnTest.java
@@ -27,6 +27,7 @@ import com.mantisrx.common.utils.Services;
 import com.spotify.futures.CompletableFutures;
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.MachineDefinitionWrapper;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ResourceClusterGateway;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorDisconnection;
@@ -65,7 +66,9 @@ public class ResourceManagerGatewayCxnTest {
             "localhost",
             "host",
             workerPorts,
-            new MachineDefinition(1, 1, 1, 1, 5));
+            MachineDefinitionWrapper.builder().machineDefinition(
+                new MachineDefinition(1, 1, 1, 1, 5))
+                .build());
         disconnection = new TaskExecutorDisconnection(taskExecutorID, clusterID);
         gateway = mock(ResourceClusterGateway.class);
         report = TaskExecutorReport.available();

--- a/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/ResourceManagerGatewayCxnTest.java
+++ b/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/ResourceManagerGatewayCxnTest.java
@@ -35,6 +35,7 @@ import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorRegistration;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorReport;
 import io.mantisrx.server.worker.TaskExecutor.ResourceManagerGatewayCxn;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import io.mantisrx.shaded.com.google.common.util.concurrent.Service.State;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -67,6 +68,7 @@ public class ResourceManagerGatewayCxnTest {
                 .taskExecutorAddress("localhost")
                 .workerPorts(workerPorts)
                 .machineDefinition(new MachineDefinition(1, 1, 1, 1, 5))
+                .taskExecutorAttributes(ImmutableMap.of())
                 .build();
 
         disconnection = new TaskExecutorDisconnection(taskExecutorID, clusterID);

--- a/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/TaskAttributeUtilsTest.java
+++ b/mantis-server/mantis-server-worker/src/test/java/io/mantisrx/server/worker/TaskAttributeUtilsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.worker;
+
+import static org.junit.Assert.assertEquals;
+
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class TaskAttributeUtilsTest {
+
+    @Test
+    public void testTaskAttibuteUtils() {
+        String t1 = "";
+        Map<String, String> res1 = TaskAttributeUtils.getTaskExecutorAttributes(t1);
+        assertEquals(ImmutableMap.of(), res1);
+
+        String t2 = "key1:val1";
+        Map<String, String> res2 = TaskAttributeUtils.getTaskExecutorAttributes(t2);
+        assertEquals(ImmutableMap.of("key1", "val1"), res2);
+
+        String t3 = "key1:val1,key2:val2,key3:val3";
+        Map<String, String> res3 = TaskAttributeUtils.getTaskExecutorAttributes(t3);
+        assertEquals(ImmutableMap.of("key1", "val1", "key2", "val2", "key3", "val3"), res3);
+    }
+}


### PR DESCRIPTION
### Context
[Update] 
Track container definition id (equivalent to SKU id) in task registration attribute map.

[Origin Description]
The machine definition returned from Titus container is converted compared to the original cluster spec machine spec and cannot be mapped back to each cluster scaling rule. To mitigate this I added a machine definition id in a new wrapper class to capture the machine definition id (mapping back to scaling rule SKU id). The new machine definition id will be set directly on the cluster provider (e.g. spinnaker/k8s) as a system env variable. 

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
- [x] Added copyright headers for new files from `CONTRIBUTING.md`
