### PR TITLE
Resource Cluster Based Scheduler should be able to handle cancellation of running tasks without hostname

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/Status.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/Status.java
@@ -16,42 +16,34 @@
 
 package io.mantisrx.server.core;
 
+import io.mantisrx.common.JsonSerializer;
 import io.mantisrx.runtime.MantisJobState;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnore;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
-import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
-import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
-import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 
-//import io.mantisrx.server.master.domain.WorkerId;
-
-
+@Slf4j
 public class Status {
 
-    private static final ObjectMapper mapper;
-
-    static {
-        mapper = new ObjectMapper();
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-    }
-
+    @JsonIgnore
+    private final JsonSerializer jsonSerializer = new JsonSerializer();
     @JsonIgnore
     private final Optional<WorkerId> workerId;
-    private String jobId;
+    private final String jobId;
     private int stageNum;
     private int workerIndex;
-    private int workerNumber;
+    private final int workerNumber;
     private String hostname = null;
-    private TYPE type;
-    private String message;
-    private long timestamp;
-    private MantisJobState state;
+    private final TYPE type;
+    private final String message;
+    private final long timestamp;
+    private final MantisJobState state;
     private JobCompletedReason reason = JobCompletedReason.Normal;
     private List<Payload> payloads;
     @JsonCreator
@@ -151,8 +143,9 @@ public class Status {
     @Override
     public String toString() {
         try {
-            return mapper.writeValueAsString(this);
-        } catch (JsonProcessingException e) {
+            return jsonSerializer.toJson(this);
+        } catch (Exception e) {
+            log.error("Failed to serialize status", e);
             return "Error getting string for status on job " + jobId;
         }
     }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/Status.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/Status.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 public class Status {
 
     @JsonIgnore
-    private final JsonSerializer jsonSerializer = new JsonSerializer();
+    private static final JsonSerializer jsonSerializer = new JsonSerializer();
     @JsonIgnore
     private final Optional<WorkerId> workerId;
     private final String jobId;

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -78,6 +78,8 @@ public interface ResourceCluster extends ResourceClusterGateway {
 
     CompletableFuture<TaskExecutorRegistration> getTaskExecutorInfo(String hostName);
 
+    CompletableFuture<TaskExecutorID> getTaskExecutorAssignedFor(WorkerId workerId);
+
     CompletableFuture<TaskExecutorRegistration> getTaskExecutorInfo(TaskExecutorID taskExecutorID);
 
     CompletableFuture<TaskExecutorStatus> getTaskExecutorState(TaskExecutorID taskExecutorID);

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -78,6 +78,11 @@ public interface ResourceCluster extends ResourceClusterGateway {
 
     CompletableFuture<TaskExecutorRegistration> getTaskExecutorInfo(String hostName);
 
+    /**
+     * Gets the task executor's ID that's currently either running or is assigned for the given workerId
+     * @param workerId workerId whose current task executor is needed
+     * @return TaskExecutorID
+     */
     CompletableFuture<TaskExecutorID> getTaskExecutorAssignedFor(WorkerId workerId);
 
     CompletableFuture<TaskExecutorRegistration> getTaskExecutorInfo(TaskExecutorID taskExecutorID);

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -44,8 +44,9 @@ dependencies {
     api "com.github.spullara.cli-parser:cli-parser:$cliParserVersion"
     api "org.skife.config:config-magic:$configMagicVersion"
 
-    // todo: separate worker entrypoint and move this to testImplementation instead. 
+    // todo: separate worker entrypoint and move this to testImplementation instead.
     implementation libraries.spectatorApi
+    implementation libraries.spotifyFutures
 
     testImplementation "com.typesafe.akka:akka-testkit_$scalaBinaryVersion:$akkaVersion"
     testImplementation "com.typesafe.akka:akka-http-testkit_$scalaBinaryVersion:$akkaHttpVersion"

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/akka/MantisActorSupervisorStrategy.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/akka/MantisActorSupervisorStrategy.java
@@ -59,7 +59,7 @@ public class MantisActorSupervisorStrategy implements SupervisorStrategyConfigur
                 return SupervisorStrategy.stop();
             })
             .match(Exception.class, e -> {
-                LOGGER.info("resuming actor on exception {}", e.getMessage(), e);
+                LOGGER.error("resuming actor on exception {}", e.getMessage(), e);
                 ActorSystemMetrics.getInstance().incrementActorResumeCount();
                 return SupervisorStrategy.resume();
             })

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/worker/WorkerHeartbeat.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/worker/WorkerHeartbeat.java
@@ -28,10 +28,10 @@ import java.time.Instant;
  */
 public class WorkerHeartbeat implements WorkerEvent {
 
-    private WorkerId workerId;
-    private Status heartBeat;
-    private WorkerState workerState;
-    private long time;
+    private final WorkerId workerId;
+    private final Status heartBeat;
+    private final WorkerState workerState;
+    private final long time;
 
     /**
      * Creates an instance of this class from a {@link Status} object.
@@ -49,11 +49,8 @@ public class WorkerHeartbeat implements WorkerEvent {
      */
     public WorkerHeartbeat(Status hb, Instant time) {
         this.heartBeat = hb;
-        String jobId = heartBeat.getJobId();
-        int index = heartBeat.getWorkerIndex();
-        int number = heartBeat.getWorkerNumber();
         this.time = time.toEpochMilli();
-        workerId = new WorkerId(jobId, index, number);
+        workerId = hb.getWorkerId().get();
         workerState = setWorkerState(heartBeat.getState());
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/worker/WorkerStatus.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/worker/WorkerStatus.java
@@ -28,10 +28,10 @@ import java.time.Instant;
  */
 public class WorkerStatus implements WorkerEvent {
 
-    private WorkerId workerId;
-    private Status heartBeat;
-    private WorkerState workerState;
-    private long time;
+    private final WorkerId workerId;
+    private final Status heartBeat;
+    private final WorkerState workerState;
+    private final long time;
 
     /**
      * Creates an instance using the given {@link Status}.
@@ -49,11 +49,8 @@ public class WorkerStatus implements WorkerEvent {
      */
     public WorkerStatus(Status hb, Instant time) {
         this.heartBeat = hb;
-        String jobId = heartBeat.getJobId();
-        int index = heartBeat.getWorkerIndex();
-        int number = heartBeat.getWorkerNumber();
         this.time = time.toEpochMilli();
-        workerId = new WorkerId(jobId, index, number);
+        workerId = hb.getWorkerId().get();
         workerState = setWorkerState(heartBeat.getState());
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -135,7 +135,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             onNewDisableTaskExecutorsRequest(request);
         }
 
-        timers().startPeriodicTimer(
+        timers().startTimerWithFixedDelay(
             String.format("periodic-disabled-task-executors-test-for-%s", clusterID.getResourceID()),
             new CheckDisabledTaskExecutors("periodic"),
             disabledTaskExecutorsCheckInterval);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -20,6 +20,7 @@ import akka.actor.ActorRef;
 import akka.pattern.Patterns;
 import io.mantisrx.common.Ack;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAssignedTaskExecutorRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAvailableTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetBusyTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetRegisteredTaskExecutorsRequest;
@@ -137,6 +138,15 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
         return
             Patterns
                 .ask(resourceClusterManagerActor, new TaskExecutorAssignmentRequest(machineDefinition, workerId, clusterID), askTimeout)
+                .thenApply(TaskExecutorID.class::cast)
+                .toCompletableFuture();
+    }
+
+    @Override
+    public CompletableFuture<TaskExecutorID> getTaskExecutorAssignedFor(WorkerId workerId) {
+        return
+            Patterns
+                .ask(resourceClusterManagerActor, new GetAssignedTaskExecutorRequest(workerId, clusterID), askTimeout)
                 .thenApply(TaskExecutorID.class::cast)
                 .toCompletableFuture();
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -23,6 +23,7 @@ import akka.actor.SupervisorStrategy;
 import akka.japi.pf.ReceiveBuilder;
 import io.mantisrx.master.akka.MantisActorSupervisorStrategy;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAssignedTaskExecutorRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAvailableTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetBusyTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetRegisteredTaskExecutorsRequest;
@@ -120,6 +121,7 @@ class ResourceClustersManagerActor extends AbstractActor {
                 .match(GetUnregisteredTaskExecutorsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
                 .match(GetTaskExecutorStatusRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
                 .match(GetActiveJobsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
+                .match(GetAssignedTaskExecutorRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
 
                 .match(TaskExecutorRegistration.class, registration ->
                     getRCActor(registration.getClusterID()).forward(registration, context()))

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareScheduler.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareScheduler.java
@@ -50,7 +50,7 @@ public class ResourceClusterAwareScheduler implements MantisScheduler {
     @Override
     public void unscheduleAndTerminateWorker(WorkerId workerId,
                                              Optional<String> hostname) {
-        schedulerActor.tell(CancelRequestEvent.of(workerId, hostname.orElse(null)), null);
+        schedulerActor.tell(CancelRequestEvent.of(workerId),null);
 
         if (!hostname.isPresent()) {
             log.error("Request for cancelling worker {} without hostname", workerId, new Exception());

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
@@ -332,13 +332,11 @@ class ResourceClusterAwareSchedulerActor extends AbstractActorWithTimers {
     static class CancelRequestEvent {
 
         WorkerId workerId;
-        @Nullable
-        String hostName;
         int attempt;
         Throwable previousFailure;
 
-        static CancelRequestEvent of(WorkerId workerId, @Nullable String hostName) {
-            return new CancelRequestEvent(workerId, hostName, 1, null);
+        static CancelRequestEvent of(WorkerId workerId) {
+            return new CancelRequestEvent(workerId, 1, null);
         }
 
         RetryCancelRequestEvent onFailure(Throwable throwable) {
@@ -353,7 +351,7 @@ class ResourceClusterAwareSchedulerActor extends AbstractActorWithTimers {
         Throwable currentFailure;
 
         CancelRequestEvent onRetry() {
-            return new CancelRequestEvent(actualEvent.getWorkerId(), actualEvent.getHostName(),
+            return new CancelRequestEvent(actualEvent.getWorkerId(),
                 actualEvent.getAttempt() + 1, currentFailure);
         }
     }

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RunningWorker.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RunningWorker.java
@@ -53,19 +53,19 @@ public class RunningWorker {
     private StageConfig stage;
     private Observer<Status> jobStatus;
     private String jobId;
-    private int stageNum;
-    private int workerNum;
-    private int workerIndex;
-    private String jobName;
-    private int totalStages;
-    private int metricsPort;
-    private Observer<VirtualMachineTaskStatus> vmTaskStatusObserver;
-    private Observable<Integer> stageTotalWorkersObservable;
-    private Observable<JobSchedulingInfo> jobSchedulingInfoObservable;
-    private Iterator<Integer> ports;
-    private PublishSubject<Boolean> requestSubject;
+    private final int stageNum;
+    private final int workerNum;
+    private final int workerIndex;
+    private final String jobName;
+    private final int totalStages;
+    private final int metricsPort;
+    private final Observer<VirtualMachineTaskStatus> vmTaskStatusObserver;
+    private final Observable<Integer> stageTotalWorkersObservable;
+    private final Observable<JobSchedulingInfo> jobSchedulingInfoObservable;
+    private final Iterator<Integer> ports;
+    private final PublishSubject<Boolean> requestSubject;
     private Context context;
-    private WorkerInfo workerInfo;
+    private final WorkerInfo workerInfo;
 
     public RunningWorker(Builder builder) {
 


### PR DESCRIPTION
### Context

Resource Cluster already maintains metadata around who is responsible for what. So, it doesn't need any additional metadata to figure out the host running the task that needs to be canceled. This diff aims to fix this behavior. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
