### PR TITLE
I am making close() implementation optional. 

### DIFF
--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/sink/Sink.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/sink/Sink.java
@@ -20,6 +20,7 @@ import io.mantisrx.runtime.Context;
 import io.mantisrx.runtime.PortRequest;
 import io.mantisrx.runtime.parameter.ParameterDefinition;
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import rx.Observable;
@@ -27,8 +28,14 @@ import rx.functions.Action3;
 
 public interface Sink<T> extends Action3<Context, PortRequest, Observable<T>>, Closeable {
 
-    default void init(Context context) {}
+    default void init(Context context) {
+    }
+
     default List<ParameterDefinition<?>> getParameters() {
         return Collections.emptyList();
+    }
+
+    @Override
+    default void close() throws IOException {
     }
 }

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/Source.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/Source.java
@@ -19,6 +19,7 @@ package io.mantisrx.runtime.source;
 import io.mantisrx.runtime.Context;
 import io.mantisrx.runtime.parameter.ParameterDefinition;
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import rx.Observable;
@@ -32,6 +33,9 @@ public interface Source<T> extends Func2<Context, Index, Observable<Observable<T
     }
 
     default void init(Context context, Index index) {
+    }
 
+    @Override
+    default void close() throws IOException {
     }
 }


### PR DESCRIPTION
### Context

Making close() implementation optional. The reason it's made optional is that we want users to migrate to Titus without any API changes. I will change this in the 3.0.0 release so that we can close sources and sinks appropriately.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
