### PR TITLE
Making sure resource cluster storage provider does not assume the root directory

### DIFF
--- a/mantis-common/build.gradle
+++ b/mantis-common/build.gradle
@@ -17,7 +17,6 @@
 apply plugin: 'java-test-fixtures'
 
 ext {
-    jacksonVersion = '2.10.+'
     jctoolsVersion = '1.+'
     nettyVersion = '4.1.17.Final'
     snappyVersion = '1.1.+'

--- a/mantis-common/src/test/java/io/mantisrx/runtime/parameter/TestSerialization.java
+++ b/mantis-common/src/test/java/io/mantisrx/runtime/parameter/TestSerialization.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.runtime.parameter;
+
+import static org.junit.Assert.assertEquals;
+
+import io.mantisrx.common.JsonSerializer;
+import org.junit.Test;
+
+public class TestSerialization {
+    private final JsonSerializer jsonSerializer = new JsonSerializer();
+
+    @Test
+    public void testSerializationOfParameters() throws Exception {
+        Parameter parameter = new Parameter("name", "value");
+        String expected = "{\"name\":\"name\",\"value\":\"value\"}";
+        assertEquals(expected, jsonSerializer.toJson(parameter));
+        Parameter actual = jsonSerializer.fromJSON(expected, Parameter.class);
+        assertEquals(parameter, actual);
+    }
+}


### PR DESCRIPTION
### Context

Resource Cluster Storage Provider was making assumptions about what the root directory was for the resource cluster storage provider. This diff aims to get rid of these assumptions. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
