### PR TITLE
Bump guava to 31.+

### DIFF
--- a/mantis-client/dependencies.lock
+++ b/mantis-client/dependencies.lock
@@ -12,7 +12,7 @@
             "locked": "1.1.1"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -107,15 +107,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -196,7 +196,7 @@
             "locked": "1.1.1"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -291,15 +291,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -383,7 +383,7 @@
             "locked": "0.20.6"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -504,7 +504,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -512,13 +512,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -529,12 +529,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -585,7 +579,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [
@@ -607,7 +601,7 @@
             "locked": "1.1.1"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -702,7 +696,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -710,13 +704,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -798,7 +792,7 @@
             "locked": "0.20.6"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -919,7 +913,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -933,13 +927,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -950,12 +944,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -1009,7 +997,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [

--- a/mantis-common/dependencies.lock
+++ b/mantis-common/dependencies.lock
@@ -14,7 +14,7 @@
     },
     "baseline-exact-dependencies-test": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -107,7 +107,7 @@
     },
     "compileClasspath": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "locked": "0.4.19.1"
@@ -217,7 +217,7 @@
     },
     "testCompileClasspath": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -489,7 +489,7 @@
     },
     "testRuntimeClasspath": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [

--- a/mantis-connectors/mantis-connector-job/dependencies.lock
+++ b/mantis-connectors/mantis-connector-job/dependencies.lock
@@ -18,7 +18,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -121,15 +121,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -205,7 +205,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -308,15 +308,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -400,13 +400,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -419,7 +419,7 @@
                 "io.mantisrx:mantis-client",
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
@@ -568,7 +568,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -576,13 +576,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -593,12 +593,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -651,7 +645,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [
@@ -679,7 +673,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -782,15 +776,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -869,13 +863,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -888,7 +882,7 @@
                 "io.mantisrx:mantis-client",
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
@@ -1037,7 +1031,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -1045,13 +1039,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -1062,12 +1056,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -1120,7 +1108,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [

--- a/mantis-connectors/mantis-connector-kafka/dependencies.lock
+++ b/mantis-connectors/mantis-connector-kafka/dependencies.lock
@@ -118,10 +118,10 @@
     },
     "compileClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.82.0"
@@ -236,10 +236,10 @@
     },
     "runtimeClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -388,10 +388,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.82.0"
@@ -513,10 +513,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [

--- a/mantis-connectors/mantis-connector-publish/dependencies.lock
+++ b/mantis-connectors/mantis-connector-publish/dependencies.lock
@@ -124,7 +124,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -221,15 +221,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -310,13 +310,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -447,7 +447,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -455,13 +455,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -542,7 +542,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -639,15 +639,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -732,13 +732,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -869,7 +869,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -877,13 +877,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],

--- a/mantis-control-plane/mantis-control-plane-client/dependencies.lock
+++ b/mantis-control-plane/mantis-control-plane-client/dependencies.lock
@@ -8,16 +8,13 @@
         "com.spotify:completable-futures": {
             "locked": "0.3.1"
         },
-        "org.apache.hadoop:hadoop-common": {
-            "locked": "2.7.7"
-        },
         "org.asynchttpclient:async-http-client": {
             "locked": "2.12.3"
         }
     },
     "baseline-exact-dependencies-test": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -171,15 +168,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -190,9 +187,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -348,7 +342,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -356,13 +350,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -373,9 +367,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -422,7 +413,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [
@@ -444,7 +435,7 @@
             "locked": "1.1.1"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -509,7 +500,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -517,13 +508,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -534,9 +525,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -610,7 +598,7 @@
             "locked": "0.20.6"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -694,7 +682,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -708,13 +696,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -725,9 +713,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -777,7 +762,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [

--- a/mantis-control-plane/mantis-control-plane-core/dependencies.lock
+++ b/mantis-control-plane/mantis-control-plane-core/dependencies.lock
@@ -70,7 +70,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -78,13 +78,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -199,12 +199,12 @@
             "locked": "1.3.8"
         },
         "joda-time:joda-time": {
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "locked": "1.14.2"
         },
         "org.apache.flink:flink-rpc-core": {
@@ -318,7 +318,7 @@
             "locked": "0.9.2"
         },
         "joda-time:joda-time": {
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -326,10 +326,10 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "locked": "1.14.2"
         },
         "org.apache.flink:flink-rpc-core": {
@@ -443,7 +443,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -451,13 +451,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -592,15 +592,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -739,7 +739,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -747,13 +747,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -892,7 +892,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -906,13 +906,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],

--- a/mantis-control-plane/mantis-control-plane-server/dependencies.lock
+++ b/mantis-control-plane/mantis-control-plane-server/dependencies.lock
@@ -5,138 +5,8 @@
         }
     },
     "baseline-exact-dependencies-main": {
-        "com.github.spullara.cli-parser:cli-parser": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.1.1"
-        },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
-        },
-        "com.netflix:mantis-rxnetty": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "0.4.19.1"
-        },
-        "io.mantisrx:mantis-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-common-serde": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-control-plane-core": {
-            "project": true
-        },
-        "io.mantisrx:mantis-shaded": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-common-serde"
-            ],
-            "project": true
-        },
-        "io.netty:netty-buffer": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.netty:netty-codec-http": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.netty:netty-transport-native-epoll": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.3.8"
-        },
-        "joda-time:joda-time": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "2.12.0"
-        },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka-loader": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.mesos:mesos": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.7.2"
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "2.1.12"
-        },
-        "org.jctools:jctools-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.2.1"
-        },
-        "org.json:json": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "20180813"
-        },
-        "org.skife.config:config-magic": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "0.11"
-        },
-        "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.7.15"
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.7.0"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.1.8.4"
+            "locked": "1.3.10"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -215,7 +85,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -223,13 +93,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -310,7 +180,7 @@
             "locked": "0.13.8"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -389,15 +259,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -480,7 +350,7 @@
             "locked": "0.13.8"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -571,7 +441,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -579,13 +449,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -665,7 +535,7 @@
             "locked": "0.13.8"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -757,7 +627,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -765,13 +635,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -855,7 +725,7 @@
             "locked": "0.13.8"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -956,7 +826,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -970,13 +840,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],

