### PR TITLE
[Minor] Fix npe in metrics collector

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerMetricsCollector.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/events/WorkerMetricsCollector.java
@@ -120,7 +120,11 @@ public class WorkerMetricsCollector extends AbstractScheduledService implements
             final WorkerId workerId = workerStatusEvent.getWorkerId();
             Preconditions.checkNotNull(jobWorkers.get(jobId));
             final IMantisWorkerMetadata metadata = jobWorkers.get(jobId).get(workerId);
-            Preconditions.checkNotNull(metadata);
+            if (metadata == null) {
+                log.warn("Unknown workerId: {} for metrics collector in job: {}", workerId, jobId);
+                return;
+            }
+
             final WorkerMetrics workerMetrics = getWorkerMetrics(
                 metadata.getCluster().orElse("unknown"));
 


### PR DESCRIPTION
### Context

Fix NPE error event reported from control plane when workerId is not available in metrics collector.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
