### PR TITLE
Fix null exception on zk init

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/master/ZookeeperMasterMonitor.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/master/ZookeeperMasterMonitor.java
@@ -66,8 +66,7 @@ public class ZookeeperMasterMonitor extends AbstractIdleService implements Maste
 
         nodeMonitor.start(true);
 
-        byte[] initialValue = nodeMonitor.getCurrentData().getData();
-        onMasterNodeUpdated(initialValue);
+        onMasterNodeUpdated(nodeMonitor.getCurrentData() == null ? null : nodeMonitor.getCurrentData().getData());
         logger.info("The ZK master monitor has started");
     }
 


### PR DESCRIPTION
### Context

The zk monitor can hit nullptr exception if no existing leader data is ready in zk.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
