### PR TITLE
IcebergWriter uses table.io() to replace HadoopOutputFile

### DIFF
--- a/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/DefaultIcebergWriter.java
+++ b/mantis-connectors/mantis-connector-iceberg/src/main/java/io/mantisrx/connector/iceberg/sink/writer/DefaultIcebergWriter.java
@@ -30,7 +30,6 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
-import org.apache.iceberg.hadoop.HadoopOutputFile;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
@@ -108,7 +107,7 @@ public class DefaultIcebergWriter implements IcebergWriter {
         Path path = new Path(table.location(), generateFilename());
         String location = locationProvider.newDataLocation(path.toString());
         logger.info("opening new {} file appender {}", format, location);
-        file = HadoopOutputFile.fromLocation(location, config.getHadoopConfig());
+        file = table.io().newOutputFile(path.toString());
 
         switch (format) {
             case PARQUET:


### PR DESCRIPTION
### Context

Currently we use HadoopOutputFile interface to open data file to write. This limits the Iceberg data file has to use a Hadoop file system to open for write. As Iceberg FileIO is more flexible than that, we should use Iceberg native IO interface for opening files. For example, in Netflix set up, we use `S3FileIO` implementation to write to secure tables.

### Checklist

- [X] `./gradlew build` compiles code correctly
- [ ] ~Added new tests where applicable~
- [X] `./gradlew test` passes all tests
- [ ] ~Extended README or added javadocs where applicable~
