### PR TITLE
Fix dead letter Ack from RC scaler

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -259,9 +259,6 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
     private void onTriggerClusterRuleRefreshRequest(TriggerClusterRuleRefreshRequest req) {
         log.info("{}: Requesting cluster rule refresh", this.clusterId);
         this.fetchRuleSet();
-
-        // when calling from API there is no need to wait.
-        getSender().tell(Ack.getInstance(), self());
     }
 
     private void fetchRuleSet() {


### PR DESCRIPTION
### Context

The ack returned to self() after the async pipe operation is redirected to the dead-letter actor since the self() reference is lost. I am removing the extra Ack from the call.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