--- a/mantis-examples/mantis-examples-groupby-sample/build.gradle
+++ b/mantis-examples/mantis-examples-groupby-sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 
 configurations.all {
     resolutionStrategy {
-        force "com.google.guava:guava:18.0"
+        force "com.google.guava:guava:31.1-jre"
 
     }
 }

--- a/mantis-examples/mantis-examples-jobconnector-sample/build.gradle
+++ b/mantis-examples/mantis-examples-jobconnector-sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 
 configurations.all {
     resolutionStrategy {
-        force "com.google.guava:guava:18.0"
+        force "com.google.guava:guava:31.1-jre"
 
     }
 }

--- a/mantis-examples/mantis-examples-jobconnector-sample/dependencies.lock
+++ b/mantis-examples/mantis-examples-jobconnector-sample/dependencies.lock
@@ -504,7 +504,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "18.0"
+            "locked": "31.1-jre"
         },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
@@ -827,7 +827,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "18.0"
+            "locked": "31.1-jre"
         },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
@@ -1098,7 +1098,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "18.0"
+            "locked": "31.1-jre"
         },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [

--- a/mantis-examples/mantis-examples-mantis-publish-sample/dependencies.lock
+++ b/mantis-examples/mantis-examples-mantis-publish-sample/dependencies.lock
@@ -12,13 +12,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -71,13 +71,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -141,7 +141,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
@@ -149,19 +149,19 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
@@ -169,7 +169,7 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-nflx-plugin": {
             "firstLevelTransitive": [
@@ -261,13 +261,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -326,7 +326,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
@@ -334,19 +334,19 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
@@ -354,7 +354,7 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-nflx-plugin": {
             "firstLevelTransitive": [

--- a/mantis-examples/mantis-examples-sine-function/build.gradle
+++ b/mantis-examples/mantis-examples-sine-function/build.gradle
@@ -16,7 +16,7 @@
 
 configurations.all {
     resolutionStrategy {
-        force "com.google.guava:guava:18.0"
+        force "com.google.guava:guava:31.1-jre"
     }
 }
 task execute(type:JavaExec) {

--- a/mantis-examples/mantis-examples-twitter-sample/build.gradle
+++ b/mantis-examples/mantis-examples-twitter-sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 
 configurations.all {
     resolutionStrategy {
-        force "com.google.guava:guava:18.0"
+        force "com.google.guava:guava:31.1-jre"
         force "org.apache.httpcomponents:httpclient:4.5.9"
     }
 }

--- a/mantis-examples/mantis-examples-wordcount/build.gradle
+++ b/mantis-examples/mantis-examples-wordcount/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java-library'
 
 configurations.all {
     resolutionStrategy {
-        force "com.google.guava:guava:18.0"
+        force "com.google.guava:guava:31.1-jre"
         force "org.apache.httpcomponents:httpclient:4.5.9"
     }
 }

--- a/mantis-network/dependencies.lock
+++ b/mantis-network/dependencies.lock
@@ -11,7 +11,7 @@
     },
     "baseline-exact-dependencies-test": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "org.junit.jupiter:junit-jupiter-api": {
             "locked": "5.4.2"
@@ -31,7 +31,7 @@
     },
     "compileClasspath": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -221,7 +221,7 @@
     },
     "testCompileClasspath": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -317,7 +317,7 @@
     },
     "testRuntimeClasspath": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [

--- a/mantis-publish/mantis-publish-core/dependencies.lock
+++ b/mantis-publish/mantis-publish-core/dependencies.lock
@@ -6,7 +6,7 @@
     },
     "baseline-exact-dependencies-main": {
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "locked": "0.134.0"
@@ -52,10 +52,10 @@
     },
     "compileClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -93,10 +93,10 @@
     },
     "runtimeClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -140,10 +140,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -197,10 +197,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"

