### PR TITLE
Allowing the user to set the mesos executor username explicitly

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -156,6 +156,10 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("MantisFramework")
     String getMantisFrameworkName();
 
+    @Config("mantis.master.framework.user")
+    @Default("")
+    String getMantisFrameworkUserName();
+
     @Config("mantis.worker.executor.name")
     @Default("Mantis Worker Executor")
     String getWorkerExecutorName();

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/mesos/MesosDriverSupplier.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/mesos/MesosDriverSupplier.java
@@ -98,7 +98,7 @@ public class MesosDriverSupplier implements Supplier<MesosSchedulerDriver> {
                     new MesosSchedulerCallbackHandler(addVMLeaseAction, vmLeaseRescindedObserver, jobMessageRouter,
                             workerRegistry);
             final Protos.FrameworkInfo framework = Protos.FrameworkInfo.newBuilder()
-                    .setUser("")
+                    .setUser(masterConfig.getMantisFrameworkUserName())
                     .setName(masterConfig.getMantisFrameworkName())
                     .setFailoverTimeout(masterConfig.getMesosFailoverTimeOutSecs())
                     .setId(Protos.FrameworkID.newBuilder().setValue(masterConfig.getMantisFrameworkName()))


### PR DESCRIPTION
### Context

Previously, the username for the executor was assumed to be user that's running the scheduler framework. However, in some instances, we would want to set the username directly. This diff allows one to do that.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
