### PR TITLE
Add ContainerSkuID to StageSchedulingInfo

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/SchedulingInfo.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/SchedulingInfo.java
@@ -23,7 +23,10 @@ import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnore;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -93,12 +96,36 @@ public class SchedulingInfo implements Serializable {
                             .build());
         }
 
+        public Builder singleWorkerStageWithConstraints(
+            MachineDefinition machineDefinition,
+            List<JobConstraints> hardConstraints,
+            List<JobConstraints> softConstraints,
+            Map<String, String> containerAttributes) {
+            return this.addStage(
+                StageSchedulingInfo.builder()
+                    .numberOfInstances(1)
+                    .machineDefinition(machineDefinition)
+                    .hardConstraints(hardConstraints)
+                    .softConstraints(softConstraints)
+                    .containerAttributes(containerAttributes)
+                    .build());
+        }
+
         public Builder singleWorkerStage(MachineDefinition machineDefinition) {
             return this.addStage(
                     StageSchedulingInfo.builder()
                             .numberOfInstances(1)
                             .machineDefinition(machineDefinition)
                             .build());
+        }
+
+        public Builder singleWorkerStage(MachineDefinition machineDefinition, Map<String, String> containerAttributes) {
+            return this.addStage(
+                StageSchedulingInfo.builder()
+                    .numberOfInstances(1)
+                    .machineDefinition(machineDefinition)
+                    .containerAttributes(containerAttributes)
+                    .build());
         }
 
         public Builder multiWorkerScalableStageWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
@@ -117,6 +144,23 @@ public class SchedulingInfo implements Serializable {
                             .build());
         }
 
