### PR TITLE
Support resource cluster based job submission API

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/DeploymentStrategy.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/DeploymentStrategy.java
@@ -16,10 +16,13 @@
 
 package io.mantisrx.runtime.descriptor;
 
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonInclude;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.Singular;
 import lombok.ToString;
 
@@ -27,23 +30,36 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class DeploymentStrategy {
-    @Singular(ignoreNullCollections = true) private Map<Integer, StageDeploymentStrategy> stages;
+    @Singular(ignoreNullCollections = true, value = "stage")
+    @Getter
+    private final Map<Integer, StageDeploymentStrategy> stageDeploymentStrategyMap;
+
+    /**
+     * If this field is not empty, it's used to indicate this is a resource cluster stack deployment and will be hosted
+     * to the given resource cluster Id.
+     */
+    @Getter
+    @JsonInclude(Include.NON_NULL)
+    private final String resourceClusterId;
 
     public DeploymentStrategy(
-            @JsonProperty("stageDeploymentStrategyMap") Map<Integer, StageDeploymentStrategy> stages) {
-        this.stages = stages;
+        @JsonProperty("stageDeploymentStrategyMap") Map<Integer, StageDeploymentStrategy> stageDeploymentStrategyMap,
+        @JsonProperty("resourceClusterId") String resourceClusterId) {
+        this.stageDeploymentStrategyMap = stageDeploymentStrategyMap;
+        this.resourceClusterId = resourceClusterId;
     }
 
     public StageDeploymentStrategy forStage(int stageNum) {
-        if (!this.stages.containsKey(stageNum)) { return null; }
-        return stages.get(stageNum);
+        if (!this.stageDeploymentStrategyMap.containsKey(stageNum)) { return null; }
+        return stageDeploymentStrategyMap.get(stageNum);
     }
 
     public boolean requireInheritInstanceCheck() {
-        return this.stages != null && this.stages.values().stream().anyMatch(StageDeploymentStrategy::isInheritInstanceCount);
+        return this.stageDeploymentStrategyMap != null && this.stageDeploymentStrategyMap.values().stream().anyMatch(StageDeploymentStrategy::isInheritInstanceCount);
     }
 
     public boolean requireInheritInstanceCheck(int stageNum) {
-        return this.stages != null && this.stages.containsKey(stageNum) && this.stages.get(stageNum).isInheritInstanceCount();
+        return this.stageDeploymentStrategyMap
+            != null && this.stageDeploymentStrategyMap.containsKey(stageNum) && this.stageDeploymentStrategyMap.get(stageNum).isInheritInstanceCount();
     }
 }

--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/DeploymentStrategy.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/DeploymentStrategy.java
@@ -36,7 +36,7 @@ public class DeploymentStrategy {
 
     /**
      * If this field is not empty, it's used to indicate this is a resource cluster stack deployment and will be hosted
-     * to the given resource cluster Id.
+     * on the given resource cluster.
      */
     @Getter
     @JsonInclude(Include.NON_NULL)

--- a/mantis-common/src/test/java/io/mantisrx/runtime/descriptor/DeploymentStrategyTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/runtime/descriptor/DeploymentStrategyTest.java
@@ -16,11 +16,16 @@
 
 package io.mantisrx.runtime.descriptor;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import io.mantisrx.common.JsonSerializer;
 import org.junit.Test;
 
 public class DeploymentStrategyTest {
+    private final JsonSerializer serializer = new JsonSerializer();
+
     @Test
     public void shouldRequireInheritInstanceCheck() {
         DeploymentStrategy res = DeploymentStrategy.builder()
@@ -63,5 +68,34 @@ public class DeploymentStrategyTest {
         assertFalse(res.requireInheritInstanceCheck(1));
         assertFalse(res.requireInheritInstanceCheck(2));
         assertFalse(res.requireInheritInstanceCheck());
+    }
+
+    @Test
+    public void testSerialization() throws Exception {
+        String expected = "{"
+            + "\"stageDeploymentStrategyMap\":"
+            + "{"
+                + "\"1\":{\"inheritInstanceCount\":false},"
+                + "\"2\":{\"inheritInstanceCount\":true},"
+                + "\"3\":{\"inheritInstanceCount\":true}},"
+            + "\"resourceClusterId\":\"rescluster1\""
+            + "}";
+
+        final DeploymentStrategy ds = serializer.fromJSON(expected, DeploymentStrategy.class);
+        assertEquals(expected.replaceAll("[\\n\\s]+", ""), serializer.toJson(ds));
+    }
+
+    @Test
+    public void testSerializationBackCompat() throws Exception {
+        String expected = "{"
+            + "\"stageDeploymentStrategyMap\":"
+            + "{"
+            + "\"1\":{\"inheritInstanceCount\":false},"
+            + "\"2\":{\"inheritInstanceCount\":true},"
+            + "\"3\":{\"inheritInstanceCount\":true}}"
+            + "}";
+
+        final DeploymentStrategy ds = serializer.fromJSON(expected, DeploymentStrategy.class);
+        assertEquals(expected.replaceAll("[\\n\\s]+", ""), serializer.toJson(ds));
     }
 }


### PR DESCRIPTION
### Context

Add support in job submission API to specify the target resource cluster. This change is supposed to be back-compat.
* Also making "labels" in JobDefintion to be unique on each label name.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
