### PR TITLE
Collect metrics with respect to worker transitions

### DIFF
--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -1,6 +1,7 @@
 name: "Publish snapshot to NetflixOSS and Maven Central"
 
-on: [pull_request_target]
+on:
+  pull_request:
 
 jobs:
   approve: # First step

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -1,7 +1,6 @@
 name: "Publish snapshot to NetflixOSS and Maven Central"
 
-on:
-  pull_request:
+on: [pull_request_target]
 
 jobs:
   approve: # First step
@@ -13,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ approve ] # Require the first step to finish
     environment:
-        name: Integrate Pull Request # Our protected environment variable
+      name: Integrate Pull Request # Our protected environment variable
     steps:
       - name: Checkout PR
         uses: actions/checkout@v3

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/BaseService.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/BaseService.java
@@ -152,4 +152,25 @@ public abstract class BaseService implements Service {
             }
         }
     }
+
+    public static BaseService wrap(io.mantisrx.shaded.com.google.common.util.concurrent.Service service) {
+        return new BaseService() {
+            @Override
+            public void start() {
+
+            }
+
+            @Override
+            public void enterActiveMode() {
+                service.startAsync().awaitRunning();
+                super.enterActiveMode();
+            }
+
+            @Override
+            public void shutdown() {
+                service.stopAsync().awaitTerminated();
+                super.shutdown();
+            }
+        };
+    }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventPublisherImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventPublisherImpl.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.events;
 