--- a/mantis-publish/mantis-publish-netty-guice/dependencies.lock
+++ b/mantis-publish/mantis-publish-netty-guice/dependencies.lock
@@ -9,10 +9,10 @@
             "locked": "4.2.2"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "locked": "0.96.0"
@@ -52,13 +52,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -110,30 +110,30 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-nflx-plugin": {
             "locked": "0.96.0"
@@ -205,13 +205,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -273,30 +273,30 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-nflx-plugin": {
             "locked": "0.96.0"

--- a/mantis-publish/mantis-publish-netty/dependencies.lock
+++ b/mantis-publish/mantis-publish-netty/dependencies.lock
@@ -9,19 +9,19 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "io.mantisrx:mantis-discovery-proto": {
             "firstLevelTransitive": [
@@ -67,19 +67,19 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "io.mantisrx:mantis-discovery-proto": {
             "firstLevelTransitive": [
@@ -116,25 +116,25 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "io.mantisrx:mantis-common-serde": {
             "firstLevelTransitive": [
@@ -190,19 +190,19 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "io.mantisrx:mantis-discovery-proto": {
             "firstLevelTransitive": [
@@ -249,25 +249,25 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "io.mantisrx:mantis-common-serde": {
             "firstLevelTransitive": [

--- a/mantis-runtime-loader/dependencies.lock
+++ b/mantis-runtime-loader/dependencies.lock
@@ -163,15 +163,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -346,7 +346,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -354,13 +354,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -371,12 +371,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -426,7 +420,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [
@@ -516,7 +510,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -524,13 +518,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -704,7 +698,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -718,13 +712,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -735,12 +729,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -793,7 +781,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [

--- a/mantis-runtime/dependencies.lock
+++ b/mantis-runtime/dependencies.lock
@@ -6,7 +6,7 @@
     },
     "baseline-exact-dependencies-test": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -20,7 +20,7 @@
     },
     "compileClasspath": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -244,7 +244,7 @@
     },
     "testCompileClasspath": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -352,7 +352,7 @@
             "locked": "0.20.6"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [

--- a/mantis-server/mantis-server-agent/dependencies.lock
+++ b/mantis-server/mantis-server-agent/dependencies.lock
@@ -5,173 +5,26 @@
         }
     },
     "baseline-exact-dependencies-main": {
-        "com.github.spullara.cli-parser:cli-parser": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.1.1"
-        },
-        "com.netflix:mantis-rxnetty": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "0.4.19.1"
-        },
         "com.spotify:completable-futures": {
             "locked": "0.3.1"
         },
         "commons-io:commons-io": {
             "locked": "2.11.0"
         },
-        "io.mantisrx:mantis-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-common-serde": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-control-plane-client": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-runtime-loader",
-                "io.mantisrx:mantis-server-worker-client"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-control-plane-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client",
-                "io.mantisrx:mantis-server-worker-client"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-remote-observable": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-runtime-loader": {
-            "project": true
-        },
-        "io.mantisrx:mantis-server-worker-client": {
-            "project": true
-        },
-        "io.mantisrx:mantis-shaded": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-common-serde"
-            ],
-            "project": true
-        },
-        "io.netty:netty-buffer": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.netty:netty-codec-http": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.netty:netty-transport-native-epoll": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.3.8"
-        },
         "io.vavr:vavr": {
             "locked": "0.9.2"
-        },
-        "joda-time:joda-time": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "2.12.0"
         },
         "net.lingala.zip4j:zip4j": {
             "locked": "2.9.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka-loader": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.hadoop:hadoop-common": {
             "locked": "2.7.7"
         },
-        "org.apache.mesos:mesos": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.7.2"
-        },
-        "org.hdrhistogram:HdrHistogram": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "2.1.12"
-        },
-        "org.jctools:jctools-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.2.1"
-        },
-        "org.json:json": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "20180813"
-        },
-        "org.skife.config:config-magic": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "0.11"
-        },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.7.15"
+            "locked": "1.7.10"
         },
         "org.slf4j:slf4j-log4j12": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
             "locked": "1.7.0"
