### PR TITLE
Fix metric name issue

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/metrics/Metrics.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/metrics/Metrics.java
@@ -208,7 +208,7 @@ public class Metrics {
 
         public Builder id(final MetricGroupId metricGroup) {
             this.metricGroup = new MetricGroupId(
-                metricGroup.id(),
+                metricGroup.name(),
                 ImmutableList.<Tag>builder().addAll(metricGroup.tags()).addAll(CommonTags).build());
             return this;
         }


### PR DESCRIPTION
### Context
When running master we noticed metrics emitted by `JobClusterActor` (eg. numJobSubmissions) changed names in Atlas (internal monitoring system). It looked like the metric would contain custom tags as part of the name.

Example:
- metric name in latest running version was: `JobClusterActor_numJobSubmissions`
- metric name in master was: `JobClusterActor_jobCluster_<clusterName>_numJobSubmissions`

`jobCluster` is a custom tag we add in https://github.com/Netflix/mantis/blob/dd88c50fcde0902466fa45f36918de48cf67061f/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java#L610 

### Investigation
I was able to repro the issue by running this simple snippet:

```
package io.mantisrx.common.metrics;
import com.netflix.spectator.api.BasicTag;
import io.mantisrx.common.metrics.spectator.MetricGroupId;
import io.mantisrx.common.metrics.spectator.SpectatorRegistryFactory;

public class Solution {
    public static void main(String[] args) {
        MetricGroupId metricGroupId = getMetricGroupId("fdcClusterName");
        Metrics m = new Metrics.Builder()
            .id(metricGroupId)
            .addCounter("numJobSubmissionsFDC")
            .build();
        m = MetricsRegistry.getInstance().registerAndGet(m);
        Counter numJobSubmissions = m.getCounter("numJobSubmissionsFDC");
        System.out.println(numJobSubmissions.id().getSpectatorId(SpectatorRegistryFactory.getRegistry()).name());
    }

    private static MetricGroupId getMetricGroupId(String name) {
        return new MetricGroupId("JobClusterActor", new BasicTag("jobCluster", name));
    }
}
```

We first believed it was `spectator-api` new version that could have caused the issue but upgrading it to `1.3.9` didn't change anything.

We finally spot a small bug in `Metrics.java` where we mistakenly use the passed metricGroup id (which contains name + tags) instead of name when the metrics builder creates the final metric groups.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
