### PR TITLE
Fix metrics in non-mesos job

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/metrics/MetricsServer.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/metrics/MetricsServer.java
@@ -82,7 +82,7 @@ public class MetricsServer {
                                     for (Entry<MetricId, Gauge> gaugeEntry : metrics.gauges().entrySet()) {
                                         gauges.add(new GaugeMeasurement(gaugeEntry.getKey().metricName(), gaugeEntry.getValue().doubleValue()));
                                     }
-                                    measurements.add(new Measurements(metrics.getMetricGroupId().id(),
+                                    measurements.add(new Measurements(metrics.getMetricGroupId().name(),
                                             timestamp, counters, gauges, tags));
                                 }
                                 return Observable.from(measurements);

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
@@ -104,7 +104,9 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
         PublishSubject<WrappedExecuteStageRequest> executeStageSubject = PublishSubject.create();
 
         mantisServices.add(MetricsFactory.newMetricsServer(config, executeStageRequest));
-        mantisServices.add(MetricsFactory.newMetricsPublisher(config, executeStageRequest));
+
+        // [TODO:andyz] disable noOp publisher for now. Need to fix the full publisher injection.
+        // mantisServices.add(MetricsFactory.newMetricsPublisher(config, executeStageRequest));
         WorkerMetricsClient workerMetricsClient = new WorkerMetricsClient(masterMonitor);
 
         mantisServices.add(new ExecuteStageRequestService(


### PR DESCRIPTION
### Context

* MetricsServer uses metric group ID as measurement name, which doesn't work when common tags are set.

* In the non-Mesos job (task executor initiated jobs) the current metrics publisher is no-op but the metrics publisher instance created from CoreConfiguration causes loader trouble in the multi-loader (Titus + SB) case. I am disabling the no-op publisher for now and will follow up to see what the proper override/injection is for this case.


### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
