### PR TITLE
Making sure container attribute field is not getting serialized as part of TaskExecutorRegistration

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
@@ -19,6 +19,7 @@ import io.mantisrx.common.WorkerConstants;
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnore;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import java.util.Map;
@@ -36,36 +37,36 @@ import lombok.experimental.FieldDefaults;
  * Different fields help identify the task executor in different dimensions.
  */
 @Builder
-@FieldDefaults(makeFinal=true, level= AccessLevel.PRIVATE)
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @Getter
 @ToString
 @EqualsAndHashCode
 public class TaskExecutorRegistration {
-  @NonNull
-  TaskExecutorID taskExecutorID;
+    @NonNull
+    TaskExecutorID taskExecutorID;
 
-  @NonNull
-  ClusterID clusterID;
+    @NonNull
+    ClusterID clusterID;
 
-  // RPC address that's used to talk to the task executor
-  @NonNull
-  String taskExecutorAddress;
+    // RPC address that's used to talk to the task executor
+    @NonNull
+    String taskExecutorAddress;
 
-  // host name of the task executor
-  @NonNull
-  String hostname;
+    // host name of the task executor
+    @NonNull
+    String hostname;
 
-  // ports used by the task executor for various purposes.
-  @NonNull
-  WorkerPorts workerPorts;
+    // ports used by the task executor for various purposes.
+    @NonNull
+    WorkerPorts workerPorts;
 
-  // machine information identifies the cpu/mem/disk/network resources of the task executor.
-  @NonNull
-  MachineDefinition machineDefinition;
+    // machine information identifies the cpu/mem/disk/network resources of the task executor.
+    @NonNull
+    MachineDefinition machineDefinition;
 
-  // custom attributes describing the task executor
-  // TODO make this field non-null once no back-compat required.
-  Map<String, String> taskExecutorAttributes;
+    // custom attributes describing the task executor
+    // TODO make this field non-null once no back-compat required.
+    Map<String, String> taskExecutorAttributes;
 
     @JsonCreator
     public TaskExecutorRegistration(
@@ -89,11 +90,12 @@ public class TaskExecutorRegistration {
         return taskExecutorAttributes.entrySet().containsAll(requiredAttributes.entrySet());
     }
 
-  public Optional<ContainerSkuID> getTaskExecutorContainerDefinitionId() {
-      return Optional.ofNullable(
-          this.getTaskExecutorAttributes() == null ||
-              !this.getTaskExecutorAttributes().containsKey(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID) ?
-              null :
-              ContainerSkuID.of(this.getTaskExecutorAttributes().get(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID)));
-  }
+    @JsonIgnore
+    public Optional<ContainerSkuID> getTaskExecutorContainerDefinitionId() {
+        return Optional.ofNullable(
+            this.getTaskExecutorAttributes() == null ||
+                !this.getTaskExecutorAttributes().containsKey(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID) ?
+                null :
+                ContainerSkuID.of(this.getTaskExecutorAttributes().get(WorkerConstants.WORKER_CONTAINER_DEFINITION_ID)));
+    }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistrationTest.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistrationTest.java
@@ -126,4 +126,45 @@ public class TaskExecutorRegistrationTest {
             serializer.fromJSON(serializer.toJson(registration), TaskExecutorRegistration.class);
         assertEquals(registration, deserialized);
     }
+
+    @Test
+    public void testSerialization() throws Exception {
+        String expected = "{\n" +
+            "    \"taskExecutorID\":\n" +
+            "    {\n" +
+            "        \"resourceId\": \"25400d92-96ed-40b9-9843-a6e7e248db52\"\n" +
+            "    },\n" +
+            "    \"clusterID\":\n" +
+            "    {\n" +
+            "        \"resourceID\": \"mantistaskexecutor\"\n" +
+            "    },\n" +
+            "    \"taskExecutorAddress\": \"akka.tcp://flink@100.118.114.30:5050/user/rpc/worker_0\",\n" +
+            "    \"hostname\": \"localhost\",\n" +
+            "    \"workerPorts\":\n" +
+            "    {\n" +
+            "        \"metricsPort\": 5051,\n" +
+            "        \"debugPort\": 5052,\n" +
+            "        \"consolePort\": 5053,\n" +
+            "        \"customPort\": 5054,\n" +
+            "        \"ports\":\n" +
+            "        [\n" +
+            "            5055" +
+            "        ],\n" +
+            "        \"sinkPort\": 5055\n" +
+            "    },\n" +
+            "    \"machineDefinition\":\n" +
+            "    {\n" +
+            "        \"cpuCores\": 4.0,\n" +
+            "        \"memoryMB\": 1.7179869184E10,\n" +
+            "        \"networkMbps\": 128.0,\n" +
+            "        \"diskMB\": 8.8969576448E10,\n" +
+            "        \"numPorts\": 5\n" +
+            "    },\n" +
+            "    \"taskExecutorAttributes\":\n" +
+            "    {}\n" +
+            "}";
+        final TaskExecutorRegistration registration =
+            serializer.fromJSON(expected, TaskExecutorRegistration.class);
+        assertEquals(expected.replaceAll("[\\n\\s]+", ""), serializer.toJson(registration));
+    }
 }


### PR DESCRIPTION
### Context

I was noticing that taskExecutorContainerDefinitionId was getting serialized as part of the TaskExecutorRegistration state. This diff aims to get rid of that. 
```
       "taskExecutorContainerDefinitionId": {
            "resourceID": "some value"
        }
```

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