+        public Builder multiWorkerScalableStageWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
+            List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints,
+            StageScalingPolicy scalingPolicy, Map<String, String> containerAttributes) {
+            StageScalingPolicy ssp = new StageScalingPolicy(currentStage, scalingPolicy.getMin(), scalingPolicy.getMax(),
+                scalingPolicy.getIncrement(), scalingPolicy.getDecrement(), scalingPolicy.getCoolDownSecs(), scalingPolicy.getStrategies());
+            return this.addStage(
+                StageSchedulingInfo.builder()
+                    .numberOfInstances(numberOfWorkers)
+                    .machineDefinition(machineDefinition)
+                    .hardConstraints(hardConstraints)
+                    .softConstraints(softConstraints)
+                    .scalingPolicy(ssp)
+                    .scalable(ssp.isEnabled())
+                    .containerAttributes(containerAttributes)
+                    .build());
+        }
+
         public Builder multiWorkerStageWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
                                                        List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints) {
             return this.addStage(
@@ -128,8 +172,25 @@ public class SchedulingInfo implements Serializable {
                             .build());
         }
 
+        public Builder multiWorkerStageWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
+            List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints, Map<String, String> containerAttributes) {
+            return this.addStage(
+                StageSchedulingInfo.builder()
+                    .numberOfInstances(numberOfWorkers)
+                    .machineDefinition(machineDefinition)
+                    .hardConstraints(hardConstraints)
+                    .softConstraints(softConstraints)
+                    .containerAttributes(containerAttributes)
+                    .build());
+        }
+
         public Builder multiWorkerStage(int numberOfWorkers, MachineDefinition machineDefinition) {
             return multiWorkerStage(numberOfWorkers, machineDefinition, false);
+        }
+
+        public Builder multiWorkerStage(
+            int numberOfWorkers, MachineDefinition machineDefinition, Map<String, String> containerAttributes) {
+            return multiWorkerStage(numberOfWorkers, machineDefinition, false, containerAttributes);
         }
 
         public Builder multiWorkerStage(int numberOfWorkers, MachineDefinition machineDefinition, boolean scalable) {
@@ -139,6 +200,18 @@ public class SchedulingInfo implements Serializable {
                             .machineDefinition(machineDefinition)
                             .scalable(scalable)
                             .build());
+        }
+
+        public Builder multiWorkerStage(
+            int numberOfWorkers, MachineDefinition machineDefinition, boolean scalable,
+            Map<String, String> containerAttributes) {
+            return this.addStage(
+                StageSchedulingInfo.builder()
+                    .numberOfInstances(numberOfWorkers)
+                    .machineDefinition(machineDefinition)
+                    .scalable(scalable)
+                    .containerAttributes(containerAttributes)
+                    .build());
         }
 
         /**

--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageSchedulingInfo.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageSchedulingInfo.java
@@ -20,9 +20,12 @@ import io.mantisrx.runtime.JobConstraints;
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonInclude;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonInclude.Include;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Singular;
 
@@ -38,6 +41,12 @@ public class StageSchedulingInfo implements Serializable {
     private final StageScalingPolicy scalingPolicy;
     private final boolean scalable;
 
+    /**
+     * Nullable field to store container attributes like sku ID assigned to this stage.
+     */
+    @JsonInclude(Include.NON_NULL)
+    private final Map<String, String> containerAttributes;
+
     @JsonCreator
     @JsonIgnoreProperties(ignoreUnknown = true)
     public StageSchedulingInfo(@JsonProperty("numberOfInstances") int numberOfInstances,
@@ -45,7 +54,8 @@ public class StageSchedulingInfo implements Serializable {
                                @JsonProperty("hardConstraints") List<JobConstraints> hardConstraints,
                                @JsonProperty("softConstraints") List<JobConstraints> softConstraints,
                                @JsonProperty("scalingPolicy") StageScalingPolicy scalingPolicy,
-                               @JsonProperty("scalable") boolean scalable) {
+                               @JsonProperty("scalable") boolean scalable,
+                               @JsonProperty("containerAttributes") Map<String, String> containerAttributes) {
         this.numberOfInstances = numberOfInstances;
         this.machineDefinition = machineDefinition;
         this.hardConstraints = hardConstraints;
@@ -53,6 +63,7 @@ public class StageSchedulingInfo implements Serializable {
         this.scalingPolicy = scalingPolicy;
 
         this.scalable = scalable;
+        this.containerAttributes = containerAttributes;
     }
 
     public int getNumberOfInstances() {
@@ -79,6 +90,10 @@ public class StageSchedulingInfo implements Serializable {
         return scalable;
     }
 
+    public Map<String, String> getContainerAttributes() {
+        return this.containerAttributes;
+    }
+
     @Override
     public String toString() {
         return "StageSchedulingInfo{" +
@@ -88,6 +103,7 @@ public class StageSchedulingInfo implements Serializable {
                 ", softConstraints=" + softConstraints +
                 ", scalingPolicy=" + scalingPolicy +
                 ", scalable=" + scalable +
+                ", containerAttributes=" + containerAttributes +
                 '}';
     }
 
@@ -101,6 +117,7 @@ public class StageSchedulingInfo implements Serializable {
         result = prime * result + (scalable ? 1231 : 1237);
         result = prime * result + ((scalingPolicy == null) ? 0 : scalingPolicy.hashCode());
         result = prime * result + ((softConstraints == null) ? 0 : softConstraints.hashCode());
+        result = prime * result + ((containerAttributes == null) ? 0 : containerAttributes.hashCode());
         return result;
     }
 
@@ -136,6 +153,11 @@ public class StageSchedulingInfo implements Serializable {
             if (other.softConstraints != null)
                 return false;
         } else if (!softConstraints.equals(other.softConstraints))
+            return false;
+        if (containerAttributes == null) {
+            if (other.containerAttributes != null)
+                return false;
+        } else if (!containerAttributes.equals(other.containerAttributes))
             return false;
         return true;
     }

--- a/mantis-common/src/test/java/io/mantisrx/runtime/descriptor/SchedulingInfoTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/runtime/descriptor/SchedulingInfoTest.java
@@ -18,11 +18,12 @@ package io.mantisrx.runtime.descriptor;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import io.mantisrx.common.JsonSerializer;
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.runtime.descriptor.SchedulingInfo.Builder;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
@@ -247,6 +248,121 @@ public class SchedulingInfoTest {
             "                \"enabled\": true" +
             "            }," +
             "            \"scalable\": true" +
+            "        }" +
+            "    }" +
+            "}";
+        assertEquals(expected.replaceAll("\\s+", ""), serializer.toJson(builder.build()));
+    }
+
+    @Test
+    public void testSerializationWithSkuId() throws Exception {
+        Map<StageScalingPolicy.ScalingReason, StageScalingPolicy.Strategy> smap = new HashMap<>();
+        smap.put(StageScalingPolicy.ScalingReason.Memory, new StageScalingPolicy.Strategy(StageScalingPolicy.ScalingReason.Memory, 0.1, 0.6, null));
+        Builder builder = new Builder()
+            .numberOfStages(2)
+            .multiWorkerScalableStageWithConstraints(
+                2,
+                new MachineDefinition(1, 1.24, 0.0, 1, 1),
+                null, null,
+                new StageScalingPolicy(1, 1, 3, 1, 1, 60, smap),
+                ImmutableMap.of("containerSkuID", "sku1")
+            )
+            .multiWorkerScalableStageWithConstraints(
+                3,
+                new MachineDefinition(1, 1.24, 0.0, 1, 1),
+                null, null,
+                new StageScalingPolicy(1, 1, 3, 1, 1, 60, smap),
+                ImmutableMap.of("containerSkuID", "sku2")
+            );
+
+        JsonSerializer serializer = new JsonSerializer();
+        String expected = "" +
+            "{" +
+            "    \"stages\":" +
+            "    {" +
+            "        \"1\":" +
+            "        {" +
+            "            \"numberOfInstances\": 2," +
+            "            \"machineDefinition\":" +
+            "            {" +
+            "                \"cpuCores\": 1.0," +
+            "                \"memoryMB\": 1.24," +
+            "                \"networkMbps\": 128.0," +
+            "                \"diskMB\": 1.0," +
+            "                \"numPorts\": 1" +
+            "            }," +
+            "            \"hardConstraints\":" +
+            "            []," +
+            "            \"softConstraints\":" +
+            "            []," +
+            "            \"scalingPolicy\":" +
+            "            {" +
+            "                \"stage\": 1," +
+            "                \"min\": 1," +
+            "                \"max\": 3," +
+            "                \"increment\": 1," +
+            "                \"decrement\": 1," +
+            "                \"coolDownSecs\": 60," +
+            "                \"strategies\":" +
+            "                {" +
+            "                    \"Memory\":" +
+            "                    {" +
+            "                        \"reason\": \"Memory\"," +
+            "                        \"scaleDownBelowPct\": 0.1," +
+            "                        \"scaleUpAbovePct\": 0.6," +
+            "                        \"rollingCount\":" +
+            "                        {" +
+            "                            \"count\": 1," +
+            "                            \"of\": 1" +
+            "                        }" +
+            "                    }" +
+            "                }," +
+            "                \"enabled\": true" +
+            "            }," +
+            "            \"scalable\": true," +
+            "            \"containerAttributes\": {\"containerSkuID\":\"sku1\"}" +
+            "        }," +
+            "        \"2\":" +
+            "        {" +
+            "            \"numberOfInstances\": 3," +
+            "            \"machineDefinition\":" +
+            "            {" +
+            "                \"cpuCores\": 1.0," +
+            "                \"memoryMB\": 1.24," +
+            "                \"networkMbps\": 128.0," +
+            "                \"diskMB\": 1.0," +
+            "                \"numPorts\": 1" +
+            "            }," +
+            "            \"hardConstraints\":" +
+            "            []," +
+            "            \"softConstraints\":" +
+            "            []," +
+            "            \"scalingPolicy\":" +
+            "            {" +
+            "                \"stage\": 2," +
+            "                \"min\": 1," +
+            "                \"max\": 3," +
+            "                \"increment\": 1," +
+            "                \"decrement\": 1," +
+            "                \"coolDownSecs\": 60," +
+            "                \"strategies\":" +
+            "                {" +
+            "                    \"Memory\":" +
+            "                    {" +
+            "                        \"reason\": \"Memory\"," +
+            "                        \"scaleDownBelowPct\": 0.1," +
+            "                        \"scaleUpAbovePct\": 0.6," +
+            "                        \"rollingCount\":" +
+            "                        {" +
+            "                            \"count\": 1," +
+            "                            \"of\": 1" +
+            "                        }" +
+            "                    }" +
+            "                }," +
+            "                \"enabled\": true" +
+            "            }," +
+            "            \"scalable\": true," +
+            "            \"containerAttributes\": {\"containerSkuID\":\"sku2\"}" +
             "        }" +
             "    }" +
             "}";

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/MantisResourceClusterSpec.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/MantisResourceClusterSpec.java
@@ -91,11 +91,11 @@ public class MantisResourceClusterSpec {
 
         int cpuCoreCount;
 
-        int memorySizeInBytes;
+        int memorySizeInMB;
 
         int networkMbps;
 
-        int diskSizeInBytes;
+        int diskSizeInMB;
 
         @Singular
         Map<String, String> skuMetadataFields;
@@ -106,17 +106,17 @@ public class MantisResourceClusterSpec {
                 @JsonProperty("capacity") final SkuCapacity capacity,
                 @JsonProperty("imageId") final String imageId,
                 @JsonProperty("cpuCoreCount") final int cpuCoreCount,
-                @JsonProperty("memorySizeInBytes") final int memorySizeInBytes,
+                @JsonProperty("memorySizeInBytes") final int memorySizeInMB,
                 @JsonProperty("networkMbps") final int networkMbps,
-                @JsonProperty("diskSizeInBytes") final int diskSizeInBytes,
+                @JsonProperty("diskSizeInBytes") final int diskSizeInMB,
                 @JsonProperty("skuMetadataFields") final Map<String, String> skuMetadataFields) {
             this.skuId = skuId;
             this.capacity = capacity;
             this.imageId = imageId;
             this.cpuCoreCount = cpuCoreCount;
-            this.memorySizeInBytes = memorySizeInBytes;
+            this.memorySizeInMB = memorySizeInMB;
             this.networkMbps = networkMbps;
-            this.diskSizeInBytes = diskSizeInBytes;
+            this.diskSizeInMB = diskSizeInMB;
             this.skuMetadataFields = skuMetadataFields;
         }
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActorTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActorTests.java
@@ -140,6 +140,222 @@ public class ResourceClustersHostManagerActorTests {
     }
 
     @Test
+    public void testProvisionSpecError() {
+        TestKit probe = new TestKit(system);
+        ResourceClusterStorageProvider resStorageProvider = mock(ResourceClusterStorageProvider.class);
+        ResourceClusterProvider resProvider = mock(ResourceClusterProvider.class);
+        ResourceClusterResponseHandler responseHandler = mock(ResourceClusterResponseHandler.class);
+
+        ResourceClusterProvisionSubmissionResponse provisionResponse =
+            ResourceClusterProvisionSubmissionResponse.builder().response("123").build();
+        when(resProvider.provisionClusterIfNotPresent(any())).thenReturn(CompletableFuture.completedFuture(
+            provisionResponse
+        ));
+
+        when(resProvider.getResponseHandler()).thenReturn(responseHandler);
+
+        ActorRef resourceClusterHostActor = system.actorOf(
+            ResourceClustersHostManagerActor.props(resProvider, resStorageProvider));
+
+        ProvisionResourceClusterRequest request =
+            ProvisionResourceClusterRequest.builder()
+                .clusterId(ClusterID.of("id1"))
+                .build();;
+
+        resourceClusterHostActor.tell(request, probe.getRef());
+        GetResourceClusterResponse createResp = probe.expectMsgClass(GetResourceClusterResponse.class);
+        assertEquals(ResponseCode.CLIENT_ERROR, createResp.responseCode);
+        verify(resProvider, times(0)).provisionClusterIfNotPresent(any());
+
+        request =
+            ProvisionResourceClusterRequest.builder()
+                .clusterId(ClusterID.of("id1"))
+                .clusterSpec(MantisResourceClusterSpec.builder()
+                    .id(ClusterID.of("id2"))
+                        .build())
+                .build();
+
+        resourceClusterHostActor.tell(request, probe.getRef());
+        createResp = probe.expectMsgClass(GetResourceClusterResponse.class);
+        assertEquals(ResponseCode.CLIENT_ERROR, createResp.responseCode);
+        verify(resProvider, times(0)).provisionClusterIfNotPresent(any());
+
+        request =
+            ProvisionResourceClusterRequest.builder()
+                .clusterId(ClusterID.of("id1"))
+                .clusterSpec(MantisResourceClusterSpec.builder()
+                    .id(ClusterID.of("id1"))
+                    .name("id1name")
+                    .envType(MantisResourceClusterEnvType.Prod)
+                    .ownerEmail("user")
+                    .ownerName("user")
+                    .skuSpec(MantisResourceClusterSpec.SkuTypeSpec.builder()
+                        //.skuId(ContainerSkuID.of("small"))
+                        .capacity(MantisResourceClusterSpec.SkuCapacity.builder()
+                            .skuId(ContainerSkuID.of("small"))
+                            .desireSize(2)
+                            .maxSize(3)
+                            .minSize(1)
+                            .build())
+                        .cpuCoreCount(2)
+                        .memorySizeInMB(16384)
+                        .diskSizeInMB(81920)
+                        .networkMbps(700)
+                        .imageId("dev/mantistaskexecutor:main-latest")
+                        .skuMetadataField(
+                            "skuKey",
+                            "us-east-1")
+                        .skuMetadataField(
+                            "sgKey",
+                            "sg-11, sg-22, sg-33, sg-44")
+                        .build())
+                    .build())
+                .build();
+        resourceClusterHostActor.tell(request, probe.getRef());
+        createResp = probe.expectMsgClass(GetResourceClusterResponse.class);
+        assertEquals(ResponseCode.CLIENT_ERROR, createResp.responseCode);
+        verify(resProvider, times(0)).provisionClusterIfNotPresent(any());
+
+        request =
+            ProvisionResourceClusterRequest.builder()
+                .clusterId(ClusterID.of("id1"))
+                .clusterSpec(MantisResourceClusterSpec.builder()
+                    .id(ClusterID.of("id1"))
+                    .name("id1name")
+                    .envType(MantisResourceClusterEnvType.Prod)
+                    .ownerEmail("user")
+                    .ownerName("user")
+                    .skuSpec(MantisResourceClusterSpec.SkuTypeSpec.builder()
+                        .skuId(ContainerSkuID.of("small"))
+                        .cpuCoreCount(2)
+                        .memorySizeInMB(16384)
+                        .diskSizeInMB(81920)
+                        .networkMbps(700)
+                        .imageId("dev/mantistaskexecutor:main-latest")
+                        .skuMetadataField(
+                            "skuKey",
+                            "us-east-1")
+                        .skuMetadataField(
+                            "sgKey",
+                            "sg-11, sg-22, sg-33, sg-44")
+                        .build())
+                    .build())
+                .build();
+        resourceClusterHostActor.tell(request, probe.getRef());
+        createResp = probe.expectMsgClass(GetResourceClusterResponse.class);
+        assertEquals(ResponseCode.CLIENT_ERROR, createResp.responseCode);
+        verify(resProvider, times(0)).provisionClusterIfNotPresent(any());
+
+        request =
+            ProvisionResourceClusterRequest.builder()
+                .clusterId(ClusterID.of("id1"))
+                .clusterSpec(MantisResourceClusterSpec.builder()
+                    .id(ClusterID.of("id1"))
+                    .name("id1name")
+                    .envType(MantisResourceClusterEnvType.Prod)
+                    .ownerEmail("user")
+                    .ownerName("user")
+                    .skuSpec(MantisResourceClusterSpec.SkuTypeSpec.builder()
+                        .skuId(ContainerSkuID.of("small"))
+                        .capacity(MantisResourceClusterSpec.SkuCapacity.builder()
+                            .skuId(ContainerSkuID.of("small"))
+                            .desireSize(2)
+                            .maxSize(3)
+                            .minSize(1)
+                            .build())
+                        .memorySizeInMB(16384)
+                        .diskSizeInMB(81920)
+                        .networkMbps(700)
+                        .imageId("dev/mantistaskexecutor:main-latest")
+                        .skuMetadataField(
+                            "skuKey",
+                            "us-east-1")
+                        .skuMetadataField(
+                            "sgKey",
+                            "sg-11, sg-22, sg-33, sg-44")
+                        .build())
+                    .build())
+                .build();
+        resourceClusterHostActor.tell(request, probe.getRef());
+        createResp = probe.expectMsgClass(GetResourceClusterResponse.class);
+        assertEquals(ResponseCode.CLIENT_ERROR, createResp.responseCode);
+        verify(resProvider, times(0)).provisionClusterIfNotPresent(any());
+
+        request =
+            ProvisionResourceClusterRequest.builder()
+                .clusterId(ClusterID.of("id1"))
+                .clusterSpec(MantisResourceClusterSpec.builder()
+                    .id(ClusterID.of("id1"))
+                    .name("id1name")
+                    .envType(MantisResourceClusterEnvType.Prod)
+                    .ownerEmail("user")
+                    .ownerName("user")
+                    .skuSpec(MantisResourceClusterSpec.SkuTypeSpec.builder()
+                        .skuId(ContainerSkuID.of("small"))
+                        .capacity(MantisResourceClusterSpec.SkuCapacity.builder()
+                            .skuId(ContainerSkuID.of("small"))
+                            .desireSize(2)
+                            .maxSize(3)
+                            .minSize(1)
+                            .build())
+                        .cpuCoreCount(2)
+                        .diskSizeInMB(81920)
+                        .networkMbps(700)
+                        .imageId("dev/mantistaskexecutor:main-latest")
+                        .skuMetadataField(
+                            "skuKey",
+                            "us-east-1")
+                        .skuMetadataField(
+                            "sgKey",
+                            "sg-11, sg-22, sg-33, sg-44")
+                        .build())
+                    .build())
+                .build();
+        resourceClusterHostActor.tell(request, probe.getRef());
+        createResp = probe.expectMsgClass(GetResourceClusterResponse.class);
+        assertEquals(ResponseCode.CLIENT_ERROR, createResp.responseCode);
+        verify(resProvider, times(0)).provisionClusterIfNotPresent(any());
+
+        request =
+            ProvisionResourceClusterRequest.builder()
+                .clusterId(ClusterID.of("id1"))
+                .clusterSpec(MantisResourceClusterSpec.builder()
+                    .id(ClusterID.of("id1"))
+                    .name("id1name")
+                    .envType(MantisResourceClusterEnvType.Prod)
+                    .ownerEmail("user")
+                    .ownerName("user")
+                    .skuSpec(MantisResourceClusterSpec.SkuTypeSpec.builder()
+                        .skuId(ContainerSkuID.of("small"))
+                        .capacity(MantisResourceClusterSpec.SkuCapacity.builder()
+                            .skuId(ContainerSkuID.of("small"))
+                            .desireSize(2)
+                            .maxSize(3)
+                            .minSize(1)
+                            .build())
+                        .cpuCoreCount(2)
+                        .memorySizeInMB(16384)
+                        .diskSizeInMB(0)
+                        .networkMbps(700)
+                        .imageId("dev/mantistaskexecutor:main-latest")
+                        .skuMetadataField(
+                            "skuKey",
+                            "us-east-1")
+                        .skuMetadataField(
+                            "sgKey",
+                            "sg-11, sg-22, sg-33, sg-44")
+                        .build())
+                    .build())
+                .build();
+        resourceClusterHostActor.tell(request, probe.getRef());
+        createResp = probe.expectMsgClass(GetResourceClusterResponse.class);
+        assertEquals(ResponseCode.CLIENT_ERROR, createResp.responseCode);
+        verify(resProvider, times(0)).provisionClusterIfNotPresent(any());
+
+        probe.getSystem().stop(resourceClusterHostActor);
+    }
+
+    @Test
     public void testProvisionPersisError() {
         TestKit probe = new TestKit(system);
         ResourceClusterStorageProvider resStorageProvider = mock(ResourceClusterStorageProvider.class);
@@ -274,8 +490,8 @@ public class ResourceClustersHostManagerActorTests {
                                         .minSize(1)
                                         .build())
                                 .cpuCoreCount(2)
-                                .memorySizeInBytes(16384)
-                                .diskSizeInBytes(81920)
+                                .memorySizeInMB(16384)
+                                .diskSizeInMB(81920)
                                 .networkMbps(700)
                                 .imageId("dev/mantistaskexecutor:main-latest")
                                 .skuMetadataField(

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
@@ -140,8 +140,8 @@ public class SimpleFileResourceStorageProviderTests {
                                 .minSize(1)
                                 .build())
                         .cpuCoreCount(5)
-                        .memorySizeInBytes(16384)
-                        .diskSizeInBytes(81920)
+                        .memorySizeInMB(16384)
+                        .diskSizeInMB(81920)
                         .networkMbps(700)
                         .imageId("mantistaskexecutor:main.latest")
                         .skuMetadataField(
@@ -183,7 +183,7 @@ public class SimpleFileResourceStorageProviderTests {
                     + "\"capacity\":{\"skuId\":{\"resourceID\":\"small\"}," +
                         "\"minSize\":1,\"maxSize\":3,\"desireSize\":2},\"imageId\":\"mantistaskexecutor:main"
                         + ".latest\"," +
-                        "\"cpuCoreCount\":5,\"memorySizeInBytes\":16384,\"networkMbps\":700,\"diskSizeInBytes\":81920," +
+                        "\"cpuCoreCount\":5,\"memorySizeInMB\":16384,\"networkMbps\":700,\"diskSizeInMB\":81920," +
                         "\"skuMetadataFields\":{\"skuKey\":\"us-east-1\","
                         + "\"sgKey\":\"sg-1," +
                         " sg-2, sg-3, sg-4\"}}],\"clusterMetadataFields\":{}}}",
@@ -206,8 +206,8 @@ public class SimpleFileResourceStorageProviderTests {
                                 .minSize(1)
                                 .build())
                         .cpuCoreCount(19)
-                        .memorySizeInBytes(54321)
-                        .diskSizeInBytes(998877)
+                        .memorySizeInMB(54321)
+                        .diskSizeInMB(998877)
                         .networkMbps(3300)
                         .imageId("dev/mantistaskexecutor:main.2")
                         .skuMetadataField(
@@ -244,8 +244,8 @@ public class SimpleFileResourceStorageProviderTests {
                     + "\"skuSpecs\":[{\"skuId\":{\"resourceID\":\"large\"},"
                         + "\"capacity\":{\"skuId\":{\"resourceID\":\"large\"},\"minSize\":1,\"maxSize\":4,"
                     + "\"desireSize\":3},\"imageId\""
-                        + ":\"dev/mantistaskexecutor:main.2\",\"cpuCoreCount\":19,\"memorySizeInBytes\":54321,"
-                        + "\"networkMbps\":3300,\"diskSizeInBytes\":998877,\"skuMetadataFields\":"
+                        + ":\"dev/mantistaskexecutor:main.2\",\"cpuCoreCount\":19,\"memorySizeInMB\":54321,"
+                        + "\"networkMbps\":3300,\"diskSizeInMB\":998877,\"skuMetadataFields\":"
                         + "{\"skuKey\":\"us-east-1\",\"sgKey\":\"sg-1, sg-2, sg-3, sg-4\"}}],"
                         + "\"clusterMetadataFields\":{}}}",
                 Files.readAllLines(clusterFilePath2).stream().collect(Collectors.joining()));

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/SimpleFileResourceStorageProviderTests.java
@@ -180,13 +180,13 @@ public class SimpleFileResourceStorageProviderTests {
                 "{\"version\":\"v1\",\"id\":{\"resourceID\":\"mantisRCMTest2\"},\"clusterSpec\":{\"name\":\"mantisRCMTest2\"," +
                         "\"id\":{\"resourceID\":\"mantisRCMTest2\"},\"ownerName\":\"andyz@netflix.com\",\"ownerEmail\":\"andyz@netflix.com\"," +
                         "\"envType\":\"Prod\",\"skuSpecs\":[{\"skuId\":{\"resourceID\":\"small\"},"
-                    + "\"capacity\":{\"skuId\":{\"resourceID\":\"small\"}," +
-                        "\"minSize\":1,\"maxSize\":3,\"desireSize\":2},\"imageId\":\"mantistaskexecutor:main"
-                        + ".latest\"," +
-                        "\"cpuCoreCount\":5,\"memorySizeInMB\":16384,\"networkMbps\":700,\"diskSizeInMB\":81920," +
-                        "\"skuMetadataFields\":{\"skuKey\":\"us-east-1\","
-                        + "\"sgKey\":\"sg-1," +
-                        " sg-2, sg-3, sg-4\"}}],\"clusterMetadataFields\":{}}}",
+                        + "\"capacity\":{\"skuId\":{\"resourceID\":\"small\"},"
+                        + "\"minSize\":1,\"maxSize\":3,\"desireSize\":2},\"imageId\":\"mantistaskexecutor:main"
+                        + ".latest\",\"cpuCoreCount\":5,\"networkMbps\":700,"
+                        + "\"skuMetadataFields\":{\"skuKey\":\"us-east-1\","
+                        + "\"sgKey\":\"sg-1,"
+                        + " sg-2, sg-3, sg-4\"},\"memorySizeInMB\":16384,\"diskSizeInMB\":81920}],"
+                        + "\"clusterMetadataFields\":{}}}",
                 Files.readAllLines(clusterFilePath).stream().collect(Collectors.joining()));
 
         //// Test register second cluster.
@@ -241,12 +241,13 @@ public class SimpleFileResourceStorageProviderTests {
                 "{\"version\":\"v2\",\"id\":{\"resourceID\":\"clusterApp2\"},\"clusterSpec\":{\"name\":\"clusterApp2\","
                         + "\"id\":{\"resourceID\":\"clusterApp2\"},\"ownerName\":\"mantisrx@netflix.com\",\"ownerEmail\":"
                         + "\"mantisrx@netflix.com\",\"envType\":\"Prod\","
-                    + "\"skuSpecs\":[{\"skuId\":{\"resourceID\":\"large\"},"
+                        + "\"skuSpecs\":[{\"skuId\":{\"resourceID\":\"large\"},"
                         + "\"capacity\":{\"skuId\":{\"resourceID\":\"large\"},\"minSize\":1,\"maxSize\":4,"
-                    + "\"desireSize\":3},\"imageId\""
-                        + ":\"dev/mantistaskexecutor:main.2\",\"cpuCoreCount\":19,\"memorySizeInMB\":54321,"
-                        + "\"networkMbps\":3300,\"diskSizeInMB\":998877,\"skuMetadataFields\":"
-                        + "{\"skuKey\":\"us-east-1\",\"sgKey\":\"sg-1, sg-2, sg-3, sg-4\"}}],"
+                        + "\"desireSize\":3},\"imageId\""
+                        + ":\"dev/mantistaskexecutor:main.2\",\"cpuCoreCount\":19,"
+                        + "\"networkMbps\":3300,\"skuMetadataFields\":"
+                        + "{\"skuKey\":\"us-east-1\",\"sgKey\":\"sg-1, sg-2, sg-3, sg-4\"},"
+                        + "\"memorySizeInMB\":54321,\"diskSizeInMB\":998877}],"
                         + "\"clusterMetadataFields\":{}}}",
                 Files.readAllLines(clusterFilePath2).stream().collect(Collectors.joining()));
 


### PR DESCRIPTION
### Context

* Move 'ContainerSkuID' and 'ClusterID' to common/contracts.
* Add 'ContainerSkuID' to 'StageSchedulingInfo' so it's available to the submit job APIs.


### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
