### PR TITLE
Fix build action

### DIFF
--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -1,15 +1,15 @@
 name: "Publish snapshot to NetflixOSS and Maven Central"
 
-on:
-  pull_request_target:
+on: [pull_request_target]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout PR
+        uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup jdk
         uses: actions/setup-java@v2
         with:

--- a/mantis-examples/mantis-examples-jobconnector-sample/build.gradle
+++ b/mantis-examples/mantis-examples-jobconnector-sample/build.gradle
@@ -17,6 +17,8 @@ ext {
 }
 
 dependencies {
+    api libraries.mantisShaded
+
     implementation project(':mantis-runtime')
     implementation "io.mantisrx:mantis-connector-job:$mantisConnectorsVersion"
 


### PR DESCRIPTION
### Context

the current `pull_request_target` workflow checkouts the main branch rather than the PR head.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
