### PR TITLE
Making sure there are extra logs when publishing events to other components fails

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventPublisherImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventPublisherImpl.java
@@ -16,7 +16,9 @@
 
 package io.mantisrx.master.events;
 
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class LifecycleEventPublisherImpl implements LifecycleEventPublisher {
 
     private final AuditEventSubscriber auditEventSubscriber;
@@ -38,10 +40,14 @@ public class LifecycleEventPublisherImpl implements LifecycleEventPublisher {
 
     @Override
     public void publishStatusEvent(final LifecycleEventsProto.StatusEvent statusEvent) {
-        statusEventSubscriber.process(statusEvent);
-        if (statusEvent instanceof LifecycleEventsProto.JobStatusEvent) {
-            LifecycleEventsProto.JobStatusEvent jobStatusEvent = (LifecycleEventsProto.JobStatusEvent) statusEvent;
-            workerEventSubscriber.process(jobStatusEvent);
+        try {
+            statusEventSubscriber.process(statusEvent);
+            if (statusEvent instanceof LifecycleEventsProto.JobStatusEvent) {
+                LifecycleEventsProto.JobStatusEvent jobStatusEvent = (LifecycleEventsProto.JobStatusEvent) statusEvent;
+                workerEventSubscriber.process(jobStatusEvent);
+            }
+        } catch (Exception e) {
+            log.error("Failed to publish the event; Ignoring the failure as this is just a listener interface", e);
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventPublisherImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventPublisherImpl.java
@@ -47,7 +47,7 @@ public class LifecycleEventPublisherImpl implements LifecycleEventPublisher {
                 workerEventSubscriber.process(jobStatusEvent);
             }
         } catch (Exception e) {
-            log.error("Failed to publish the event; Ignoring the failure as this is just a listener interface", e);
+            log.error("Failed to publish the event={}; Ignoring the failure as this is just a listener interface", statusEvent, e);
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventsProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventsProto.java
@@ -28,6 +28,10 @@ import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.domain.DataFormatAdapter;
 import io.mantisrx.server.master.domain.JobId;
 import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
 public class LifecycleEventsProto {
 
@@ -95,6 +99,10 @@ public class LifecycleEventsProto {
         }
     }
 
+    @Getter
+    @EqualsAndHashCode
+    @AllArgsConstructor
+    @ToString
     public static class StatusEvent {
         public enum StatusEventType {
             ERROR, WARN, INFO, DEBUG, HEARTBEAT
@@ -106,26 +114,10 @@ public class LifecycleEventsProto {
         public StatusEvent(StatusEventType type, String message) {
             this(type, message, System.currentTimeMillis());
         }
-
-        public StatusEvent(StatusEventType type, String message, long ts) {
-            this.statusEventType = type;
-            this.message = message;
-            timestamp = ts;
-        }
-
-        public StatusEventType getStatusEventType() {
-            return statusEventType;
-        }
-
-        public String getMessage() {
-            return message;
-        }
-
-        public long getTimestamp() {
-            return timestamp;
-        }
     }
 
+    @Getter
+    @ToString
     public static final class WorkerStatusEvent extends StatusEvent {
         private final int stageNum;
         private final WorkerId workerId;
@@ -185,33 +177,9 @@ public class LifecycleEventsProto {
             this.workerState = workerState;
             this.hostName = hostName;
         }
-
-        public int getStageNum() {
-            return stageNum;
-        }
-
-        public WorkerId getWorkerId() {
-            return workerId;
-        }
-
-        public WorkerState getWorkerState() {
-            return workerState;
-        }
-
-        public Optional<String> getHostName() { return this.hostName; }
-
-        @Override
-        public String toString() {
-            return "WorkerStatusEvent{" +
-                    "stageNum=" + stageNum +
-                    ", workerId=" + workerId +
-                    ", workerState=" + workerState +
-                    ", hostName=" + hostName.orElse("") +
-                    '}';
-        }
-
     }
 
+    @ToString
     public static final class JobStatusEvent extends StatusEvent {
         private final JobId jobId;
         private final JobState jobState;
@@ -232,19 +200,9 @@ public class LifecycleEventsProto {
         public JobState getJobState() {
             return jobState;
         }
-
-        @Override
-        public String toString() {
-            return "JobStatusEvent{" +
-                "statusEventType=" + statusEventType +
-                ", message='" + message + '\'' +
-                ", timestamp=" + timestamp +
-                ", jobId='" + jobId + '\'' +
-                ", jobState=" + jobState +
-                '}';
-        }
     }
 
+    @ToString
     public static final class JobClusterStatusEvent extends StatusEvent {
         private final String jobCluster;
 
@@ -257,16 +215,6 @@ public class LifecycleEventsProto {
 
         public String getJobCluster() {
             return jobCluster;
-        }
-
-        @Override
-        public String toString() {
-            return "JobClusterStatusEvent{" +
-                "statusEventType=" + statusEventType +
-                ", message='" + message + '\'' +
-                ", timestamp=" + timestamp +
-                ", jobCluster='" + jobCluster + '\'' +
-                '}';
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -843,10 +843,10 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
         if (LOGGER.isDebugEnabled()) {
             LOGGER.info("shutting down job with metadata {}", mantisJobMetaData);
         }
-        eventPublisher.publishStatusEvent(new LifecycleEventsProto.JobStatusEvent(INFO,
+        try {
+            eventPublisher.publishStatusEvent(new LifecycleEventsProto.JobStatusEvent(INFO,
                 "Killing job, reason: " + req.reason,
                 getJobId(), getJobState()));
-        try {
             JobState newState;
             if (req.jobCompletedReason.equals(JobCompletedReason.Error)
                     || req.jobCompletedReason.equals(JobCompletedReason.Lost)) {


### PR DESCRIPTION
### Context

See these messages when the job was requested to be killed, but no more messages after that. 
```
2022-10-15 23:18:14.562  INFO 5863 --- [dispatcher-7242] i.m.m.j.JobClusterActor                  : JobClusterActor.onKillJobRequest KillJobRequest [jobId=RavenConnectorJob-1929614, reason=runtime limit reached, user=MantisMaster, requestor=null]
2022-10-15 23:18:14.563  INFO 5863 --- [dispatcher-7242] i.m.m.j.j.JobActor                       : Shutting down job RavenConnectorJob-1929614 on request by Actor[akka://MantisMaster/user/JobClustersManager/JobClusterActor-RavenConnectorJob#799277631]
```
### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
