### PR TITLE
Provide a default implementation of EventPublisher::hasSubscriptions 

### DIFF
--- a/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/MantisEventPublisher.java
+++ b/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/MantisEventPublisher.java
@@ -19,7 +19,6 @@ package io.mantisrx.publish;
 import io.mantisrx.publish.api.Event;
 import io.mantisrx.publish.api.EventPublisher;
 import io.mantisrx.publish.api.PublishStatus;
-import io.mantisrx.publish.api.StreamType;
 import io.mantisrx.publish.config.MrePublishConfiguration;
 import io.mantisrx.publish.internal.metrics.StreamMetrics;
 import java.util.Optional;
@@ -43,11 +42,6 @@ public class MantisEventPublisher implements EventPublisher {
                                 StreamManager streamManager) {
         this.mrePublishConfiguration = mrePublishConfiguration;
         this.streamManager = streamManager;
-    }
-
-    @Override
-    public CompletionStage<PublishStatus> publish(final Event event) {
-        return publish(StreamType.DEFAULT_EVENT_STREAM, event);
     }
 
     @Override

--- a/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/api/EventPublisher.java
+++ b/mantis-publish/mantis-publish-core/src/main/java/io/mantisrx/publish/api/EventPublisher.java
@@ -59,7 +59,22 @@ public interface EventPublisher {
      * @param event event data to publish to Mantis
      * @return {@link CompletionStage<PublishStatus>} status of publishing the message
      */
-    CompletionStage<PublishStatus> publish(Event event);
+    default CompletionStage<PublishStatus> publish(Event event) {
+        return publish(StreamType.DEFAULT_EVENT_STREAM, event);
+    }
+
+    /**
+     * Returns whether or not this event publisher has active {@link Subscription}s on
+     * {@value StreamType#DEFAULT_EVENT_STREAM}
+     * <p>
+     * This method is useful for checking for the existence of a stream before
+     * calling {@link EventPublisher#publish(Event)} to avoid the performance penalty when there
+     * are no active subscriptions for the stream.
+     *
+     */
+    default boolean hasSubscriptions() {
+        return hasSubscriptions(StreamType.DEFAULT_EVENT_STREAM);
+    }
 
     /**
      * Returns whether or not this event publisher has active {@link Subscription}s.


### PR DESCRIPTION

### Context

`EventPublisher::publish` has a method that publishes events to a default stream. `hasSubscriptions` should have a similar method that defaults to the same stream.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
