### PR TITLE
Defaulting to the mesos cluster in case of non-terminal events with unknown job definitions

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
@@ -1690,7 +1690,8 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
                         .forJob(jobDefinition)
                         .unscheduleAndTerminateWorker(r.getWorkerId(), host);
                 } else {
-                    logger.error("Non-terminal Event from worker {} has no completed job. Ignoring event ", r.getWorkerId());
+                    logger.warn("Non-terminal Event from worker {} has no completed job. Sending event to default cluster", r.getWorkerId());
+                    mantisSchedulerFactory.forClusterID(null).unscheduleAndTerminateWorker(r.getWorkerId(), host);
                 }
             } else {
                 logger.warn("Terminal Event from worker {} has no valid running job. Ignoring event ", r.getWorkerId());

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisSchedulerFactory.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisSchedulerFactory.java
@@ -18,13 +18,18 @@ package io.mantisrx.server.master.scheduler;
 
 import io.mantisrx.server.master.domain.JobDefinition;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
  * Factory for the Mantis Scheduler based on the JobDefinition
  */
+@FunctionalInterface
 public interface MantisSchedulerFactory {
-    MantisScheduler forJob(JobDefinition jobDefinition);
+    default MantisScheduler forJob(JobDefinition jobDefinition) {
+        Optional<ClusterID> clusterIDOptional = jobDefinition.getResourceCluster();
+        return forClusterID(clusterIDOptional.orElse(null));
+    }
 
     /**
      * returns the MantisScheduler based on the ClusterID.

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisSchedulerFactory.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisSchedulerFactory.java
@@ -17,10 +17,20 @@
 package io.mantisrx.server.master.scheduler;
 
 import io.mantisrx.server.master.domain.JobDefinition;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import javax.annotation.Nullable;
 
 /**
  * Factory for the Mantis Scheduler based on the JobDefinition
  */
 public interface MantisSchedulerFactory {
     MantisScheduler forJob(JobDefinition jobDefinition);
+
+    /**
+     * returns the MantisScheduler based on the ClusterID.
+     *
+     * @param clusterID cluster ID for which the mantisscheduler is requested.
+     * @return MantisScheduler corresponding to the ClusterID.
+     */
+    MantisScheduler forClusterID(@Nullable ClusterID clusterID);
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisSchedulerFactoryImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisSchedulerFactoryImpl.java
@@ -23,7 +23,6 @@ import io.mantisrx.common.metrics.MetricsRegistry;
 import io.mantisrx.server.master.ExecuteStageRequestFactory;
 import io.mantisrx.server.master.SchedulingService;
 import io.mantisrx.server.master.config.MasterConfiguration;
-import io.mantisrx.server.master.domain.JobDefinition;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ResourceClusters;
 import java.util.HashMap;
@@ -42,12 +41,6 @@ public class MantisSchedulerFactoryImpl implements MantisSchedulerFactory {
     private final MasterConfiguration masterConfiguration;
     private final MetricsRegistry metricsRegistry;
     private final Map<ClusterID, ActorRef> actorRefMap = new HashMap<>();
-
-    @Override
-    public MantisScheduler forJob(JobDefinition jobDefinition) {
-        Optional<ClusterID> clusterIDOptional = jobDefinition.getResourceCluster();
-        return forClusterID(clusterIDOptional.orElse(null));
-    }
 
     @Override
     public MantisScheduler forClusterID(@Nullable ClusterID clusterID) {


### PR DESCRIPTION
### Context

When we receive non-terminal events (such as heartbeats) for jobs that are currently not running according to the control plane, we send them to the resource cluster specified in their job definition to decommission them. However, we ignore the event if there's a failure to load the job definition at this point. This diff changes this behavior to assume that all ghost workers that don't have corresponding job definitions belong to mesos. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
