### PR TITLE
Add job init start timeout config

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -1871,7 +1871,8 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
             //// heartbeat misses are calculated as 3 * heartbeatInterval, pick 1.5 multiplier for this check interval
             long missedHeartBeatToleranceSecs = (long) (1.5 * ConfigurationProvider.getConfig().getWorkerTimeoutSecs());
             // Allow more time for workers to start
-            long stuckInSubmitToleranceSecs = missedHeartBeatToleranceSecs + 120;
+            long stuckInSubmitToleranceSecs =
+                missedHeartBeatToleranceSecs + ConfigurationProvider.getConfig().getWorkerInitTimeoutSecs();
 
             List<JobWorker> workersToResubmit = Lists.newArrayList();
             // expire worker resubmit entries

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -193,6 +193,10 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("60")
     long getWorkerTimeoutSecs();
 
+    @Config("mantis.worker.heartbeat.interval.init.secs")
+    @Default("180")
+    long getWorkerInitTimeoutSecs();
+
     @Config("mantis.worker.heartbeat.receipts.min.threshold.percent")
     @Default("55")
     double getHeartbeatReceiptsMinThresholdPercentage();


### PR DESCRIPTION
### Context

Convert hard-coded constant to a job init start timeout with larger value to compensate SBN job start time lag.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
