### PR TITLE
Fix multiple HA sevice instance

### DIFF
--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 import rx.Scheduler;
 import rx.Subscription;
@@ -37,12 +38,17 @@ import rx.schedulers.Schedulers;
  */
 @Slf4j
 public class HighAvailabilityServicesUtil {
+  private static AtomicReference<HighAvailabilityServices> HAServiceInstanceRef = new AtomicReference<>();
 
   public static HighAvailabilityServices createHAServices(CoreConfiguration configuration) {
     if (configuration.isLocalMode()) {
       throw new UnsupportedOperationException();
     } else {
-      return new ZkHighAvailabilityServices(configuration);
+      if (HAServiceInstanceRef.get() == null) {
+          HAServiceInstanceRef.compareAndSet(null, new ZkHighAvailabilityServices(configuration));
+      }
+
+      return HAServiceInstanceRef.get();
     }
   }
 

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HighAvailabilityServicesUtil.java
@@ -38,7 +38,7 @@ import rx.schedulers.Schedulers;
  */
 @Slf4j
 public class HighAvailabilityServicesUtil {
-  private static AtomicReference<HighAvailabilityServices> HAServiceInstanceRef = new AtomicReference<>();
+  private final static AtomicReference<HighAvailabilityServices> HAServiceInstanceRef = new AtomicReference<>();
 
   public static HighAvailabilityServices createHAServices(CoreConfiguration configuration) {
     if (configuration.isLocalMode()) {


### PR DESCRIPTION
### Context

There are multiple places creating HA service instances and their own curator instance. A regression was introduced when some of the HA service creations no longer initialize/run their own curator service. 
The fix here is to consolidate and use a single HA service instance across all components and ensure the singleton instance will be ran.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