-        },
-        "org.xerial.snappy:snappy-java": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.1.8.4"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -186,12 +39,6 @@
                 "io.mantisrx:mantis-common"
             ],
             "locked": "0.4.19.1"
-        },
-        "com.yahoo.datasketches:sketches-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
-            "locked": "0.9.1"
         },
         "io.mantisrx:mantis-common": {
             "firstLevelTransitive": [
@@ -210,7 +57,6 @@
         "io.mantisrx:mantis-control-plane-client": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-runtime-loader",
-                "io.mantisrx:mantis-server-worker",
                 "io.mantisrx:mantis-server-worker-client"
             ],
             "project": true
@@ -219,7 +65,6 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-client",
                 "io.mantisrx:mantis-control-plane-core",
-                "io.mantisrx:mantis-server-worker",
                 "io.mantisrx:mantis-server-worker-client"
             ],
             "project": true
@@ -248,12 +93,6 @@
                 "io.mantisrx:mantis-server-worker"
             ],
             "project": true
-        },
-        "io.mantisrx:mantis-rxcontrol": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
-            "locked": "1.3.20"
         },
         "io.mantisrx:mantis-server-worker": {
             "project": true
@@ -301,17 +140,11 @@
             ],
             "locked": "1.3.8"
         },
-        "io.vavr:vavr": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
-            "locked": "0.9.2"
-        },
         "joda-time:joda-time": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -319,19 +152,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
