### PR TITLE
Support get active jobs per ResourceCluster

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/PagedActiveJobOverview.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/PagedActiveJobOverview.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.master.resourcecluster;
+
+import java.util.List;
+import lombok.Value;
+
+@Value
+public class PagedActiveJobOverview {
+    List<String> activeJobs;
+    int endPosition;
+}

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -23,6 +23,7 @@ import io.mantisrx.server.worker.TaskExecutorGateway;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import lombok.Value;
@@ -94,6 +95,16 @@ public interface ResourceCluster extends ResourceClusterGateway {
      * @return a future that completes when the underlying operation is registered by the system
      */
     CompletableFuture<Ack> disableTaskExecutorsFor(Map<String, String> attributes, Instant expiry);
+
+    /**
+     * Get a paged result of all active jobs associated with this resource cluster.
+     * @param startingIndex Starting index for the paged list of all the active jobs.
+     * @param pageSize Max size of returned paged list.
+     * @return PagedActiveJobOverview instance.
+     */
+    CompletableFuture<PagedActiveJobOverview> getActiveJobOverview(
+        Optional<Integer> startingIndex,
+        Optional<Integer> pageSize);
 
     /**
      * Gets the task executors to worker mapping for the given resource cluster

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -289,6 +289,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             .filter(Objects::nonNull)
             .map(WorkerId::getJobId)
             .distinct()
+            .sorted((String::compareToIgnoreCase))
             .skip(req.getStartingIndex().orElse(0))
             .limit(req.getPageSize().orElse(3000))
             .collect(Collectors.toList());
@@ -686,6 +687,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
 
     @Value
     @Builder
+    @AllArgsConstructor // needed for build to work with custom ctor.
     static class GetActiveJobsRequest {
         ClusterID clusterID;
         Optional<Integer> startingIndex;
@@ -695,12 +697,6 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             this.clusterID = clusterID;
             this.pageSize = Optional.empty();
             this.startingIndex = Optional.empty();
-        }
-
-        public GetActiveJobsRequest(ClusterID clusterID, Optional<Integer> startingIndex, Optional<Integer> pageSize) {
-            this.clusterID = clusterID;
-            this.pageSize = pageSize;
-            this.startingIndex = startingIndex;
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -33,6 +33,7 @@ import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
+import io.mantisrx.server.master.resourcecluster.PagedActiveJobOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.NoResourceAvailableException;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.TaskExecutorStatus;
@@ -57,6 +58,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -65,6 +67,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.ToString;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
@@ -147,6 +150,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
                 .match(GetAvailableTaskExecutorsRequest.class, req -> sender().tell(getTaskExecutors(isAvailable), self()))
                 .match(GetDisabledTaskExecutorsRequest.class, req -> sender().tell(getTaskExecutors(isDisabled), self()))
                 .match(GetUnregisteredTaskExecutorsRequest.class, req -> sender().tell(getTaskExecutors(unregistered), self()))
+                .match(GetActiveJobsRequest.class, this::getActiveJobs)
                 .match(GetTaskExecutorStatusRequest.class, req -> sender().tell(getTaskExecutorStatus(req.getTaskExecutorID()), self()))
                 .match(GetClusterUsageRequest.class, req -> sender().tell(getClusterUsage(req), self()))
                 .match(GetClusterIdleInstancesRequest.class,
@@ -275,6 +279,28 @@ class ResourceClusterActor extends AbstractActorWithTimers {
                     .filter(predicate)
                     .map(Entry::getKey)
                     .collect(Collectors.toList()));
+    }
+
+    private void getActiveJobs(GetActiveJobsRequest req) {
+        List<String> pagedList = this.taskExecutorStateMap
+            .values()
+            .stream()
+            .map(TaskExecutorState::getWorkerId)
+            .filter(Objects::nonNull)
+            .map(WorkerId::getJobId)
+            .distinct()
+            .skip(req.getStartingIndex().orElse(0))
+            .limit(req.getPageSize().orElse(3000))
+            .collect(Collectors.toList());
+
+        PagedActiveJobOverview res =
+            new PagedActiveJobOverview(
+                pagedList,
+                req.getStartingIndex().orElse(0) + pagedList.size()
+            );
+
+        log.info("Returning getActiveJobs res starting at {}: {}", req.getStartingIndex(), res.getActiveJobs().size());
+        sender().tell(res, self());
     }
 
     private void onTaskExecutorInfoRequest(TaskExecutorInfoRequest request) {
@@ -656,6 +682,26 @@ class ResourceClusterActor extends AbstractActorWithTimers {
     @Value
     static class GetRegisteredTaskExecutorsRequest {
         ClusterID clusterID;
+    }
+
+    @Value
+    @Builder
+    static class GetActiveJobsRequest {
+        ClusterID clusterID;
+        Optional<Integer> startingIndex;
+        Optional<Integer> pageSize;
+
+        public GetActiveJobsRequest(ClusterID clusterID) {
+            this.clusterID = clusterID;
+            this.pageSize = Optional.empty();
+            this.startingIndex = Optional.empty();
+        }
+
+        public GetActiveJobsRequest(ClusterID clusterID, Optional<Integer> startingIndex, Optional<Integer> pageSize) {
+            this.clusterID = clusterID;
+            this.pageSize = pageSize;
+            this.startingIndex = startingIndex;
+        }
     }
 
     @Value

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -19,6 +19,7 @@ package io.mantisrx.master.resourcecluster;
 import akka.actor.ActorRef;
 import akka.pattern.Patterns;
 import io.mantisrx.common.Ack;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAvailableTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetBusyTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetRegisteredTaskExecutorsRequest;
@@ -35,6 +36,7 @@ import io.mantisrx.master.resourcecluster.ResourceClusterScalerActor.TriggerClus
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.PagedActiveJobOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster;
 import io.mantisrx.server.master.resourcecluster.ResourceClusterTaskExecutorMapper;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
@@ -45,6 +47,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements ResourceCluster {
@@ -195,6 +198,23 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
             Patterns
                 .ask(resourceClusterManagerActor, msg, askTimeout)
                 .thenApply(Ack.class::cast)
+                .toCompletableFuture();
+    }
+
+    @Override
+    public CompletableFuture<PagedActiveJobOverview> getActiveJobOverview(
+        Optional<Integer> startingIndex,
+        Optional<Integer> maxSize) {
+        final GetActiveJobsRequest msg = GetActiveJobsRequest.builder()
+            .clusterID(clusterID)
+            .startingIndex(startingIndex)
+            .pageSize(maxSize)
+            .build();
+
+        return
+            Patterns
+                .ask(resourceClusterManagerActor, msg, askTimeout)
+                .thenApply(PagedActiveJobOverview.class::cast)
                 .toCompletableFuture();
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -22,6 +22,7 @@ import akka.actor.Props;
 import akka.actor.SupervisorStrategy;
 import akka.japi.pf.ReceiveBuilder;
 import io.mantisrx.master.akka.MantisActorSupervisorStrategy;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAvailableTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetBusyTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetRegisteredTaskExecutorsRequest;
@@ -118,6 +119,7 @@ class ResourceClustersManagerActor extends AbstractActor {
                 .match(GetAvailableTaskExecutorsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
                 .match(GetUnregisteredTaskExecutorsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
                 .match(GetTaskExecutorStatusRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
+                .match(GetActiveJobsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
 
                 .match(TaskExecutorRegistration.class, registration ->
                     getRCActor(registration.getClusterID()).forward(registration, context()))

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -29,6 +29,7 @@ import akka.testkit.javadsl.TestKit;
 import io.mantisrx.common.Ack;
 import io.mantisrx.common.WorkerConstants;
 import io.mantisrx.common.WorkerPorts;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetClusterUsageRequest;
 import io.mantisrx.master.resourcecluster.proto.GetClusterIdleInstancesRequest;
 import io.mantisrx.master.resourcecluster.proto.GetClusterIdleInstancesResponse;
@@ -40,6 +41,7 @@ import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
+import io.mantisrx.server.master.resourcecluster.PagedActiveJobOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceClusterTaskExecutorMapper;
@@ -56,8 +58,12 @@ import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -222,7 +228,7 @@ public class ResourceClusterActorTest {
     }
 
     @Test
-    public void testGetTaskExecutorsUsage() throws Exception {
+    public void testGetTaskExecutorsUsageAndList() throws Exception {
         assertEquals(Ack.getInstance(), resourceCluster.registerTaskExecutor(TASK_EXECUTOR_REGISTRATION).get());
         assertEquals(Ack.getInstance(),
             resourceCluster
@@ -274,6 +280,14 @@ public class ResourceClusterActorTest {
                 .findFirst().get();
         assertEquals(2, usage2.getIdleCount());
         assertEquals(2, usage2.getTotalCount());
+
+        // test get empty job list
+        resourceClusterActor.tell(new GetActiveJobsRequest(
+                CLUSTER_ID),
+            probe.getRef());
+        PagedActiveJobOverview jobsList = probe.expectMsgClass(PagedActiveJobOverview.class);
+        assertEquals(0, jobsList.getActiveJobs().size());
+        assertEquals(0, jobsList.getEndPosition());
 
         // test get idle list
         resourceClusterActor.tell(
@@ -337,6 +351,15 @@ public class ResourceClusterActorTest {
         assertEquals(1, usage1.getIdleCount());
         assertEquals(1, usage1.getTotalCount());
 
+        // test get non-empty job list
+        resourceClusterActor.tell(new GetActiveJobsRequest(
+                CLUSTER_ID),
+            probe.getRef());
+        jobsList = probe.expectMsgClass(PagedActiveJobOverview.class);
+        assertEquals(1, jobsList.getActiveJobs().size());
+        assertTrue(jobsList.getActiveJobs().contains(WORKER_ID.getJobId()));
+        assertEquals(1, jobsList.getEndPosition());
+
         // test get idle list
         resourceClusterActor.tell(
             GetClusterIdleInstancesRequest.builder()
@@ -377,6 +400,75 @@ public class ResourceClusterActorTest {
         assertEquals(
             TASK_EXECUTOR_ID,
             resourceCluster.getTaskExecutorFor(MACHINE_DEFINITION, WORKER_ID).get());
+    }
+
+    @Test
+    public void testGetMultipleActiveJobs() throws ExecutionException, InterruptedException {
+        final int n = 11;
+        Set<String> expectedJobIdList = new HashSet<>(n);
+        for (int i = 0; i < n * 2; i ++) {
+            int idx = (i % n);
+            TaskExecutorID taskExecutorID = TaskExecutorID.of("taskExecutorId" + i);
+            assertEquals(Ack.getInstance(), resourceCluster.registerTaskExecutor(
+                TaskExecutorRegistration.builder()
+                    .taskExecutorID(taskExecutorID)
+                    .clusterID(CLUSTER_ID)
+                    .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+                    .hostname(HOST_NAME + i)
+                    .workerPorts(WORKER_PORTS)
+                    .machineDefinition(MACHINE_DEFINITION)
+                    .taskExecutorAttributes(
+                        ImmutableMap.of(
+                            WorkerConstants.WORKER_CONTAINER_DEFINITION_ID, CONTAINER_DEF_ID_1.getResourceID(),
+                            "attr1", "attr1"))
+                    .build()
+            ).get());
+
+            assertEquals(Ack.getInstance(),
+                resourceCluster
+                    .heartBeatFromTaskExecutor(
+                        new TaskExecutorHeartbeat(
+                            taskExecutorID,
+                            CLUSTER_ID,
+                            TaskExecutorReport.available())).get());
+
+            WorkerId workerId =
+                WorkerId.fromIdUnsafe(String.format("late-sine-function-tutorial-%d-worker-%d-1", idx, i));
+            expectedJobIdList.add(String.format("late-sine-function-tutorial-%d", idx));
+            assertEquals(
+                taskExecutorID,
+                resourceCluster.getTaskExecutorFor(
+                    MACHINE_DEFINITION,
+                    workerId)
+                    .get());
+        }
+
+        TestKit probe = new TestKit(actorSystem);
+        resourceClusterActor.tell(new GetActiveJobsRequest(
+                CLUSTER_ID),
+            probe.getRef());
+        PagedActiveJobOverview jobsList = probe.expectMsgClass(PagedActiveJobOverview.class);
+        assertEquals(n, jobsList.getActiveJobs().size());
+        assertEquals(expectedJobIdList, new HashSet<>(jobsList.getActiveJobs()));
+        assertEquals(n, jobsList.getEndPosition());
+
+        Set<String> resJobsSet = new HashSet<>();
+        int start = 0;
+
+        do {
+            resourceClusterActor.tell(
+                GetActiveJobsRequest.builder()
+                    .clusterID(CLUSTER_ID)
+                    .startingIndex(Optional.of(start))
+                    .pageSize(Optional.of(5))
+                    .build(),
+                probe.getRef());
+            jobsList = probe.expectMsgClass(PagedActiveJobOverview.class);
+            resJobsSet.addAll(jobsList.getActiveJobs());
+            assertTrue(jobsList.getActiveJobs().size() <= 5);
+            start = jobsList.getEndPosition();
+        } while (jobsList.getActiveJobs().size() > 0);
+        assertEquals(expectedJobIdList, resJobsSet);
     }
 
     @Test

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -58,11 +58,11 @@ import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -404,8 +404,8 @@ public class ResourceClusterActorTest {
 
     @Test
     public void testGetMultipleActiveJobs() throws ExecutionException, InterruptedException {
-        final int n = 11;
-        Set<String> expectedJobIdList = new HashSet<>(n);
+        final int n = 10;
+        List<String> expectedJobIdList = new ArrayList<>(n);
         for (int i = 0; i < n * 2; i ++) {
             int idx = (i % n);
             TaskExecutorID taskExecutorID = TaskExecutorID.of("taskExecutorId" + i);
@@ -434,7 +434,10 @@ public class ResourceClusterActorTest {
 
             WorkerId workerId =
                 WorkerId.fromIdUnsafe(String.format("late-sine-function-tutorial-%d-worker-%d-1", idx, i));
-            expectedJobIdList.add(String.format("late-sine-function-tutorial-%d", idx));
+            if (i < n) {
+                expectedJobIdList.add(String.format("late-sine-function-tutorial-%d", idx));
+            }
+
             assertEquals(
                 taskExecutorID,
                 resourceCluster.getTaskExecutorFor(
@@ -449,10 +452,10 @@ public class ResourceClusterActorTest {
             probe.getRef());
         PagedActiveJobOverview jobsList = probe.expectMsgClass(PagedActiveJobOverview.class);
         assertEquals(n, jobsList.getActiveJobs().size());
-        assertEquals(expectedJobIdList, new HashSet<>(jobsList.getActiveJobs()));
+        assertEquals(expectedJobIdList, jobsList.getActiveJobs());
         assertEquals(n, jobsList.getEndPosition());
 
-        Set<String> resJobsSet = new HashSet<>();
+        List<String> resJobsList = new ArrayList<>();
         int start = 0;
 
         do {
@@ -464,11 +467,11 @@ public class ResourceClusterActorTest {
                     .build(),
                 probe.getRef());
             jobsList = probe.expectMsgClass(PagedActiveJobOverview.class);
-            resJobsSet.addAll(jobsList.getActiveJobs());
+            resJobsList.addAll(jobsList.getActiveJobs());
             assertTrue(jobsList.getActiveJobs().size() <= 5);
             start = jobsList.getEndPosition();
         } while (jobsList.getActiveJobs().size() > 0);
-        assertEquals(expectedJobIdList, resJobsSet);
+        assertEquals(expectedJobIdList, resJobsList);
     }
 
     @Test


### PR DESCRIPTION
### Context

Add API to fetch active jobs for a given resource cluster ID.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
