### PR TITLE
Handle null return values in load/get call for guava cacheloader

### DIFF
--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -3,7 +3,7 @@ name: "Publish snapshot to NetflixOSS and Maven Central"
 on:
   push:
     branches:
-      - '*'
+      - '**'
 
 jobs:
   build:


### PR DESCRIPTION
### Context

This effectively reverts #245 where we introduced a null return value in load/get method for guava cacheloader which isn't liked. I'm using an optional return value instead with an explicit null on any exception.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