-            "locked": "2017.06"
-        },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -343,16 +170,9 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.httpcomponents:httpclient": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
-            "locked": "4.5.6"
-        },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core",
-                "io.mantisrx:mantis-server-worker"
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.7.2"
         },
@@ -386,15 +206,13 @@
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-runtime",
-                "io.mantisrx:mantis-server-worker"
+                "io.mantisrx:mantis-runtime"
             ],
             "locked": "1.7.15"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-server-worker"
+                "io.mantisrx:mantis-common"
             ],
             "locked": "1.7.0"
         },
@@ -500,18 +318,18 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.lingala.zip4j:zip4j": {
             "locked": "2.9.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -700,7 +518,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -711,13 +529,13 @@
         "net.lingala.zip4j:zip4j": {
             "locked": "2.9.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -730,9 +548,6 @@
             "locked": "1.14.2"
         },
         "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
             "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
@@ -813,12 +628,6 @@
         "com.spotify:completable-futures": {
             "locked": "0.3.1"
         },
-        "com.yahoo.datasketches:sketches-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
-            "locked": "0.9.1"
-        },
         "commons-io:commons-io": {
             "locked": "2.11.0"
         },
@@ -839,7 +648,6 @@
         "io.mantisrx:mantis-control-plane-client": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-runtime-loader",
-                "io.mantisrx:mantis-server-worker",
                 "io.mantisrx:mantis-server-worker-client"
             ],
             "project": true
@@ -848,7 +656,6 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-client",
                 "io.mantisrx:mantis-control-plane-core",
-                "io.mantisrx:mantis-server-worker",
                 "io.mantisrx:mantis-server-worker-client"
             ],
             "project": true
@@ -877,12 +684,6 @@
                 "io.mantisrx:mantis-server-worker"
             ],
             "project": true
-        },
-        "io.mantisrx:mantis-rxcontrol": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
-            "locked": "1.3.20"
         },
         "io.mantisrx:mantis-server-worker": {
             "project": true
@@ -931,16 +732,13 @@
             "locked": "1.3.8"
         },
         "io.vavr:vavr": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
             "locked": "0.9.2"
         },
         "joda-time:joda-time": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -951,19 +749,13 @@
         "net.lingala.zip4j:zip4j": {
             "locked": "2.9.0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
-            "locked": "2017.06"
-        },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -978,16 +770,9 @@
         "org.apache.hadoop:hadoop-common": {
             "locked": "2.7.7"
         },
-        "org.apache.httpcomponents:httpclient": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-server-worker"
-            ],
-            "locked": "4.5.6"
-        },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core",
-                "io.mantisrx:mantis-server-worker"
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.7.2"
         },
@@ -1024,15 +809,13 @@
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-runtime",
-                "io.mantisrx:mantis-server-worker"
+                "io.mantisrx:mantis-runtime"
             ],
             "locked": "1.7.15"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-server-worker"
+                "io.mantisrx:mantis-common"
             ],
             "locked": "1.7.0"
         },
@@ -1060,7 +843,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-server-worker"
             ],
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -1104,7 +887,6 @@
         "io.mantisrx:mantis-control-plane-client": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-runtime-loader",
-                "io.mantisrx:mantis-server-worker",
                 "io.mantisrx:mantis-server-worker-client"
             ],
             "project": true
@@ -1113,7 +895,6 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-client",
                 "io.mantisrx:mantis-control-plane-core",
-                "io.mantisrx:mantis-server-worker",
                 "io.mantisrx:mantis-server-worker-client"
             ],
             "project": true
