### PR TITLE
Add JobArtifact model and storeNewArtifact function in StorageProvider

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/domain/ArtifactID.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/domain/ArtifactID.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.core.domain;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+/**
+ * Represents the job artifact that mantis can run.
+ */
+@RequiredArgsConstructor(staticName="of")
+@Value
+public class ArtifactID {
+    String resourceID;
+}

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/domain/JobArtifact.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/domain/JobArtifact.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.core.domain;
+
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JobArtifact {
+    // Job artifact unique identifier
+    @JsonProperty("artifactID")
+    ArtifactID artifactID;
+    // Job artifact name
+    @JsonProperty("name")
+    String name;
+    // Job artifact version
+    @JsonProperty("version")
+    String version;
+    // Job artifact creation timestamp
+    @JsonProperty("createdAt")
+    Instant createdAt;
+    // Runtime Type Identification. For java potential values: spring-boot, guice
+    @JsonProperty("runtimeType")
+    String runtimeType;
+    // Job artifact external dependencies
+    // Example: {"mantis-runtime": "1.0.0"}
+    @JsonProperty("dependencies")
+    Map<String, String> dependencies;
+    // Job entrypoint clas.
+    @JsonProperty("entrypoint")
+    String entrypoint;
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/Jackson.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/Jackson.java
@@ -131,7 +131,7 @@ public class Jackson {
                            });
     }
 
