### PR TITLE
Adding a new contructor for MantisClient

### DIFF
--- a/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
@@ -102,7 +102,16 @@ public class MantisClient {
             HighAvailabilityServicesUtil.createHAServices(
                 Configurations.frmProperties(properties, CoreConfiguration.class));
         clientWrapper = new MasterClientWrapper(haServices.getMasterClientApi());
-        this.disablePingFiltering = Boolean.valueOf(properties.getProperty(ENABLE_PINGS_KEY));
+        this.disablePingFiltering = Boolean.parseBoolean(properties.getProperty(ENABLE_PINGS_KEY));
+    }
+
+    public MantisClient(MasterClientWrapper clientWrapper, boolean disablePingFiltering) {
+        this.disablePingFiltering = disablePingFiltering;
+        this.clientWrapper = clientWrapper;
+    }
+
+    public MantisClient(MasterClientWrapper clientWrapper) {
+        this(clientWrapper, false);
     }
 
     public JobSinkLocator getSinkLocator() {


### PR DESCRIPTION
### Context

Need a constructor for MantisClient that allows one to supply the MantisClientWrapper.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