@@ -1213,7 +994,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -1236,13 +1017,13 @@
             ],
             "locked": "2017.06"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -1255,9 +1036,6 @@
             "locked": "1.14.2"
         },
         "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
             "locked": "2.7.7"
         },
         "org.apache.httpcomponents:httpclient": {

--- a/mantis-server/mantis-server-worker-client/dependencies.lock
+++ b/mantis-server/mantis-server-worker-client/dependencies.lock
@@ -6,7 +6,7 @@
     },
     "baseline-exact-dependencies-test": {
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -96,15 +96,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -279,7 +279,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -287,13 +287,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -304,12 +304,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -359,7 +353,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [
@@ -381,7 +375,7 @@
             "locked": "1.1.1"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -451,7 +445,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -459,13 +453,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -549,7 +543,7 @@
             "locked": "0.20.6"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -644,7 +638,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -658,13 +652,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -675,12 +669,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.mesos:mesos": {
             "firstLevelTransitive": [
@@ -736,7 +724,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [

--- a/mantis-server/mantis-server-worker/dependencies.lock
+++ b/mantis-server/mantis-server-worker/dependencies.lock
@@ -5,195 +5,32 @@
         }
     },
     "baseline-exact-dependencies-main": {
-        "com.github.spullara.cli-parser:cli-parser": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.1.1"
-        },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
-        },
-        "com.netflix:mantis-rxnetty": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "0.4.19.1"
+            "locked": "1.3.10"
         },
         "com.yahoo.datasketches:sketches-core": {
             "locked": "0.9.1"
         },
-        "io.mantisrx:mantis-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core",
-                "io.mantisrx:mantis-network",
-                "io.mantisrx:mantis-runtime"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-common-serde": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-control-plane-client": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-runtime-loader",
-                "io.mantisrx:mantis-server-worker-client"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-control-plane-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client",
-                "io.mantisrx:mantis-server-worker-client"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-network": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-runtime"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-remote-observable": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client",
-                "io.mantisrx:mantis-runtime"
-            ],
-            "project": true
-        },
-        "io.mantisrx:mantis-runtime": {
-            "project": true
-        },
-        "io.mantisrx:mantis-runtime-loader": {
-            "project": true
-        },
         "io.mantisrx:mantis-rxcontrol": {
             "locked": "1.3.20"
-        },
-        "io.mantisrx:mantis-server-worker-client": {
-            "project": true
-        },
-        "io.mantisrx:mantis-shaded": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-common-serde"
-            ],
-            "project": true
-        },
-        "io.netty:netty-buffer": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.netty:netty-codec-http": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.netty:netty-handler": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-network"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.netty:netty-transport-native-epoll": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "4.1.17.Final"
-        },
-        "io.reactivex:rxjava": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.3.8"
         },
         "io.vavr:vavr": {
             "locked": "0.9.2"
         },
-        "joda-time:joda-time": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "2.12.0"
-        },
         "nz.ac.waikato.cms.moa:moa": {
             "locked": "2017.06"
-        },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka-loader": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
         },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.6"
         },
         "org.apache.mesos:mesos": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
             "locked": "1.7.2"
         },
-        "org.hdrhistogram:HdrHistogram": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "2.1.12"
-        },
-        "org.jctools:jctools-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.2.1"
-        },
-        "org.json:json": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "20180813"
-        },
-        "org.skife.config:config-magic": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "0.11"
-        },
         "org.slf4j:slf4j-api": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-runtime"
-            ],
-            "locked": "1.7.15"
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
             "locked": "1.7.0"
         },
