### PR TITLE
Move getUserCodeClassLoader to interface default

### DIFF
--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/TaskFactory.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/TaskFactory.java
@@ -25,7 +25,13 @@ import org.apache.flink.util.UserCodeClassLoader;
 public interface TaskFactory {
     RuntimeTask getRuntimeTaskInstance(ExecuteStageRequest request, ClassLoader cl);
 
-    UserCodeClassLoader getUserCodeClassLoader(
+    default UserCodeClassLoader getUserCodeClassLoader(
         ExecuteStageRequest request,
-        ClassLoaderHandle classLoaderHandle);
+        ClassLoaderHandle classLoaderHandle) {
+        try {
+            return classLoaderHandle.createUserCodeClassloader(request);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
 }

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/SingleTaskOnlyFactory.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/SingleTaskOnlyFactory.java
@@ -16,13 +16,11 @@
 
 package io.mantisrx.server.agent;
 
-import io.mantisrx.runtime.loader.ClassLoaderHandle;
 import io.mantisrx.runtime.loader.RuntimeTask;
 import io.mantisrx.runtime.loader.TaskFactory;
 import io.mantisrx.server.core.ExecuteStageRequest;
 import java.util.ServiceLoader;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.flink.util.UserCodeClassLoader;
 
 /**
  * This factory is used when there is only 1 RuntimeTask implementation.
@@ -34,17 +32,5 @@ public class SingleTaskOnlyFactory implements TaskFactory {
     public RuntimeTask getRuntimeTaskInstance(ExecuteStageRequest request, ClassLoader cl) {
         ServiceLoader<RuntimeTask> loader = ServiceLoader.load(RuntimeTask.class, cl);
         return loader.iterator().next();
-    }
-
-    @Override
-    public UserCodeClassLoader getUserCodeClassLoader(
-        ExecuteStageRequest request,
-        ClassLoaderHandle classLoaderHandle) {
-        try {
-            return classLoaderHandle.createUserCodeClassloader(request);
-        } catch (Exception ex) {
-            log.error("Failed to submit task, request: {}", request, ex);
-            throw new RuntimeException(ex);
-        }
     }
 }


### PR DESCRIPTION
### Context

Move getUserCodeClassLoader to have a default interface version.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
