### PR TITLE
Cleaning up unused code AgentClusterOperations

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperations.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperations.java
@@ -16,7 +16,6 @@
 
 package io.mantisrx.master.vm;
 
-import com.netflix.fenzo.VirtualMachineCurrentState;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnore;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,11 +28,8 @@ import java.util.Set;
 public interface AgentClusterOperations {
 
     void setActiveVMsAttributeValues(List<String> values) throws IOException;
-    List<String> getActiveVMsAttributeValues();
+    Set<String> getActiveVMsAttributeValues();
     boolean isActive(String name);
-
-    void setAgentInfos(List<VirtualMachineCurrentState> agentInfos);
-    List<AgentInfo> getAgentInfos();
 
     /**
      * Get all current jobs assigned to VMs. This produces a map with key as the value for VM attribute used to

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperations.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperations.java
@@ -29,7 +29,7 @@ import java.util.Set;
 public interface AgentClusterOperations {
 
     void setActiveVMsAttributeValues(List<String> values) throws IOException;
-    List<String> getActiveVMsAttributeValues();
+    Set<String> getActiveVMsAttributeValues();
     boolean isActive(String name);
 
     void setAgentInfos(List<VirtualMachineCurrentState> agentInfos);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperations.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperations.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.vm;
 
+import com.netflix.fenzo.VirtualMachineCurrentState;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnore;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,8 +29,11 @@ import java.util.Set;
 public interface AgentClusterOperations {
 
     void setActiveVMsAttributeValues(List<String> values) throws IOException;
-    Set<String> getActiveVMsAttributeValues();
+    List<String> getActiveVMsAttributeValues();
     boolean isActive(String name);
+
+    void setAgentInfos(List<VirtualMachineCurrentState> agentInfos);
+    List<AgentInfo> getAgentInfos();
 
     /**
      * Get all current jobs assigned to VMs. This produces a map with key as the value for VM attribute used to

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperationsImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperationsImpl.java
@@ -23,6 +23,7 @@ import com.netflix.fenzo.VirtualMachineLease;
 import com.netflix.spectator.impl.Preconditions;
 import io.mantisrx.common.metrics.Counter;
 import io.mantisrx.common.metrics.Metrics;
+import io.mantisrx.common.util.DateTimeExt;
 import io.mantisrx.master.events.LifecycleEventPublisher;
 import io.mantisrx.master.events.LifecycleEventsProto;
 import io.mantisrx.server.core.BaseService;
@@ -39,7 +40,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -71,6 +71,7 @@ public class AgentClusterOperationsImpl extends BaseService implements AgentClus
     private final MantisScheduler scheduler;
     private final LifecycleEventPublisher lifecycleEventPublisher;
     private volatile ActiveVmAttributeValues activeVmAttributeValues=null;
+    private final ConcurrentMap<String, List<VirtualMachineCurrentState>> vmStatesMap;
     private final AgentClustersAutoScaler agentClustersAutoScaler;
     private final String attrName;
     private final Counter listJobsOnVMsCount;
@@ -90,6 +91,7 @@ public class AgentClusterOperationsImpl extends BaseService implements AgentClus
         this.jobMessageRouter = jobMessageRouter;
         this.scheduler = scheduler;
         this.lifecycleEventPublisher = lifecycleEventPublisher;
+        this.vmStatesMap = new ConcurrentHashMap<>();
         this.agentClustersAutoScaler = AgentClustersAutoScaler.get();
         this.attrName = activeSlaveAttributeName;
         Metrics metrics = new Metrics.Builder()
@@ -132,10 +134,10 @@ public class AgentClusterOperationsImpl extends BaseService implements AgentClus
     }
 
     @Override
-    public Set<String> getActiveVMsAttributeValues() {
+    public List<String> getActiveVMsAttributeValues() {
         return activeVmAttributeValues==null?
             null :
-            new HashSet<>(activeVmAttributeValues.values);
+            activeVmAttributeValues.values;
     }
 
     private List<JobsOnVMStatus> getJobsOnVMStatus() {
@@ -184,14 +186,51 @@ public class AgentClusterOperationsImpl extends BaseService implements AgentClus
         return result;
     }
 
-    private boolean isIn(String name, Set<String> activeVMs) {
-        return activeVMs.contains(name);
+    private boolean isIn(String name, List<String> activeVMs) {
+        for(String vm: activeVMs)
+            if(vm.equals(name))
+                return true;
+        return false;
     }
 
     @Override
     public boolean isActive(String name) {
         return activeVmAttributeValues==null || activeVmAttributeValues.isEmpty() ||
-            isIn(name, getActiveVMsAttributeValues());
+            isIn(name, activeVmAttributeValues.getValues());
+    }
+
+    @Override
+    public void setAgentInfos(List<VirtualMachineCurrentState> vmStates) {
+        vmStatesMap.put("0", vmStates);
+    }
+
+    @Override
+    public List<AgentInfo> getAgentInfos() {
+        List<VirtualMachineCurrentState> vmStates = vmStatesMap.get("0");
+        List<AgentInfo> agentInfos = new ArrayList<>();
+        if (vmStates != null && !vmStates.isEmpty()) {
+            for (VirtualMachineCurrentState s : vmStates) {
+                List<VirtualMachineLease.Range> ranges = s.getCurrAvailableResources().portRanges();
+                int ports = 0;
+                if (ranges != null && !ranges.isEmpty())
+                    for (VirtualMachineLease.Range r : ranges)
+                        ports += r.getEnd() - r.getBeg();
+                Map<String, Protos.Attribute> attributeMap = s.getCurrAvailableResources().getAttributeMap();
+                Map<String, String> attributes = new HashMap<>();
+                if (attributeMap != null && !attributeMap.isEmpty()) {
+                    for (Map.Entry<String, Protos.Attribute> entry : attributeMap.entrySet()) {
+                        attributes.put(entry.getKey(), entry.getValue().getText().getValue());
+                    }
+                }
+                agentInfos.add(new AgentInfo(
+                    s.getHostname(), s.getCurrAvailableResources().cpuCores(),
+                    s.getCurrAvailableResources().memoryMB(), s.getCurrAvailableResources().diskMB(),
+                    ports, s.getCurrAvailableResources().getScalarValues(), attributes, s.getResourceSets().keySet(),
+                    getTimeString(s.getDisabledUntil())
+                ));
+            }
+        }
+        return agentInfos;
     }
 
     @Override
@@ -213,10 +252,16 @@ public class AgentClusterOperationsImpl extends BaseService implements AgentClus
         return result;
     }
 
+    private String getTimeString(long disabledUntil) {
+        if (System.currentTimeMillis() > disabledUntil)
+            return null;
+        return DateTimeExt.toUtcDateTimeString(disabledUntil);
+    }
+
     List<String> manageActiveVMs(final List<VirtualMachineCurrentState> currentStates) {
         List<String> inactiveVMs = new ArrayList<>();
         if(currentStates!=null && !currentStates.isEmpty()) {
-            final Set<String> values = getActiveVMsAttributeValues();
+            final List<String> values = getActiveVMsAttributeValues();
             if(values==null || values.isEmpty())
                 return Collections.EMPTY_LIST; // treat no valid active VMs attribute value as all are active
             for(VirtualMachineCurrentState currentState: currentStates) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperationsImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperationsImpl.java
@@ -35,12 +35,12 @@ import io.mantisrx.server.master.scheduler.MantisScheduler;
 import io.mantisrx.server.master.scheduler.WorkerOnDisabledVM;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -140,7 +140,7 @@ public class AgentClusterOperationsImpl extends BaseService implements AgentClus
     public Set<String> getActiveVMsAttributeValues() {
         return activeVmAttributeValues==null?
             null :
-            new HashSet<>(activeVmAttributeValues.values);
+            ImmutableSet.copyOf(activeVmAttributeValues.values);
     }
 
     private List<JobsOnVMStatus> getJobsOnVMStatus() {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperationsImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperationsImpl.java
@@ -44,8 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperationsImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/vm/AgentClusterOperationsImpl.java
@@ -40,10 +40,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import org.apache.mesos.Protos;
 import org.slf4j.Logger;
@@ -134,10 +137,10 @@ public class AgentClusterOperationsImpl extends BaseService implements AgentClus
     }
 
     @Override
-    public List<String> getActiveVMsAttributeValues() {
+    public Set<String> getActiveVMsAttributeValues() {
         return activeVmAttributeValues==null?
             null :
-            activeVmAttributeValues.values;
+            new HashSet<>(activeVmAttributeValues.values);
     }
 
     private List<JobsOnVMStatus> getJobsOnVMStatus() {
@@ -173,30 +176,23 @@ public class AgentClusterOperationsImpl extends BaseService implements AgentClus
         listJobsOnVMsCount.increment();
         Map<String, List<JobsOnVMStatus>> result = new HashMap<>();
         final List<JobsOnVMStatus> statusList = getJobsOnVMStatus();
-        if (statusList != null && !statusList.isEmpty()) {
+        if (!statusList.isEmpty()) {
             for (JobsOnVMStatus status: statusList) {
-                List<JobsOnVMStatus> jobsOnVMStatuses = result.get(status.getAttributeValue());
-                if (jobsOnVMStatuses == null) {
-                    jobsOnVMStatuses = new ArrayList<>();
-                    result.put(status.getAttributeValue(), jobsOnVMStatuses);
-                }
+                List<JobsOnVMStatus> jobsOnVMStatuses = result.computeIfAbsent(status.getAttributeValue(), k -> new ArrayList<>());
                 jobsOnVMStatuses.add(status);
             }
         }
         return result;
     }
 
-    private boolean isIn(String name, List<String> activeVMs) {
-        for(String vm: activeVMs)
-            if(vm.equals(name))
-                return true;
-        return false;
+    private boolean isIn(String name, Set<String> activeVMs) {
+        return activeVMs.contains(name);
     }
 
     @Override
     public boolean isActive(String name) {
         return activeVmAttributeValues==null || activeVmAttributeValues.isEmpty() ||
-            isIn(name, activeVmAttributeValues.getValues());
+            isIn(name, getActiveVMsAttributeValues());
     }
 
     @Override
@@ -261,7 +257,7 @@ public class AgentClusterOperationsImpl extends BaseService implements AgentClus
     List<String> manageActiveVMs(final List<VirtualMachineCurrentState> currentStates) {
         List<String> inactiveVMs = new ArrayList<>();
         if(currentStates!=null && !currentStates.isEmpty()) {
-            final List<String> values = getActiveVMsAttributeValues();
+            final Set<String> values = getActiveVMsAttributeValues();
             if(values==null || values.isEmpty())
                 return Collections.EMPTY_LIST; // treat no valid active VMs attribute value as all are active
             for(VirtualMachineCurrentState currentState: currentStates) {


### PR DESCRIPTION
### Context

Started hacking into Agent Cluster Operations implementation to get it working for Titus implementation and realized there's some unused code. This diff gets rid of it. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