-        "org.xerial.snappy:snappy-java": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
-            ],
-            "locked": "1.1.8.4"
+        "org.slf4j:slf4j-log4j12": {
+            "locked": "1.7.0"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -266,7 +103,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -274,13 +111,13 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -355,7 +192,7 @@
             "locked": "1.1.1"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -463,18 +300,18 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "nz.ac.waikato.cms.moa:moa": {
             "locked": "2017.06"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -561,7 +398,7 @@
             "locked": "0.20.6"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -692,7 +529,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -703,13 +540,13 @@
         "nz.ac.waikato.cms.moa:moa": {
             "locked": "2017.06"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -720,12 +557,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.6"
@@ -779,7 +610,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [
@@ -801,7 +632,7 @@
             "locked": "1.1.1"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -914,7 +745,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -925,13 +756,13 @@
         "nz.ac.waikato.cms.moa:moa": {
             "locked": "2017.06"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -1019,7 +850,7 @@
             "locked": "0.20.6"
         },
         "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.9"
+            "locked": "1.3.10"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -1155,7 +986,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -1172,13 +1003,13 @@
         "nz.ac.waikato.cms.moa:moa": {
             "locked": "2017.06"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -1189,12 +1020,6 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
-        },
-        "org.apache.hadoop:hadoop-common": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
-            ],
-            "locked": "2.7.7"
         },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.6"
@@ -1254,7 +1079,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable"
             ],
-            "locked": "1.7.10"
+            "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [

--- a/mantis-shaded/build.gradle
+++ b/mantis-shaded/build.gradle
@@ -26,7 +26,8 @@ apply plugin: 'com.github.johnrengelman.shadow'
  */
 ext {
     jacksonVersion = '2.12.+'
-    guavaVersion = '31.+'
+    guavaFailureAccessVersion = '1.0.1'
+    guavaVersion = '31.1-jre'
     curatorVersion = '2.12.+'
     zookeeperVersion = '3.4.+'
     jlineVersion = '0.9.94'
@@ -55,6 +56,7 @@ dependencies {
     shaded "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:$jacksonVersion"
     shaded libraries.vavrJackson
     shaded "com.google.guava:guava:$guavaVersion"
+    shaded "com.google.guava:failureaccess:$guavaFailureAccessVersion"
     shaded "org.apache.curator:curator-recipes:$curatorVersion"
     shaded "org.apache.curator:curator-framework:$curatorVersion"
     shaded "org.apache.curator:curator-client:$curatorVersion"

--- a/mantis-shaded/build.gradle
+++ b/mantis-shaded/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'com.github.johnrengelman.shadow'
  */
 ext {
     jacksonVersion = '2.12.+'
-    guavaVersion = '18.+'
+    guavaVersion = '31.+'
     curatorVersion = '2.12.+'
     zookeeperVersion = '3.4.+'
     jlineVersion = '0.9.94'

--- a/mantis-shaded/dependencies.lock
+++ b/mantis-shaded/dependencies.lock
@@ -49,8 +49,11 @@
         "com.fasterxml.jackson.module:jackson-module-afterburner": {
             "locked": "2.12.7"
         },
+        "com.google.guava:failureaccess": {
+            "locked": "1.0.1"
+        },
         "com.google.guava:guava": {
-            "locked": "18.0"
+            "locked": "31.1-jre"
         },
         "io.netty:netty": {
             "locked": "3.7.0.Final"

--- a/mantis-source-jobs/mantis-source-job-kafka/dependencies.lock
+++ b/mantis-source-jobs/mantis-source-job-kafka/dependencies.lock
@@ -9,13 +9,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -138,13 +138,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -275,13 +275,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -444,13 +444,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -576,13 +576,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [

--- a/mantis-source-jobs/mantis-source-job-publish/dependencies.lock
+++ b/mantis-source-jobs/mantis-source-job-publish/dependencies.lock
@@ -15,7 +15,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -124,15 +124,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -219,7 +219,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -328,15 +328,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -417,14 +417,14 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -436,14 +436,14 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -579,7 +579,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -587,13 +587,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -675,7 +675,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -784,15 +784,15 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -880,14 +880,14 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.17"
+            "locked": "2.3.18"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -899,14 +899,14 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "1.3.9"
+            "locked": "1.5.2"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -1042,7 +1042,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.0"
+            "locked": "2.12.2"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -1050,13 +1050,13 @@
             ],
             "locked": "1.0"
         },
-        "org.apache.flink:flink-rpc-akka": {
+        "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka-loader": {
+        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],


### PR DESCRIPTION
### Context

Bumping guava to a more recent version to use newer implementations. I need this PR to bump mantis-shaded which would tell me if there are any issues.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