+import io.mantisrx.master.events.LifecycleEventsProto.WorkerStatusEvent;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -45,6 +46,8 @@ public class LifecycleEventPublisherImpl implements LifecycleEventPublisher {
             if (statusEvent instanceof LifecycleEventsProto.JobStatusEvent) {
                 LifecycleEventsProto.JobStatusEvent jobStatusEvent = (LifecycleEventsProto.JobStatusEvent) statusEvent;
                 workerEventSubscriber.process(jobStatusEvent);
+            } else if (statusEvent instanceof WorkerStatusEvent) {
+                workerEventSubscriber.process((WorkerStatusEvent) statusEvent);
             }
         } catch (Exception e) {
             log.error("Failed to publish the event={}; Ignoring the failure as this is just a listener interface", statusEvent, e);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventsProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/LifecycleEventsProto.java
@@ -180,6 +180,7 @@ public class LifecycleEventsProto {
     }
 
     @ToString
+    @Getter
     public static final class JobStatusEvent extends StatusEvent {
         private final JobId jobId;
         private final JobState jobState;
@@ -191,14 +192,6 @@ public class LifecycleEventsProto {
             super(type, message);
             this.jobId = jobId;
             this.jobState = jobState;
-        }
-
-        public String getJobId() {
-            return jobId.getId();
-        }
-
-        public JobState getJobState() {
-            return jobState;
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerEventSubscriberLoggingImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerEventSubscriberLoggingImpl.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.events;
 
+import io.mantisrx.master.events.LifecycleEventsProto.WorkerStatusEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,5 +30,10 @@ public class WorkerEventSubscriberLoggingImpl implements WorkerEventSubscriber {
     @Override
     public void process(LifecycleEventsProto.JobStatusEvent statusEvent) {
         logger.info("Received status event {}", statusEvent);
+    }
+
+    @Override
+    public void process(WorkerStatusEvent workerStatusEvent) {
+        logger.info("Received worker status event {}", workerStatusEvent);
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerEventSubscriberLoggingImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerEventSubscriberLoggingImpl.java
@@ -34,6 +34,6 @@ public class WorkerEventSubscriberLoggingImpl implements WorkerEventSubscriber {
 
     @Override
     public void process(WorkerStatusEvent workerStatusEvent) {
-        logger.info("Received worker status event {}", workerStatusEvent);
+        logger.debug("Received worker status event {}", workerStatusEvent);
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerMetricsCollector.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerMetricsCollector.java
@@ -69,11 +69,11 @@ public class WorkerMetricsCollector extends AbstractScheduledService implements
 
     @Override
     protected void runOneIteration() {
-        Instant expiry = clock.instant().minus(cleanupInterval);
+        Instant current = clock.instant();
         Iterator<CleanupJobEvent> iterator = jobsToBeCleaned.iterator();
         while (iterator.hasNext()) {
             CleanupJobEvent event = iterator.next();
-            if (event.isAfter(expiry)) {
+            if (current.isAfter(event.getExpiry())) {
                 jobWorkers.remove(event.getJobId());
                 iterator.remove();
             }
@@ -158,7 +158,7 @@ public class WorkerMetricsCollector extends AbstractScheduledService implements
     }
 
     private void cleanUp(JobId jobId) {
-        jobsToBeCleaned.add(new CleanupJobEvent(jobId, clock.instant()));
+        jobsToBeCleaned.add(new CleanupJobEvent(jobId, clock.instant().plus(cleanupInterval)));
     }
 
     private static class WorkerMetrics {
@@ -224,10 +224,6 @@ public class WorkerMetricsCollector extends AbstractScheduledService implements
     private static class CleanupJobEvent {
 
         JobId jobId;
-        Instant eventTimestamp;
-
-        boolean isAfter(Instant expiry) {
-            return eventTimestamp.isAfter(expiry);
-        }
+        Instant expiry;
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerMetricsCollector.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerMetricsCollector.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.events;
+
+import com.netflix.spectator.api.Tag;
+import io.mantisrx.common.metrics.Metrics;
+import io.mantisrx.common.metrics.MetricsRegistry;
+import io.mantisrx.common.metrics.Timer;
+import io.mantisrx.common.metrics.spectator.MetricGroupId;
+import io.mantisrx.master.events.LifecycleEventsProto.JobStatusEvent;
+import io.mantisrx.master.events.LifecycleEventsProto.WorkerListChangedEvent;
+import io.mantisrx.master.events.LifecycleEventsProto.WorkerStatusEvent;
+import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
+import io.mantisrx.master.jobcluster.job.worker.WorkerState;
+import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.master.domain.JobId;
+import io.mantisrx.shaded.com.google.common.util.concurrent.AbstractScheduledService;
+import io.mantisrx.shaded.org.apache.curator.shaded.com.google.common.base.Preconditions;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The goal of this service is to keep emitting metrics around how long it took for the worker to be
+ * scheduled, to be prepared and how long it was running for.
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class WorkerMetricsCollector extends AbstractScheduledService implements
+    WorkerEventSubscriber {
+
+    public static final String SCHEDULING_DURATION = "schedulingDuration";
+    public static final String PREPARATION_DURATION = "preparationDuration";
+    public static final String RUNNING_DURATION = "runningDuration";
+    private final ConcurrentMap<JobId, Map<WorkerId, IMantisWorkerMetadata>> jobWorkers =
+        new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, WorkerMetrics> clusterWorkersMetrics =
+        new ConcurrentHashMap<>();
+    private final Set<CleanupJobEvent> jobsToBeCleaned = new HashSet<>();
+    private final Duration cleanupInterval;
+
+    private final Duration epochDuration;
+    private final Clock clock;
+
+    @Override
+    protected void runOneIteration() throws Exception {
+        Instant expiry = clock.instant().minus(cleanupInterval);
+        Set<CleanupJobEvent> toBeRemoved = new HashSet<>();
+
+        synchronized (jobsToBeCleaned) {
+            jobsToBeCleaned.forEach(event -> {
+                if (event.isAfter(expiry)) {
+                    jobWorkers.remove(event.getJobId());
+                    toBeRemoved.add(event);
+                }
+            });
+            jobsToBeCleaned.removeAll(toBeRemoved);
+        }
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+        return Scheduler.newFixedDelaySchedule(
+            epochDuration.toMillis(),
+            epochDuration.toMillis(),
+            TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void process(WorkerListChangedEvent event) {
+        final JobId jobId = event.getWorkerInfoListHolder().getJobId();
+        final List<IMantisWorkerMetadata> workers =
+            event.getWorkerInfoListHolder().getWorkerMetadataList();
+        jobWorkers.put(jobId,
+            workers.stream().collect(Collectors.toMap(IMantisWorkerMetadata::getWorkerId, m -> m)));
+    }
+
+    @Override
+    public void process(JobStatusEvent statusEvent) {
+        if (statusEvent.getJobState().isTerminal()) {
+            cleanUp(statusEvent.getJobId());
+        }
+    }
+
+    private WorkerMetrics getWorkerMetrics(String clusterName) {
+        return clusterWorkersMetrics.computeIfAbsent(
+            clusterName, dontCare -> new WorkerMetrics(clusterName));
+    }
+
+    @Override
+    public void process(WorkerStatusEvent workerStatusEvent) {
+        try {
+            final WorkerState workerState =
+                workerStatusEvent.getWorkerState();
+            final JobId jobId = JobId.fromId(workerStatusEvent.getWorkerId().getJobId()).get();
+            final WorkerId workerId = workerStatusEvent.getWorkerId();
+            Preconditions.checkNotNull(jobWorkers.get(jobId));
+            final IMantisWorkerMetadata metadata = jobWorkers.get(jobId).get(workerId);
+            Preconditions.checkNotNull(metadata);
+            final WorkerMetrics workerMetrics = getWorkerMetrics(metadata.getCluster().orElse("unknown"));
+
+            switch (workerState) {
+                case Accepted:
+                    // do nothing; This is the initial state
+                    break;
+                case Launched:
+                    // this represents the scheduling time
+                    workerMetrics.reportSchedulingDuration(
+                        Math.max(0L, workerStatusEvent.getTimestamp() - metadata.getAcceptedAt()));
+                    break;
+                case StartInitiated:
+                    // do nothing; this event gets sent when the worker has received the request; it's too granular and expected to be really low -
+                    // so there's no point in measuring it.
+                    break;
+                case Started:
+                    workerMetrics.reportWorkerPreparationDuration(
+                        Math.max(0L, workerStatusEvent.getTimestamp() - metadata.getLaunchedAt()));
+                    break;
+                case Failed:
+                case Completed:
+                    workerMetrics.reportRunningDuration(
+                        Math.max(0L, workerStatusEvent.getTimestamp() - metadata.getStartedAt()));
+                    break;
+                case Noop:
+                    break;
+                case Unknown:
+                    log.error("Unknown WorkerStatusEvent {}", workerStatusEvent);
+                    break;
+            }
+        } catch (Exception e) {
+            log.error("Failed to process worker status event {}", workerStatusEvent);
+        }
+    }
+
+    private void cleanUp(JobId jobId) {
+        synchronized (jobsToBeCleaned) {
+            jobsToBeCleaned.add(new CleanupJobEvent(jobId, clock.instant()));
+        }
+    }
+
+    private class WorkerMetrics {
+
+        private final String clusterName;
+        private final Timer schedulingDuration;
+        private final Timer preparationDuration;
+        private final Timer runningDuration;
+
+        public WorkerMetrics(final String clusterName) {
+            this.clusterName = clusterName;
+            MetricGroupId metricGroupId =
+                new MetricGroupId("WorkerMetricsCollector", Tag.of("cluster", clusterName));
+            Metrics m = new Metrics.Builder()
+                .id(metricGroupId)
+                .addTimer(SCHEDULING_DURATION)
+                .addTimer(PREPARATION_DURATION)
+                .addTimer(RUNNING_DURATION)
+                .build();
+
+            m = MetricsRegistry.getInstance().registerAndGet(m);
+            this.schedulingDuration = m.getTimer(SCHEDULING_DURATION);
+            this.preparationDuration = m.getTimer(PREPARATION_DURATION);
+            this.runningDuration = m.getTimer(RUNNING_DURATION);
+        }
+
+        private void reportSchedulingDuration(long durationInMillis) {
+            this.schedulingDuration.record(durationInMillis, TimeUnit.MILLISECONDS);
+        }
+
+        private void reportWorkerPreparationDuration(long durationInMillis) {
+            this.preparationDuration.record(durationInMillis, TimeUnit.MILLISECONDS);
+        }
+
+        private void reportRunningDuration(long durationInMillis) {
+            this.runningDuration.record(durationInMillis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Value
+    private static class CleanupJobEvent {
+
+        JobId jobId;
+        Instant eventTimestamp;
+
+        boolean isAfter(Instant expiry) {
+            return eventTimestamp.isAfter(expiry);
+        }
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerRegistryV2.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerRegistryV2.java
@@ -19,6 +19,7 @@ package io.mantisrx.master.events;
 import static java.util.stream.Collectors.toMap;
 
 import akka.actor.Props;
+import io.mantisrx.master.events.LifecycleEventsProto.WorkerStatusEvent;
 import io.mantisrx.master.jobcluster.job.JobState;
 import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
 import io.mantisrx.master.jobcluster.job.worker.WorkerState;
@@ -51,13 +52,6 @@ public class WorkerRegistryV2 implements WorkerRegistry, WorkerEventSubscriber {
 
      WorkerRegistryV2() {
         logger.info("WorkerRegistryV2 created");
-    }
-
-    /**
-     * For Testing
-     */
-    public void clearState() {
-        jobToWorkerInfoMap.clear();
     }
 
 
@@ -129,7 +123,6 @@ public class WorkerRegistryV2 implements WorkerRegistry, WorkerEventSubscriber {
             return false;
         }
         List<IMantisWorkerMetadata> mantisWorkerMetadataList = jobToWorkerInfoMap.get(jIdOp.get());
-      //  logger.info("Current Map {}", jobToWorkerInfoMap);
         boolean isValid = false;
         if(mantisWorkerMetadataList != null) {
 
@@ -189,15 +182,13 @@ public class WorkerRegistryV2 implements WorkerRegistry, WorkerEventSubscriber {
         if(logger.isDebugEnabled()) {  logger.debug("In JobStatusEvent {}", statusEvent); }
         JobState jobState = statusEvent.getJobState();
         if(JobState.isTerminalState(jobState)) {
-            String jobId = statusEvent.getJobId();
-            Optional<JobId> optionalJobId = JobId.fromId(jobId);
-            if(optionalJobId.isPresent()) {
-                deregisterJob(optionalJobId.get());
-            } else {
-                logger.warn("Invalid Job id {} Ignoring terminate event", jobId);
-            }
+            final JobId jobId = statusEvent.getJobId();
+            deregisterJob(jobId);
         }
     }
 
+    @Override
+    public void process(WorkerStatusEvent workerStatusEvent) {
 
+    }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobState.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobState.java
@@ -144,6 +144,10 @@ public enum JobState {
         }
     }
 
+    public boolean isTerminal() {
+        return isTerminalState(this);
+    }
+
     /**
      * Returns true if the current state is abnormal.
      *

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -52,6 +52,7 @@ import io.mantisrx.master.scheduler.AgentsErrorMonitorActor;
 import io.mantisrx.master.scheduler.JobMessageRouterImpl;
 import io.mantisrx.master.vm.AgentClusterOperationsImpl;
 import io.mantisrx.master.zk.LeaderElector;
+import io.mantisrx.server.core.BaseService;
 import io.mantisrx.server.core.MantisAkkaRpcSystemLoader;
 import io.mantisrx.server.core.Service;
 import io.mantisrx.server.core.json.DefaultObjectMapper;
@@ -155,6 +156,7 @@ public class MasterMain implements Service {
                 Duration.ofMinutes(5), // cleanup jobs after 5 minutes
                 Duration.ofMinutes(1), // check every 1 minute for jobs to be cleaned up
                 Clock.systemDefaultZone());
+            mantisServices.addService(BaseService.wrap(workerMetricsCollector));
 
             // TODO who watches actors created at this level?
             final LifecycleEventPublisher lifecycleEventPublisher =

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/events/WorkerRegistryV2Test.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/events/WorkerRegistryV2Test.java
@@ -29,6 +29,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.testkit.javadsl.TestKit;
 import com.netflix.mantis.master.scheduler.TestHelpers;
+import io.mantisrx.master.events.LifecycleEventsProto.WorkerStatusEvent;
 import io.mantisrx.master.jobcluster.WorkerInfoListHolder;
 import io.mantisrx.master.jobcluster.job.IMantisStageMetadata;
 import io.mantisrx.master.jobcluster.job.JobState;
@@ -410,6 +411,11 @@ public class WorkerRegistryV2Test {
         public void process(LifecycleEventsProto.JobStatusEvent statusEvent) {
             workerRegistry.process(statusEvent);
         }
+
+        @Override
+        public void process(WorkerStatusEvent workerStatusEvent) {
+            workerRegistry.process(workerStatusEvent);
+        }
     }
 
     class NoOpWorkerEventSubscriberImpl implements  WorkerEventSubscriber {
@@ -421,6 +427,11 @@ public class WorkerRegistryV2Test {
 
         @Override
         public void process(LifecycleEventsProto.JobStatusEvent statusEvent) {
+
+        }
+
+        @Override
+        public void process(WorkerStatusEvent workerStatusEvent) {
 
         }
     }


### PR DESCRIPTION
### Context

This diff aims to collect individual worker metrics such as 
1. How long it took to schedule a worker?
2. How long it took to prepare a worker?
3. How long a worker ran?

All these metrics are tagged with cluster names. This would help us differentiate mesos & titus schedule latencies, for instance. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
