### PR TITLE
Handle load archive job cache error

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/MantisJobStore.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/MantisJobStore.java
@@ -399,7 +399,17 @@ public class MantisJobStore {
             }
         }
 
-        private IMantisJobMetadata loadArchivedJob(String jobId) throws IOException, InvalidJobException, ExecutionException {
+        private IMantisJobMetadata loadArchivedJob(String jobId) {
+            try
+            {
+                return loadArchivedJobImpl(jobId);
+            } catch (IOException|ExecutionException e) {
+                logger.warn("Failed to load archive job {}, error: {}", jobId, e);
+                return null;
+            }
+        }
+
+        private IMantisJobMetadata loadArchivedJobImpl(String jobId) throws IOException, ExecutionException {
             if (logger.isTraceEnabled()) {logger.trace("Loading archived job {}", jobId);}
             final Optional<IMantisJobMetadata> jobMetadata = storageProvider.loadArchivedJob(jobId);
             if (!jobMetadata.isPresent())


### PR DESCRIPTION
### Context

Currently, when the archive job cache tried to load any out-of-date archive job it will trigger an error thrown from the cache get and becomes an unhandled error (to radar detection as well).
Adding the IOException type to the catch clause to reduce the error noise.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
