### PR TITLE
Getting rid of hostname that's getting passed to RuntimeLoader

### DIFF
--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/RuntimeTask.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/RuntimeTask.java
@@ -23,7 +23,6 @@ import io.mantisrx.server.core.WrappedExecuteStageRequest;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.client.MantisMasterGateway;
 import io.mantisrx.shaded.com.google.common.util.concurrent.Service;
-import java.util.Optional;
 import org.apache.flink.util.UserCodeClassLoader;
 import rx.Observable;
 

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/RuntimeTask.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/RuntimeTask.java
@@ -33,8 +33,7 @@ public interface RuntimeTask extends Service {
                     WorkerConfiguration config,
                     MantisMasterGateway masterMonitor,
                     UserCodeClassLoader userCodeClassLoader,
-                    Factory sinkSubscriptionStateHandlerFactory,
-                    Optional<String> hostname);
+                    Factory sinkSubscriptionStateHandlerFactory);
 
     Observable<Status> getStatus();
 

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
@@ -41,6 +41,10 @@ public interface WorkerConfiguration extends CoreConfiguration {
     @DefaultNull
     String getTaskExecutorId();
 
+    default String getTaskExecutorHostName() {
+        return getExternalAddress();
+    }
+
     @Config("mantis.taskexecutor.cluster-id")
     @Default("DEFAULT_CLUSTER")
     String getClusterId();

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
@@ -464,9 +464,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
                 workerConfiguration,
                 masterMonitor,
                 userCodeClassLoader,
-                subscriptionStateHandlerFactory,
-                Optional.of(getHostname())
-            );
+                subscriptionStateHandlerFactory);
 
             scheduleRunAsync(() -> {
                 setCurrentTask(task);

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/Heartbeat.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/Heartbeat.java
@@ -27,6 +27,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,15 +44,15 @@ class Heartbeat {
     private final Optional<String> host;
 
     Heartbeat(String jobId, int stageNumber, int workerIndex, int workerNumber) {
-        this(jobId, stageNumber, workerIndex, workerNumber, Optional.empty());
+        this(jobId, stageNumber, workerIndex, workerNumber, null);
     }
 
-    Heartbeat(String jobId, int stageNumber, int workerIndex, int workerNumber, Optional<String> host) {
+    Heartbeat(String jobId, int stageNumber, int workerIndex, int workerNumber, @Nullable String host) {
         this.jobId = jobId;
         this.stageNumber = stageNumber;
         this.workerIndex = workerIndex;
         this.workerNumber = workerNumber;
-        this.host = host;
+        this.host = Optional.ofNullable(host);
         payloads = new ConcurrentHashMap<>();
     }
 

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/MantisWorker.java
@@ -151,9 +151,7 @@ public class MantisWorker extends BaseService {
                                     .Factory
                                     .forEphemeralJobsThatNeedToBeKilledInAbsenceOfSubscriber(
                                         gateway,
-                                        Clock.systemDefaultZone()),
-                                Optional.empty()
-                            );
+                                        Clock.systemDefaultZone()));
                             runtimeTaskImpl.setJob(jobToRun);
 
                             taskStatusUpdateSubscription =

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
@@ -57,9 +57,6 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
 
     private final PublishSubject<VirtualMachineTaskStatus> vmTaskStatusSubject = PublishSubject.create();
 
-    // hostname from which the task is run from
-    private Optional<String> hostname = Optional.empty();
-
     private Optional<Job> mantisJob = Optional.empty();
 
     private ExecuteStageRequest executeStageRequest;
@@ -78,15 +75,13 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
                            WorkerConfiguration config,
                            MantisMasterGateway masterMonitor,
                            UserCodeClassLoader userCodeClassLoader,
-                           SinkSubscriptionStateHandler.Factory sinkSubscriptionStateHandlerFactory,
-                           Optional<String> hostname) {
+                           SinkSubscriptionStateHandler.Factory sinkSubscriptionStateHandlerFactory) {
         this.wrappedExecuteStageRequest = wrappedExecuteStageRequest;
         this.executeStageRequest = wrappedExecuteStageRequest.getRequest();
         this.config = config;
         this.masterMonitor = masterMonitor;
         this.userCodeClassLoader = userCodeClassLoader;
         this.sinkSubscriptionStateHandlerFactory = sinkSubscriptionStateHandlerFactory;
-        this.hostname = hostname;
     }
 
     public void setJob(Optional<Job> job) {
@@ -120,8 +115,7 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
                 masterMonitor,
                 config,
                 workerMetricsClient,
-                sinkSubscriptionStateHandlerFactory,
-                hostname),
+                sinkSubscriptionStateHandlerFactory),
             getJobProviderClass(),
             userCodeClassLoader,
             mantisJob));

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/WorkerExecutionOperationsNetworkStage.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/WorkerExecutionOperationsNetworkStage.java
@@ -105,15 +105,13 @@ public class WorkerExecutionOperationsNetworkStage implements WorkerExecutionOpe
     private Action0 onSinkUnsubscribe = null;
     private final List<Closeable> closeables = new ArrayList<>();
     private final ScheduledExecutorService scheduledExecutorService;
-    private final Optional<String> hostname;
 
     public WorkerExecutionOperationsNetworkStage(
         Observer<VirtualMachineTaskStatus> vmTaskStatusObserver,
         MantisMasterGateway mantisMasterApi,
         WorkerConfiguration config,
         WorkerMetricsClient workerMetricsClient,
-        SinkSubscriptionStateHandler.Factory sinkSubscriptionStateHandlerFactory,
-        Optional<String> hostname) {
+        SinkSubscriptionStateHandler.Factory sinkSubscriptionStateHandlerFactory) {
         this.vmTaskStatusObserver = vmTaskStatusObserver;
         this.mantisMasterApi = mantisMasterApi;
         this.config = config;
@@ -130,7 +128,6 @@ public class WorkerExecutionOperationsNetworkStage implements WorkerExecutionOpe
             ServiceRegistry.INSTANCE.getPropertiesService().getStringValue("mantis.worker.locate.spectator.registry", "true");
         lookupSpectatorRegistry = Boolean.valueOf(locateSpectatorRegistry);
         scheduledExecutorService = new ScheduledThreadPoolExecutor(1);
-        this.hostname = hostname;
     }
 
     /**
@@ -356,7 +353,7 @@ public class WorkerExecutionOperationsNetworkStage implements WorkerExecutionOpe
             rw.setContext(context);
             // setup heartbeats
             heartbeatRef.set(new Heartbeat(rw.getJobId(),
-                    rw.getStageNum(), rw.getWorkerIndex(), rw.getWorkerNum(), hostname));
+                    rw.getStageNum(), rw.getWorkerIndex(), rw.getWorkerNum(), config.getTaskExecutorHostName()));
             final double networkMbps = executionRequest.getSchedulingInfo().forStage(rw.getStageNum()).getMachineDefinition().getNetworkMbps();
             Closeable heartbeatCloseable = startSendingHeartbeats(rw.getJobStatus(), networkMbps);
             closeables.add(heartbeatCloseable);


### PR DESCRIPTION
### Context

I think the server expects the hostname of a worker to be WorkerConfiguration::getExternalAddress (at least, that's what is set when the registration is sent; In mesos, this is set to the external IPV4). So, make sure we are using that consistently across the codebase. I'm also introducing a new method in WorkerConfiguration that also makes this the norm. 

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