-    private static String toJSON(
+    public static String toJSON(
             ObjectMapper mapper,
             FilterProvider filters,
             Object object) throws JsonProcessingException {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/MantisMasterRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/MantisMasterRoute.java
@@ -28,6 +28,7 @@ import io.mantisrx.master.api.akka.route.v0.JobStatusRoute;
 import io.mantisrx.master.api.akka.route.v0.MasterDescriptionRoute;
 import io.mantisrx.master.api.akka.route.v1.AdminMasterRoute;
 import io.mantisrx.master.api.akka.route.v1.AgentClustersRoute;
+import io.mantisrx.master.api.akka.route.v1.JobArtifactsRoute;
 import io.mantisrx.master.api.akka.route.v1.JobClustersRoute;
 import io.mantisrx.master.api.akka.route.v1.JobDiscoveryStreamRoute;
 import io.mantisrx.master.api.akka.route.v1.JobStatusStreamRoute;
@@ -52,6 +53,7 @@ public class MantisMasterRoute extends AllDirectives {
 
     private final JobClustersRoute v1JobClusterRoute;
     private final JobsRoute v1JobsRoute;
+    private final JobArtifactsRoute v1JobArtifactsRoute;
     private final AdminMasterRoute v1MasterRoute;
     private final AgentClustersRoute v1AgentClustersRoute;
     private final JobDiscoveryStreamRoute v1JobDiscoveryStreamRoute;
@@ -71,6 +73,7 @@ public class MantisMasterRoute extends AllDirectives {
         final AgentClusterRoute v0AgentClusterRoute,
         final JobClustersRoute v1JobClusterRoute,
         final JobsRoute v1JobsRoute,
+        final JobArtifactsRoute v1JobArtifactsRoute,
         final AdminMasterRoute v1MasterRoute,
         final AgentClustersRoute v1AgentClustersRoute,
         final JobDiscoveryStreamRoute v1JobDiscoveryStreamRoute,
@@ -88,6 +91,7 @@ public class MantisMasterRoute extends AllDirectives {
 
         this.v1JobClusterRoute = v1JobClusterRoute;
         this.v1JobsRoute = v1JobsRoute;
+        this.v1JobArtifactsRoute = v1JobArtifactsRoute;
         this.v1MasterRoute = v1MasterRoute;
         this.v1AgentClustersRoute = v1AgentClustersRoute;
         this.v1JobDiscoveryStreamRoute = v1JobDiscoveryStreamRoute;
@@ -108,6 +112,7 @@ public class MantisMasterRoute extends AllDirectives {
                 v0AgentClusterRoute.createRoute(leaderRedirectionFilter::redirectIfNotLeader),
                 v1JobClusterRoute.createRoute(leaderRedirectionFilter::redirectIfNotLeader),
                 v1JobsRoute.createRoute(leaderRedirectionFilter::redirectIfNotLeader),
+                v1JobArtifactsRoute.createRoute(leaderRedirectionFilter::redirectIfNotLeader),
                 v1MasterRoute.createRoute(leaderRedirectionFilter::redirectIfNotLeader),
                 v1AgentClustersRoute.createRoute(leaderRedirectionFilter::redirectIfNotLeader),
                 v1JobDiscoveryStreamRoute.createRoute(leaderRedirectionFilter::redirectIfNotLeader),

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobArtifactRouteHandler.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobArtifactRouteHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.api.akka.route.handlers;
+
+import io.mantisrx.master.jobcluster.proto.JobArtifactProto;
+import java.util.concurrent.CompletionStage;
+
+public interface JobArtifactRouteHandler {
+    /**
+     * Upsert given job artifact to the metadata store.
+     */
+    CompletionStage<JobArtifactProto.UpsertJobArtifactResponse> upsert(final JobArtifactProto.UpsertJobArtifactRequest request);
+
+    /**
+     * Search job artifacts with given name an optionally given version.
+     * If version is not provided the result will contain the list of
+     * all job artifacts matching the name.
+     */
+    CompletionStage<JobArtifactProto.SearchJobArtifactsResponse> search(final JobArtifactProto.SearchJobArtifactsRequest request);
+
+    /**
+     * Search job artifact names by given prefix. Returns only the names for faster lookups.
+     */
+    CompletionStage<JobArtifactProto.ListJobArtifactsByNameResponse> listArtifactsByName(final JobArtifactProto.ListJobArtifactsByNameRequest request);
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobArtifactRouteHandlerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobArtifactRouteHandlerImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.api.akka.route.handlers;
+
+import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SERVER_ERROR;
+import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SUCCESS;
+
+import io.mantisrx.master.jobcluster.proto.JobArtifactProto;
+import io.mantisrx.server.core.domain.JobArtifact;
+import io.mantisrx.server.master.store.MantisStorageProvider;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JobArtifactRouteHandlerImpl implements JobArtifactRouteHandler {
+    private final MantisStorageProvider mantisStorageProvider;
+
+    public JobArtifactRouteHandlerImpl(MantisStorageProvider mantisStorageProvider) {
+        this.mantisStorageProvider = mantisStorageProvider;
+    }
+
+    @Override
+    public CompletionStage<JobArtifactProto.SearchJobArtifactsResponse> search(JobArtifactProto.SearchJobArtifactsRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                final List<JobArtifact> jobArtifactList = mantisStorageProvider.listJobArtifacts(request.getName(), request.getVersion());
+                return new JobArtifactProto.SearchJobArtifactsResponse(request.requestId, SUCCESS, "", jobArtifactList);
+            } catch (IOException e) {
+                log.warn("Error while fetching job artifacts. Traceback: {}", e.getMessage(), e);
+                return new JobArtifactProto.SearchJobArtifactsResponse(request.requestId, SERVER_ERROR, e.getMessage(), Collections.emptyList());
+            }
+        });
+    }
+
+    @Override
+    public CompletionStage<JobArtifactProto.ListJobArtifactsByNameResponse> listArtifactsByName(JobArtifactProto.ListJobArtifactsByNameRequest request) {
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                final List<String> artifactNames = mantisStorageProvider.listJobArtifactsByName(request.getPrefix());
+                return new JobArtifactProto.ListJobArtifactsByNameResponse(request.requestId, SUCCESS, "", artifactNames);
+            } catch (IOException e) {
+                log.warn("Error while searching job artifact names. Traceback: {}", e.getMessage(), e);
+                return new JobArtifactProto.ListJobArtifactsByNameResponse(request.requestId, SERVER_ERROR, e.getMessage(), Collections.emptyList());
+            }
+        });
+    }
+
+    @Override
+    public CompletionStage<JobArtifactProto.UpsertJobArtifactResponse> upsert(JobArtifactProto.UpsertJobArtifactRequest request) {
+        final JobArtifact jobArtifact = request.getJobArtifact();
+        return CompletableFuture.supplyAsync(() -> {
+            try {
+                mantisStorageProvider.addNewJobArtifact(jobArtifact);
+                return new JobArtifactProto.UpsertJobArtifactResponse(request.requestId, SUCCESS, "", jobArtifact.getArtifactID());
+            } catch (IOException e) {
+                log.warn("Error while storing new job artifact. Traceback: {}", e.getMessage(), e);
+                return new JobArtifactProto.UpsertJobArtifactResponse(request.requestId, SERVER_ERROR, e.getMessage(), jobArtifact.getArtifactID());
+            }
+        });
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/HttpRequestMetrics.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/HttpRequestMetrics.java
@@ -33,6 +33,8 @@ public class HttpRequestMetrics {
     }
 
     public static class Endpoints {
+        public static final String JOB_ARTIFACTS = "api.v1.jobArtifacts";
+        public static final String JOB_ARTIFACTS_NAMES = "api.v1.jobArtifacts.names";
         public static final String JOB_CLUSTERS = "api.v1.jobClusters";
         public static final String JOB_CLUSTER_INSTANCE = "api.v1.jobClusters.instance";
         public static final String JOB_CLUSTER_INSTANCE_LATEST_JOB_DISCOVERY_INFO = "api.v1.jobClusters.instance.latestJobDiscoveryInfo";
@@ -64,6 +66,8 @@ public class HttpRequestMetrics {
         public static final String RESOURCE_CLUSTERS = "api.v1.resourceClusters";
 
         private static String[] endpoints = new String[]{
+                JOB_ARTIFACTS,
+                JOB_ARTIFACTS_NAMES,
                 JOB_CLUSTERS,
                 JOB_CLUSTER_INSTANCE,
                 JOB_CLUSTER_INSTANCE_LATEST_JOB_DISCOVERY_INFO,

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobArtifactsRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobArtifactsRoute.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.api.akka.route.v1;
+
+import static akka.http.javadsl.server.PathMatchers.segment;
+
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.PathMatcher0;
+import akka.http.javadsl.server.Route;
+import io.mantisrx.master.api.akka.route.Jackson;
+import io.mantisrx.master.api.akka.route.handlers.JobArtifactRouteHandler;
+import io.mantisrx.master.jobcluster.proto.JobArtifactProto;
+import io.mantisrx.master.jobcluster.proto.JobArtifactProto.SearchJobArtifactsRequest;
+import io.mantisrx.master.jobcluster.proto.JobArtifactProto.UpsertJobArtifactResponse;
+import io.mantisrx.server.core.domain.JobArtifact;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.SerializationFeature;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import io.mantisrx.shaded.com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.mantisrx.shaded.com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/***
+ * JobArtifactsRoute endpoints:
+ *  - /api/v1/jobArtifacts (GET, POST)
+ *  - /api/v1/jobArtifacts/names (GET)
+ */
+public class JobArtifactsRoute extends BaseRoute {
+    private static final Logger logger = LoggerFactory.getLogger(JobArtifactsRoute.class);
+    private static final PathMatcher0 JOB_ARTIFACTS_API_PREFIX = segment("api").slash("v1").slash("jobArtifacts");
+
+    private final JobArtifactRouteHandler jobArtifactRouteHandler;
+
+    // TODO(fdichiara): consolidate object mappers. This is needed because
+    //  Instant cannot be serialized by the existing ObjectMappers
+    private static final ObjectMapper JAVA_TIME_COMPATIBLE_MAPPER = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+        .registerModule(new Jdk8Module())
+        .registerModule(new JavaTimeModule());
+    public static final SimpleFilterProvider DEFAULT_FILTER_PROVIDER;
+
+    static {
+        DEFAULT_FILTER_PROVIDER = new SimpleFilterProvider();
+        DEFAULT_FILTER_PROVIDER.setFailOnUnknownId(false);
+    }
+
+    public JobArtifactsRoute(final JobArtifactRouteHandler jobArtifactRouteHandler) {
+        this.jobArtifactRouteHandler = jobArtifactRouteHandler;
+    }
+
+    public Route constructRoutes() {
+        return concat(
+                pathPrefix(JOB_ARTIFACTS_API_PREFIX, () -> concat(
+                        // /api/v1/jobArtifacts
+                        pathEndOrSingleSlash(() -> concat(
+                                // GET - search job artifacts by name and version (optional)
+                                get(this::getJobArtifactsRoute),
+
+                                // POST - register new job artifact
+                                post(this::postJobArtifactRoute)
+                        )),
+                        // /api/v1/jobArtifacts/names
+                        path(
+                            "names",
+                            () -> pathEndOrSingleSlash(
+                                // GET - search job artifacts names by prefix
+                                () -> get(this::listJobArtifactsByNameRoute)
+                            )
+                        )
+                    )
+                )
+        );
+    }
+
+    @Override
+    public Route createRoute(Function<Route, Route> routeFilter) {
+        logger.info("creating /api/v1/jobArtifacts routes");
+        return super.createRoute(routeFilter);
+    }
+
+    private Route getJobArtifactsRoute() {
+        logger.trace("GET /api/v1/jobArtifacts called");
+        return parameterMap(param -> completeAsync(
+            jobArtifactRouteHandler.search(new SearchJobArtifactsRequest(param.get("name"), param.get("version"))),
+            resp -> completeOK(
+                resp.getJobArtifacts(),
+                Jackson.marshaller(JAVA_TIME_COMPATIBLE_MAPPER)),
+            HttpRequestMetrics.Endpoints.JOB_ARTIFACTS,
+            HttpRequestMetrics.HttpVerb.GET));
+    }
+
+    private Route postJobArtifactRoute() {
+        return entity(
+            Jackson.unmarshaller(JAVA_TIME_COMPATIBLE_MAPPER, JobArtifact.class),
+            jobArtifact -> {
+                logger.trace("POST /api/v1/jobArtifacts called with payload: {}", jobArtifact);
+                try {
+                    final CompletionStage<UpsertJobArtifactResponse> response = jobArtifactRouteHandler.upsert(new JobArtifactProto.UpsertJobArtifactRequest(jobArtifact));
+
+                    // TODO(fdichiara): introduce job artifact pre-fetching in task executors.
+
+                    return completeAsync(
+                        response,
+                        resp -> complete(
+                                StatusCodes.CREATED,
+                                resp.getArtifactID(),
+                                Jackson.marshaller(JAVA_TIME_COMPATIBLE_MAPPER)),
+                        HttpRequestMetrics.Endpoints.JOB_ARTIFACTS,
+                        HttpRequestMetrics.HttpVerb.POST);
+                } catch (Exception e) {
+                    return complete(StatusCodes.INTERNAL_SERVER_ERROR, "Failed to store job artifact");
+                }
+            }
+        );
+    }
+
+    private Route listJobArtifactsByNameRoute() {
+        logger.trace("GET /api/v1/jobArtifacts/names called");
+        return parameterMap(param -> completeAsync(
+            jobArtifactRouteHandler.listArtifactsByName(new JobArtifactProto.ListJobArtifactsByNameRequest(param.getOrDefault("prefix", ""))),
+            resp -> completeOK(
+                resp.getNames(),
+                Jackson.marshaller(JAVA_TIME_COMPATIBLE_MAPPER)),
+            HttpRequestMetrics.Endpoints.JOB_ARTIFACTS_NAMES,
+            HttpRequestMetrics.HttpVerb.GET));
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobArtifactProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobArtifactProto.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.jobcluster.proto;
+
+import com.netflix.spectator.impl.Preconditions;
+import io.mantisrx.server.core.domain.ArtifactID;
+import io.mantisrx.server.core.domain.JobArtifact;
+import java.util.List;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+public class JobArtifactProto {
+
+    @EqualsAndHashCode(callSuper = true)
+    @Value
+    public static class SearchJobArtifactsRequest extends BaseRequest {
+        String name;
+        String version;
+
+        public SearchJobArtifactsRequest(String name, String version) {
+            super();
+            Preconditions.checkNotNull(name, "JobArtifact name cannot be null");
+            this.name = name;
+            this.version = version;
+        }
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Value
+    public static class SearchJobArtifactsResponse extends BaseResponse {
+        List<JobArtifact> jobArtifacts;
+
+        // TODO(fdichiara): add paginated list.
+        public SearchJobArtifactsResponse(
+            long requestId,
+            ResponseCode responseCode,
+            String message,
+            List<JobArtifact> jobArtifacts) {
+            super(requestId, responseCode, message);
+            this.jobArtifacts = jobArtifacts;
+        }
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Value
+    public static class ListJobArtifactsByNameRequest extends BaseRequest {
+        String prefix;
+
+        public ListJobArtifactsByNameRequest(String prefix) {
+            super();
+            this.prefix = prefix;
+        }
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Value
+    public static class ListJobArtifactsByNameResponse extends BaseResponse {
+        List<String> names;
+
+        // TODO(fdichiara): add paginated list.
+        public ListJobArtifactsByNameResponse(
+            long requestId,
+            ResponseCode responseCode,
+            String message,
+            List<String> names) {
+            super(requestId, responseCode, message);
+            this.names = names;
+        }
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Value
+    public static class UpsertJobArtifactRequest extends BaseRequest {
+        JobArtifact jobArtifact;
+
+        public UpsertJobArtifactRequest(final JobArtifact jobArtifact) {
+            super();
+            Preconditions.checkNotNull(jobArtifact, "JobArtifact cannot be null");
+            this.jobArtifact = jobArtifact;
+        }
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Value
+    public static class UpsertJobArtifactResponse extends BaseResponse {
+        ArtifactID artifactID;
+
+        public UpsertJobArtifactResponse(
+            final long requestId,
+            final ResponseCode responseCode,
+            final String message,
+            final ArtifactID artifactID
+        ) {
+            super(requestId, responseCode, message);
+            this.artifactID = artifactID;
+        }
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -73,6 +73,7 @@ import io.mantisrx.server.master.scheduler.JobMessageRouter;
 import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.server.master.scheduler.MantisSchedulerFactoryImpl;
 import io.mantisrx.server.master.scheduler.WorkerRegistry;
+import io.mantisrx.server.master.store.MantisStorageProvider;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import io.mantisrx.shaded.org.apache.curator.utils.ZKPaths;
 import java.io.File;
@@ -153,7 +154,8 @@ public class MasterMain implements Service {
             final LifecycleEventPublisher lifecycleEventPublisher = new LifecycleEventPublisherImpl(auditEventSubscriberAkka, statusEventSubscriber, workerEventSubscriber);
 
 
-            IMantisStorageProvider storageProvider = new MantisStorageProviderAdapter(this.config.getStorageProvider(), lifecycleEventPublisher);
+            final MantisStorageProvider actualStorageProvider = this.config.getStorageProvider();
+            IMantisStorageProvider storageProvider = new MantisStorageProviderAdapter(actualStorageProvider, lifecycleEventPublisher);
             final MantisJobStore mantisJobStore = new MantisJobStore(storageProvider);
             final ActorRef jobClusterManagerActor = system.actorOf(JobClustersManagerActor.props(mantisJobStore, lifecycleEventPublisher), "JobClustersManager");
             final JobMessageRouter jobMessageRouter = new JobMessageRouterImpl(jobClusterManagerActor);
@@ -226,13 +228,13 @@ public class MasterMain implements Service {
             if (this.config.isLocalMode()) {
                 leadershipManager.becomeLeader();
                 mantisServices.addService(new MasterApiAkkaService(new LocalMasterMonitor(leadershipManager.getDescription()), leadershipManager.getDescription(), jobClusterManagerActor, statusEventBrokerActor,
-                       resourceClusters, resourceClustersHostActor, config.getApiPort(), storageProvider, schedulingService, lifecycleEventPublisher, leadershipManager, agentClusterOps));
+                       resourceClusters, resourceClustersHostActor, config.getApiPort(), actualStorageProvider, schedulingService, lifecycleEventPublisher, leadershipManager, agentClusterOps));
             } else {
                 curatorService = new CuratorService(this.config);
                 curatorService.start();
                 mantisServices.addService(createLeaderElector(curatorService, leadershipManager));
                 mantisServices.addService(new MasterApiAkkaService(curatorService.getMasterMonitor(), leadershipManager.getDescription(), jobClusterManagerActor, statusEventBrokerActor,
-                       resourceClusters, resourceClustersHostActor, config.getApiPort(), storageProvider, schedulingService, lifecycleEventPublisher, leadershipManager, agentClusterOps));
+                       resourceClusters, resourceClustersHostActor, config.getApiPort(), actualStorageProvider, schedulingService, lifecycleEventPublisher, leadershipManager, agentClusterOps));
             }
             m.getCounter("masterInitSuccess").increment();
         } catch (Exception e) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisStorageProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisStorageProvider.java
@@ -17,11 +17,14 @@
 package io.mantisrx.server.master.store;
 
 import io.mantisrx.master.resourcecluster.DisableTaskExecutorsRequest;
+import io.mantisrx.server.core.domain.ArtifactID;
+import io.mantisrx.server.core.domain.JobArtifact;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorRegistration;
 import java.io.IOException;
 import java.util.List;
+import javax.annotation.Nullable;
 import rx.Observable;
 
 
@@ -32,21 +35,19 @@ public interface MantisStorageProvider {
      * jobId as given in the <code>jobMetadata</code> object already exists in persistence store.
      *
      * @param jobMetadata
-     *
      * @throws JobAlreadyExistsException If a job with same id as in the given metadata object already exists
      * @throws IOException
      */
     void storeNewJob(MantisJobMetadataWritable jobMetadata)
-            throws JobAlreadyExistsException, IOException;
+        throws JobAlreadyExistsException, IOException;
 
     void updateJob(MantisJobMetadataWritable jobMetadata)
-            throws InvalidJobException, IOException;
+        throws InvalidJobException, IOException;
 
     /**
      * Mark the job as not active and move it to an inactive archived collection of jobs.
      *
      * @param jobId The Job Id of the job to archive
-     *
      * @throws IOException upon errors with storage invocation
      */
     void archiveJob(String jobId) throws IOException;
@@ -55,14 +56,13 @@ public interface MantisStorageProvider {
      * Delete the job metadata permanently.
      *
      * @param jobId The Job Id of the job to delete
-     *
      * @throws InvalidJobException If there is no such job to delete
      * @throws IOException         Upon errors with storage invocation
      */
     void deleteJob(String jobId) throws InvalidJobException, IOException;
 
     void storeMantisStage(MantisStageMetadataWritable msmd)
-            throws IOException;
+        throws IOException;
 
     void updateMantisStage(MantisStageMetadataWritable msmd) throws IOException;
 
@@ -72,11 +72,10 @@ public interface MantisStorageProvider {
      * different worker.
      *
      * @param workerMetadata The worker metadata to store.
-     *
      * @throws IOException
      */
     void storeWorker(MantisWorkerMetadataWritable workerMetadata)
-            throws IOException;
+        throws IOException;
 
     /**
      * Store multiple new workers for the give job. This is called only once for a given worker. This method enables
@@ -84,43 +83,39 @@ public interface MantisStorageProvider {
      *
      * @param jobId   The Job ID.
      * @param workers The list of workers to store.
-     *
      * @throws IOException if there were errors storing the workers.
      */
     void storeWorkers(String jobId, List<MantisWorkerMetadataWritable> workers)
-            throws IOException;
+        throws IOException;
 
     /**
      * Store a new worker and update existing worker of a job atomically. Either both are stored or none is.
      *
      * @param worker1 Existing worker to update.
      * @param worker2 New worker to store.
-     *
      * @throws IOException
      * @throws InvalidJobException If workers don't have the same JobId.
      */
     void storeAndUpdateWorkers(MantisWorkerMetadataWritable worker1, MantisWorkerMetadataWritable worker2)
-            throws InvalidJobException, IOException;
+        throws InvalidJobException, IOException;
 
     /**
      * Update (overwrite) existing worker metadata with the given metadata.
      *
      * @param mwmd Worker metadata to update
-     *
      * @throws IOException
      */
     void updateWorker(MantisWorkerMetadataWritable mwmd)
-            throws IOException;
+        throws IOException;
 
     /**
      * Initialize and return all existing jobs from persistence, including all corresponding job stages and workers.
      *
      * @return List of job metadata objects
-     *
      * @throws IOException
      */
     List<MantisJobMetadataWritable> initJobs()
-            throws IOException;
+        throws IOException;
 
     Observable<MantisJobMetadata> initArchivedJobs();
 
@@ -128,7 +123,6 @@ public interface MantisStorageProvider {
      * Initialize and return all existing NamedJobs from persistence.
      *
      * @return List of {@link NamedJob} objects.
-     *
      * @throws IOException Upon error connecting to or reading from persistence.
      */
     List<NamedJob> initNamedJobs() throws IOException;
@@ -137,7 +131,6 @@ public interface MantisStorageProvider {
      * Initialize and return completed jobs of all NamedJobs in the system.
      *
      * @return An Observable of all completed jobs for all NamedJobs.
-     *
      * @throws IOException Upon error connecting to or reading from persistence.
      */
     Observable<NamedJob.CompletedJob> initNamedJobCompletedJobs() throws IOException;
@@ -147,14 +140,13 @@ public interface MantisStorageProvider {
      * are moved out from regular store elsewhere so when jobs are loaded they do not contain archived workers.
      *
      * @param mwmd Worker metadata to archive
-     *
      * @throws IOException
      */
     void archiveWorker(MantisWorkerMetadataWritable mwmd)
-            throws IOException;
+        throws IOException;
 
     List<MantisWorkerMetadataWritable> getArchivedWorkers(String jobid)
-            throws IOException;
+        throws IOException;
 
     void storeNewNamedJob(NamedJob namedJob) throws JobNameAlreadyExistsException, IOException;
 
@@ -183,4 +175,13 @@ public interface MantisStorageProvider {
     void deleteExpiredDisableTaskExecutorRequest(DisableTaskExecutorsRequest request) throws IOException;
 
     List<DisableTaskExecutorsRequest> loadAllDisableTaskExecutorsRequests(ClusterID clusterID) throws IOException;
+
+    void addNewJobArtifact(JobArtifact jobArtifact) throws IOException;
+
+    boolean jobArtifactExists(ArtifactID artifactID);
+
+    // Note: returns list of job artifact names only for performance reasons
+    List<String> listJobArtifactsByName(@Nullable String prefix) throws IOException;
+
+    List<JobArtifact> listJobArtifacts(String name, @Nullable String version) throws IOException;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/NoopStorageProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/NoopStorageProvider.java
@@ -17,6 +17,8 @@
 package io.mantisrx.server.master.store;
 
 import io.mantisrx.master.resourcecluster.DisableTaskExecutorsRequest;
+import io.mantisrx.server.core.domain.ArtifactID;
+import io.mantisrx.server.core.domain.JobArtifact;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorRegistration;
@@ -24,6 +26,7 @@ import io.mantisrx.shaded.com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import rx.Observable;
 
 
@@ -162,4 +165,24 @@ public class NoopStorageProvider implements MantisStorageProvider {
     public List<DisableTaskExecutorsRequest> loadAllDisableTaskExecutorsRequests(ClusterID clusterID) {
         return ImmutableList.of();
     }
+
+    @Override
+    public void addNewJobArtifact(JobArtifact jobArtifact) throws IOException {
+    }
+
+    @Override
+    public boolean jobArtifactExists(ArtifactID artifactID){
+        return false;
+    }
+
+    @Override
+    public List<String> listJobArtifactsByName(@Nullable String prefix) throws IOException {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<JobArtifact> listJobArtifacts(String name, @Nullable String version) throws IOException {
+        return ImmutableList.of();
+    }
+
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
@@ -48,6 +48,8 @@ import io.mantisrx.master.api.akka.payloads.JobClusterPayloads;
 import io.mantisrx.master.api.akka.payloads.JobPayloads;
 import io.mantisrx.master.api.akka.route.Jackson;
 import io.mantisrx.master.api.akka.route.MantisMasterRoute;
+import io.mantisrx.master.api.akka.route.handlers.JobArtifactRouteHandler;
+import io.mantisrx.master.api.akka.route.handlers.JobArtifactRouteHandlerImpl;
 import io.mantisrx.master.api.akka.route.handlers.JobClusterRouteHandler;
 import io.mantisrx.master.api.akka.route.handlers.JobClusterRouteHandlerAkkaImpl;
 import io.mantisrx.master.api.akka.route.handlers.JobDiscoveryRouteHandler;
@@ -59,6 +61,7 @@ import io.mantisrx.master.api.akka.route.handlers.ResourceClusterRouteHandler;
 import io.mantisrx.master.api.akka.route.proto.JobClusterProtoAdapter;
 import io.mantisrx.master.api.akka.route.v1.AdminMasterRoute;
 import io.mantisrx.master.api.akka.route.v1.AgentClustersRoute;
+import io.mantisrx.master.api.akka.route.v1.JobArtifactsRoute;
 import io.mantisrx.master.api.akka.route.v1.JobClustersRoute;
 import io.mantisrx.master.api.akka.route.v1.JobDiscoveryStreamRoute;
 import io.mantisrx.master.api.akka.route.v1.JobStatusStreamRoute;
@@ -90,6 +93,7 @@ import io.mantisrx.server.master.scheduler.MantisScheduler;
 import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.server.master.store.MantisStageMetadataWritable;
 import io.mantisrx.server.master.store.MantisWorkerMetadataWritable;
+import io.mantisrx.server.master.store.SimpleCachedFileStorageProvider;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.type.TypeReference;
 import java.io.IOException;
 import java.time.Duration;
@@ -181,7 +185,7 @@ public class JobRouteTest {
                 final Http http = Http.get(system);
                 final ActorMaterializer materializer = ActorMaterializer.create(system);
 
-//                SimpleCachedFileStorageProvider simpleCachedFileStorageProvider = new SimpleCachedFileStorageProvider();
+                SimpleCachedFileStorageProvider simpleCachedFileStorageProvider = new SimpleCachedFileStorageProvider();
 //                new File("/tmp/MantisSpool/namedJobs").mkdirs();
 //                IMantisStorageProvider storageProvider = new MantisStorageProviderAdapter(simpleCachedFileStorageProvider);
                 final LifecycleEventPublisher lifecycleEventPublisher = new LifecycleEventPublisherImpl(
@@ -202,6 +206,7 @@ public class JobRouteTest {
 
                 final JobClusterRouteHandler jobClusterRouteHandler = new JobClusterRouteHandlerAkkaImpl(
                         jobClustersManagerActor);
+                final JobArtifactRouteHandler jobArtifactRouteHandler = new JobArtifactRouteHandlerImpl(simpleCachedFileStorageProvider);
                 final JobRouteHandler jobRouteHandler = new JobRouteHandlerAkkaImpl(
                         jobClustersManagerActor);
 
@@ -238,6 +243,7 @@ public class JobRouteTest {
                         jobClusterRouteHandler,
                         jobRouteHandler,
                         system);
+                final JobArtifactsRoute v1JobArtifactsRoute = new JobArtifactsRoute(jobArtifactRouteHandler);
                 final AdminMasterRoute v1AdminMasterRoute = new AdminMasterRoute(masterDescription);
 
                 final JobStatusRouteHandler jobStatusRouteHandler = mock(JobStatusRouteHandler.class);
@@ -272,6 +278,7 @@ public class JobRouteTest {
                         v0AgentClusterRoute,
                         v1JobClusterRoute,
                         v1JobsRoute,
+                        v1JobArtifactsRoute,
                         v1AdminMasterRoute,
                         v1AgentClusterRoute,
                         v1JobDiscoveryStreamRoute,

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobArtifactSerdeTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobArtifactSerdeTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.api.akka.route.v1;
+
+import static org.junit.Assert.assertEquals;
+
+import io.mantisrx.master.api.akka.route.Jackson;
+import io.mantisrx.server.core.domain.ArtifactID;
+import io.mantisrx.server.core.domain.JobArtifact;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.SerializationFeature;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
+import io.mantisrx.shaded.com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import io.mantisrx.shaded.com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
+import java.time.Instant;
+import org.junit.Test;
+
+public class JobArtifactSerdeTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper()
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+        .registerModule(new Jdk8Module())
+        .registerModule(new JavaTimeModule());
+    public static final SimpleFilterProvider DEFAULT_FILTER_PROVIDER;
+
+    static {
+        DEFAULT_FILTER_PROVIDER = new SimpleFilterProvider();
+        DEFAULT_FILTER_PROVIDER.setFailOnUnknownId(false);
+    }
+
+    @Test
+    public void testIfJobArtifactIsSerializableByJson() throws Exception {
+        final JobArtifact artifact =
+            JobArtifact.builder()
+                .artifactID(ArtifactID.of("id"))
+                .name("proj1")
+                .version("v1")
+                .createdAt(Instant.ofEpochMilli(1668135952L))
+                .runtimeType("sbn")
+                .dependencies(ImmutableMap.of("de1", "1.0.0"))
+                .entrypoint("entrypoint")
+                .build();
+        String metaJson = Jackson.toJSON(mapper, null, artifact);
+        assertEquals(metaJson, "{\"artifactID\":{\"resourceID\":\"id\"},\"name\":\"proj1\",\"version\":\"v1\",\"createdAt\":1668135.952000000,\"runtimeType\":\"sbn\",\"dependencies\":{\"de1\":\"1.0.0\"},\"entrypoint\":\"entrypoint\"}");
+
+        final JobArtifact actual = Jackson.fromJSON(mapper, metaJson, JobArtifact.class);
+        assertEquals(artifact, actual);
+    }
+}


### PR DESCRIPTION
Add JobArtifact model and storeNewArtifact function in StorageProvider interface

### Context

This PR aims to define the model for Job artifacts we plan to store going forward. A new functionality has been added to MantisStorageProvider to be able to store new job artifacts (right now it only saves 1 artifact at the time, maybe in the future we can store more than one at the time).

Note: before merging I plan to change `JobArtifact` model a bit to have a list of dependencies where the runtime is only 1 of the dependencies; can be empty if the artifact is in the form of a uber jar.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
