### PR TITLE
Cleaning up a newly written test that makes assumption around serialization ordering

### DIFF
--- a/mantis-common/src/test/java/io/mantisrx/runtime/descriptor/StageScalingPolicyTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/runtime/descriptor/StageScalingPolicyTest.java
@@ -22,6 +22,7 @@ import io.mantisrx.common.JsonSerializer;
 import io.mantisrx.runtime.descriptor.StageScalingPolicy.RollingCount;
 import io.mantisrx.runtime.descriptor.StageScalingPolicy.ScalingReason;
 import io.mantisrx.runtime.descriptor.StageScalingPolicy.Strategy;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -70,7 +71,9 @@ public class StageScalingPolicyTest {
             "    },\n" +
             "    \"enabled\": true\n" +
             "}";
-        assertEquals(expected.replaceAll("[\n\\s]+", ""), serializer.toJson(policy));
+        StageScalingPolicy actual =
+            serializer.fromJson(expected.getBytes(StandardCharsets.UTF_8), StageScalingPolicy.class);
+        assertEquals(policy, actual);
     }
 
     @Test


### PR DESCRIPTION
### Context

This particular serialization test made some assumptions about ordering the keys in a map. Since it uses a hashmap under the hood, the ordering is not guaranteed; hence, the test is flaky. This diff fixes that. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
