### PR TITLE
Schedule TE in min sku

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.resourcecluster;
+
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetClusterUsageRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssignmentRequest;
+import io.mantisrx.master.resourcecluster.proto.GetClusterIdleInstancesRequest;
+import io.mantisrx.master.resourcecluster.proto.GetClusterUsageResponse;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * A component to manage the states of {@link TaskExecutorState} for a given {@link ResourceClusterActor}.
+ */
+public interface ExecutorStateManager {
+    void putIfAbsent(TaskExecutorID taskExecutorID, TaskExecutorState state);
+    void markAvailable(TaskExecutorID taskExecutorID);
+    void markUnavailable(TaskExecutorID taskExecutorID);
+
+    @Nullable
+    TaskExecutorState get(TaskExecutorID taskExecutorID);
+
+    @Nullable
+    TaskExecutorState archive(TaskExecutorID taskExecutorID);
+
+    ResourceOverview getResourceOverview();
+
+    GetClusterUsageResponse getClusterUsage(GetClusterUsageRequest req);
+
+    List<TaskExecutorID> getIdleInstanceList(GetClusterIdleInstancesRequest req);
+
+    List<TaskExecutorID> getTaskExecutors(Predicate<Entry<TaskExecutorID, TaskExecutorState>> predicate);
+
+    List<String> getActiveJobs(GetActiveJobsRequest req);
+
+    Optional<Entry<TaskExecutorID, TaskExecutorState>> findFirst(
+        Predicate<Entry<TaskExecutorID, TaskExecutorState>> predicate);
+
+    /**
+     * Find a matched task executor best fitting the given assignment request.
+     * @param request Assignment request.
+     * @return Optional of matched task executor.
+     */
+    Optional<Pair<TaskExecutorID, TaskExecutorState>> findBestFit(TaskExecutorAssignmentRequest request);
+
+    Set<Entry<TaskExecutorID, TaskExecutorState>> getActiveExecutorEntry();
+
+    Predicate<Entry<TaskExecutorID, TaskExecutorState>> isRegistered =
+        e -> e.getValue().isRegistered();
+
+    Predicate<Entry<TaskExecutorID, TaskExecutorState>> isBusy =
+        e -> e.getValue().isRunningTask();
+
+    Predicate<Entry<TaskExecutorID, TaskExecutorState>> unregistered =
+        e -> e.getValue().isDisconnected();
+
+    Predicate<Entry<TaskExecutorID, TaskExecutorState>> isAvailable =
+        e -> e.getValue().isAvailable();
+
+    Predicate<Entry<TaskExecutorID, TaskExecutorState>> isDisabled =
+        e -> e.getValue().isDisabled();
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.resourcecluster;
+
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetClusterUsageRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssignmentRequest;
+import io.mantisrx.master.resourcecluster.proto.GetClusterIdleInstancesRequest;
+import io.mantisrx.master.resourcecluster.proto.GetClusterUsageResponse;
+import io.mantisrx.master.resourcecluster.proto.GetClusterUsageResponse.GetClusterUsageResponseBuilder;
+import io.mantisrx.master.resourcecluster.proto.GetClusterUsageResponse.UsageByGroupKey;
+import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
+import io.mantisrx.shaded.com.google.common.cache.Cache;
+import io.mantisrx.shaded.com.google.common.cache.CacheBuilder;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+
+@Slf4j
+public class ExecutorStateManagerImpl implements ExecutorStateManager{
+    private final Map<TaskExecutorID, TaskExecutorState> taskExecutorStateMap = new HashMap<>();
+
+    /**
+     * Cache the available executors ready to accept assignments. Note these executors' state are not strongly
+     * synchronized and requires state level check when matching.
+     */
+    private final SortedMap<Double, Set<TaskExecutorID>> executorByCores = new ConcurrentSkipListMap<>();
+
+    private final Cache<TaskExecutorID, TaskExecutorState> archivedState = CacheBuilder.newBuilder()
+        .maximumSize(10000)
+        .expireAfterWrite(24, TimeUnit.HOURS)
+        .removalListener(notification ->
+            log.info("Archived TaskExecutor: {} removed due to: {}", notification.getKey(), notification.getCause()))
+        .build();
+
+    @Override
+    public void putIfAbsent(TaskExecutorID taskExecutorID, TaskExecutorState state) {
+        this.taskExecutorStateMap.putIfAbsent(taskExecutorID, state);
+        if (this.archivedState.getIfPresent(taskExecutorID) != null) {
+            log.info("Reviving archived executor: {}", taskExecutorID);
+            this.archivedState.invalidate(taskExecutorID);
+        }
+
+        // add to buckets. however new executors won't have valid registration at this moment and requires marking
+        // again later when registration is ready.
+        if (state.isAvailable() && state.getRegistration() != null) {
+            log.info("Marking executor {} as available for matching.", taskExecutorID);
+            double cpuCores = state.getRegistration().getMachineDefinition().getCpuCores();
+            if (!this.executorByCores.containsKey(cpuCores)) {
+                this.executorByCores.putIfAbsent(cpuCores, new HashSet<>());
+            }
+
+            this.executorByCores.get(cpuCores).add(taskExecutorID);
+        }
+    }
+
+    @Override
+    public void markAvailable(TaskExecutorID taskExecutorID) {
+        if (!this.taskExecutorStateMap.containsKey(taskExecutorID)) {
+            log.warn("marking invalid executor as available: {}", taskExecutorID);
+            return;
+        }
+
+        TaskExecutorState taskExecutorState = this.taskExecutorStateMap.get(taskExecutorID);
+        if (taskExecutorState.getRegistration() == null) {
+            log.warn("marking invalid executor registration as available: {}", taskExecutorID);
+            return;
+        }
+
+        double cpuCores = taskExecutorState.getRegistration().getMachineDefinition().getCpuCores();
+        if (!this.executorByCores.containsKey(cpuCores)) {
+            this.executorByCores.putIfAbsent(cpuCores, new HashSet<>());
+        }
+
+        this.executorByCores.get(cpuCores).add(taskExecutorID);
+    }
+
+    @Override
+    public void markUnavailable(TaskExecutorID taskExecutorID) {
+        if (this.taskExecutorStateMap.containsKey(taskExecutorID)) {
+            TaskExecutorState taskExecutorState = this.taskExecutorStateMap.get(taskExecutorID);
+            if (taskExecutorState.getRegistration() != null) {
+                double cpuCores = taskExecutorState.getRegistration().getMachineDefinition().getCpuCores();
+                if (this.executorByCores.containsKey(cpuCores)) {
+                    this.executorByCores.get(cpuCores).remove(taskExecutorID);
+                }
+                return;
+            }
+        }
+
+        // todo: check archive map as well?
+        log.warn("invalid task executor to mark as unavailable: {}", taskExecutorID);
+    }
+
+    @Override
+    public ResourceOverview getResourceOverview() {
+        long numRegistered = taskExecutorStateMap.values().stream().filter(TaskExecutorState::isRegistered).count();
+        long numAvailable = taskExecutorStateMap.values().stream().filter(TaskExecutorState::isAvailable).count();
+        long numOccupied = taskExecutorStateMap.values().stream().filter(TaskExecutorState::isRunningTask).count();
+        long numAssigned = taskExecutorStateMap.values().stream().filter(TaskExecutorState::isAssigned).count();
+        long numDisabled = taskExecutorStateMap.values().stream().filter(TaskExecutorState::isDisabled).count();
+
+        return new ResourceOverview(numRegistered, numAvailable, numOccupied, numAssigned, numDisabled);
+    }
+
+    @Override
+    public List<TaskExecutorID> getIdleInstanceList(GetClusterIdleInstancesRequest req) {
+        return this.taskExecutorStateMap.entrySet().stream()
+            .filter(kv -> {
+                if (kv.getValue().getRegistration() == null) {
+                    return false;
+                }
+
+                Optional<ContainerSkuID> skuIdO =
+                    kv.getValue().getRegistration().getTaskExecutorContainerDefinitionId();
+                return skuIdO.isPresent() && skuIdO.get().equals(req.getSkuId());
+            })
+            .filter(isAvailable)
+            .map(Entry::getKey)
+            .limit(req.getMaxInstanceCount())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public TaskExecutorState get(TaskExecutorID taskExecutorID) {
+        if (this.taskExecutorStateMap.containsKey(taskExecutorID)) {
+            return this.taskExecutorStateMap.get(taskExecutorID);
+        }
+        return this.archivedState.getIfPresent(taskExecutorID);
+    }
+
+    @Override
+    public TaskExecutorState archive(TaskExecutorID taskExecutorID) {
+        if (this.taskExecutorStateMap.containsKey(taskExecutorID)) {
+            this.archivedState.put(taskExecutorID, this.taskExecutorStateMap.get(taskExecutorID));
+            this.taskExecutorStateMap.remove(taskExecutorID);
+            return this.archivedState.getIfPresent(taskExecutorID);
+        }
+        else {
+            log.warn("archiving invalid TaskExecutor: {}", taskExecutorID);
+            return null;
+        }
+    }
+
+    @Override
+    public List<TaskExecutorID> getTaskExecutors(Predicate<Entry<TaskExecutorID, TaskExecutorState>> predicate) {
+        return this.taskExecutorStateMap
+            .entrySet()
+            .stream()
+            .filter(predicate)
+            .map(Entry::getKey)
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> getActiveJobs(GetActiveJobsRequest req) {
+        return this.taskExecutorStateMap
+            .values()
+            .stream()
+            .map(TaskExecutorState::getWorkerId)
+            .filter(Objects::nonNull)
+            .map(WorkerId::getJobId)
+            .distinct()
+            .sorted((String::compareToIgnoreCase))
+            .skip(req.getStartingIndex().orElse(0))
+            .limit(req.getPageSize().orElse(3000))
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<Entry<TaskExecutorID, TaskExecutorState>> findFirst(
+        Predicate<Entry<TaskExecutorID, TaskExecutorState>> predicate) {
+        return taskExecutorStateMap
+            .entrySet()
+            .stream()
+            .filter(predicate)
+            .findFirst();
+    }
+
+    @Override
+    public Optional<Pair<TaskExecutorID, TaskExecutorState>> findBestFit(TaskExecutorAssignmentRequest request) {
+        for (Entry<Double, Set<TaskExecutorID>> entry :
+            this.executorByCores.tailMap(request.getMachineDefinition().getCpuCores()).entrySet()) {
+
+            Optional<TaskExecutorID> executorO = entry.getValue()
+                .stream()
+                .filter(tid -> {
+                    if (!this.taskExecutorStateMap.containsKey(tid)) {
+                        return false;
+                    }
+
+                    TaskExecutorState st = this.taskExecutorStateMap.get(tid);
+                    return st.isAvailable() &&
+                        st.getRegistration() != null &&
+                        st.getRegistration().getMachineDefinition().canFit(request.getMachineDefinition());
+                })
+                .findAny();
+
+            if (executorO.isPresent()) {
+                return Optional.of(Pair.of(executorO.get(), this.taskExecutorStateMap.get(executorO.get())));
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public Set<Entry<TaskExecutorID, TaskExecutorState>> getActiveExecutorEntry() {
+        return this.taskExecutorStateMap.entrySet();
+    }
+
+    @Override
+    public GetClusterUsageResponse getClusterUsage(GetClusterUsageRequest req) {
+        log.info("Computing cluster usage: {}", req.getClusterID());
+
+        // default grouping is containerSkuID to usage
+        Map<String, Pair<Integer, Integer>> usageByGroupKey = new HashMap<>();
+        taskExecutorStateMap.forEach((key, value) -> {
+            if (value == null ||
+                value.getRegistration() == null) {
+                log.info("Empty registration: {}, {}. Skip usage request.", req.getClusterID(), key);
+                return;
+            }
+
+            Optional<String> groupKeyO =
+                req.getGroupKeyFunc().apply(value.getRegistration());
+
+            if (!groupKeyO.isPresent()) {
+                log.info("Empty groupKey from: {}, {}. Skip usage request.", req.getClusterID(), key);
+                return;
+            }
+
+            String groupKey = groupKeyO.get();
+
+            Pair<Integer, Integer> kvState = Pair.of(
+                value.isAvailable() ? 1 : 0,
+                value.isRegistered() ? 1 : 0);
+
+            if (usageByGroupKey.containsKey(groupKey)) {
+                Pair<Integer, Integer> prevState = usageByGroupKey.get(groupKey);
+                usageByGroupKey.put(
+                    groupKey,
+                    Pair.of(
+                        kvState.getLeft() + prevState.getLeft(), kvState.getRight() + prevState.getRight()));
+            } else {
+                usageByGroupKey.put(groupKey, kvState);
+            }
+        });
+
+        GetClusterUsageResponseBuilder resBuilder = GetClusterUsageResponse.builder().clusterID(req.getClusterID());
+        usageByGroupKey.forEach((key, value) -> resBuilder.usage(UsageByGroupKey.builder()
+            .usageGroupKey(key)
+            .idleCount(value.getLeft())
+            .totalCount(value.getRight())
+            .build()));
+
+        GetClusterUsageResponse res = resBuilder.build();
+        log.info("Usage result: {}", res);
+        return res;
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.resourcecluster;
+
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.Assigned;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.AvailabilityState;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.Pending;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.Running;
+import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorHeartbeat;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorRegistration;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorReport;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorReport.Available;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorReport.Occupied;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorStatusChange;
+import io.mantisrx.server.master.scheduler.JobMessageRouter;
+import io.mantisrx.server.master.scheduler.WorkerOnDisabledVM;
+import io.mantisrx.server.worker.TaskExecutorGateway;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.runtime.rpc.RpcService;
+
+@SuppressWarnings("UnusedReturnValue")
+@AllArgsConstructor
+@Slf4j
+class TaskExecutorState {
+
+    enum RegistrationState {
+        Registered,
+        Unregistered,
+    }
+
+    private RegistrationState state;
+    @Nullable
+    private TaskExecutorRegistration registration;
+
+    @Nullable
+    private CompletableFuture<TaskExecutorGateway> gateway;
+
+    // availabilityState being null here represents that we don't know about the actual state of the task executor
+    // and are waiting for more information
+    @Nullable
+    private AvailabilityState availabilityState;
+    private boolean disabled;
+    // last interaction initiated by the task executor
+    private Instant lastActivity;
+    private final Clock clock;
+    private final RpcService rpcService;
+    private final JobMessageRouter jobMessageRouter;
+
+    static TaskExecutorState of(Clock clock, RpcService rpcService, JobMessageRouter jobMessageRouter) {
+        return new TaskExecutorState(
+            RegistrationState.Unregistered,
+            null,
+            null,
+            null,
+            false,
+            clock.instant(),
+            clock,
+            rpcService,
+            jobMessageRouter);
+    }
+
+    boolean isRegistered() {
+        return state == RegistrationState.Registered;
+    }
+
+    boolean isDisconnected() {
+        return !isRegistered();
+    }
+
+    boolean isDisabled() {
+        return disabled;
+    }
+
+    boolean onRegistration(TaskExecutorRegistration registration) {
+        if (state == RegistrationState.Registered) {
+            return false;
+        } else {
+            this.state = RegistrationState.Registered;
+            this.registration = registration;
+            this.gateway =
+                rpcService.connect(registration.getTaskExecutorAddress(), TaskExecutorGateway.class)
+                    .whenComplete((gateway, throwable) -> {
+                        if (throwable != null) {
+                            log.error("Failed to connect to the gateway", throwable);
+                        }
+                    });
+            updateTicker();
+            return true;
+        }
+    }
+
+    boolean onDisconnection() {
+        if (state == RegistrationState.Unregistered) {
+            return false;
+        } else {
+            state = RegistrationState.Unregistered;
+            registration = null;
+            setAvailabilityState(null);
+            gateway = null;
+            updateTicker();
+            return true;
+        }
+    }
+
+    private static AvailabilityState from(TaskExecutorReport report) {
+        if (report instanceof Available) {
+            return AvailabilityState.pending();
+        } else if (report instanceof Occupied) {
+            return AvailabilityState.running(((Occupied) report).getWorkerId());
+        } else {
+            throw new RuntimeException(String.format("TaskExecutorReport=%s was unexpected", report));
+        }
+    }
+
+    boolean onAssignment(WorkerId workerId) throws IllegalStateException {
+        if (!isRegistered()) {
+            throwNotRegistered(String.format("assignment to %s", workerId));
+        }
+
+        if (this.availabilityState == null) {
+            throw new IllegalStateException("availability state was null when unassignmentas was issued");
+        }
+
+        return setAvailabilityState(this.availabilityState.onAssignment(workerId));
+    }
+
+    boolean onUnassignment() throws IllegalStateException {
+        if (this.availabilityState == null) {
+            throw new IllegalStateException("availability state was null when unassignment was issued");
+        }
+
+        return setAvailabilityState(this.availabilityState.onUnassignment());
+    }
+
+    boolean onNodeDisabled() {
+        if (!this.disabled) {
+            this.disabled = true;
+            if (this.availabilityState instanceof Running) {
+                jobMessageRouter.routeWorkerEvent(new WorkerOnDisabledVM(this.availabilityState.getWorkerId()));
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    boolean onHeartbeat(TaskExecutorHeartbeat heartbeat) throws IllegalStateException {
+        if (!isRegistered()) {
+            throwNotRegistered(String.format("heartbeat %s", heartbeat));
+        }
+
+        boolean result = handleStatusChange(heartbeat.getTaskExecutorReport());
+        updateTicker();
+        return result;
+    }
+
+    boolean onTaskExecutorStatusChange(TaskExecutorStatusChange statusChange) {
+        if (!isRegistered()) {
+            throwNotRegistered(String.format("status change %s", statusChange));
+        }
+
+        boolean result = handleStatusChange(statusChange.getTaskExecutorReport());
+        updateTicker();
+        return result;
+    }
+
+    private boolean handleStatusChange(TaskExecutorReport report) throws IllegalStateException {
+        if (availabilityState == null) {
+            return setAvailabilityState(from(report));
+        } else {
+            return setAvailabilityState(availabilityState.onTaskExecutorStatusChange(report));
+        }
+    }
+
+    private boolean setAvailabilityState(AvailabilityState newState) {
+        if (this.availabilityState != newState) {
+            this.availabilityState = newState;
+            if (this.availabilityState instanceof Running) {
+                if (isDisabled()) {
+                    jobMessageRouter.routeWorkerEvent(new WorkerOnDisabledVM(newState.getWorkerId()));
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    @Nullable
+    protected WorkerId getWorkerId() {
+        if (this.availabilityState != null) {
+            return this.availabilityState.getWorkerId();
+        } else {
+            return null;
+        }
+    }
+
+    private void throwNotRegistered(String message) throws IllegalStateException {
+        throw new IllegalStateException(
+            String.format("Task Executor un-registered when it received %s", message));
+    }
+
+    private void updateTicker() {
+        this.lastActivity = clock.instant();
+    }
+
+    boolean isAvailable() {
+        return this.availabilityState instanceof Pending && !isDisabled();
+    }
+
+    boolean isRunningTask() {
+        return this.availabilityState instanceof Running;
+    }
+
+    boolean isAssigned() {
+        return this.availabilityState instanceof Assigned;
+    }
+
+    boolean isRunningOrAssigned(WorkerId workerId) {
+        return this.getWorkerId() != null && this.getWorkerId().equals(workerId);
+    }
+
+    // Captures the last interaction from the task executor. Any interactions
+    // that are caused from within the server do not cause an uptick.
+    Instant getLastActivity() {
+        return this.lastActivity;
+    }
+
+    TaskExecutorRegistration getRegistration() {
+        return this.registration;
+    }
+
+    protected CompletableFuture<TaskExecutorGateway> getGateway() {
+        return this.gateway;
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.resourcecluster;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import io.mantisrx.common.WorkerPorts;
+import io.mantisrx.common.util.DelegateClock;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssignmentRequest;
+import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.server.core.TestingRpcService;
+import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorRegistration;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorReport;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorStatusChange;
+import io.mantisrx.server.master.scheduler.JobMessageRouter;
+import io.mantisrx.server.worker.TaskExecutorGateway;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableList;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExecutorStateManagerTests {
+    private final AtomicReference<Clock> actual =
+        new AtomicReference<>(Clock.fixed(Instant.ofEpochSecond(1), ZoneId.systemDefault()));
+    private final Clock clock = new DelegateClock(actual);
+
+    private final TestingRpcService rpc = new TestingRpcService();
+    private final TaskExecutorGateway gateway = mock(TaskExecutorGateway.class);
+    private final JobMessageRouter router = mock(JobMessageRouter.class);
+    private final TaskExecutorState state1 = TaskExecutorState.of(clock, rpc, router);
+    private final TaskExecutorState state2 = TaskExecutorState.of(clock, rpc, router);
+
+    private final TaskExecutorState state3 = TaskExecutorState.of(clock, rpc, router);
+
+
+    private static final ClusterID CLUSTER_ID = ClusterID.of("clusterId");
+    private static final TaskExecutorID TASK_EXECUTOR_ID_1 = TaskExecutorID.of("taskExecutorId1");
+
+    private static final TaskExecutorID TASK_EXECUTOR_ID_2 = TaskExecutorID.of("taskExecutorId2");
+    private static final TaskExecutorID TASK_EXECUTOR_ID_3 = TaskExecutorID.of("taskExecutorId3");
+
+
+    private static final String TASK_EXECUTOR_ADDRESS = "127.0.0.1";
+    private static final String HOST_NAME = "hostName";
+    private static final WorkerPorts WORKER_PORTS = new WorkerPorts(ImmutableList.of(1, 2, 3, 4, 5));
+    private static final MachineDefinition MACHINE_DEFINITION_1 =
+        new MachineDefinition(1.0, 2.0, 3.0, 4.0, 5);
+
+    private static final MachineDefinition MACHINE_DEFINITION_2 =
+        new MachineDefinition(4.0, 2.0, 3.0, 4.0, 5);
+    private static final Map<String, String> ATTRIBUTES =
+        ImmutableMap.of("attr1", "attr2");
+    private static final WorkerId WORKER_ID = WorkerId.fromIdUnsafe("late-sine-function-tutorial-1-worker-0-1");
+
+    private final TaskExecutorRegistration registration1 = TaskExecutorRegistration.builder()
+        .taskExecutorID(TASK_EXECUTOR_ID_1)
+                .clusterID(CLUSTER_ID)
+                .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+                .hostname(HOST_NAME)
+                .workerPorts(WORKER_PORTS)
+                .machineDefinition(MACHINE_DEFINITION_1)
+                .taskExecutorAttributes(ATTRIBUTES)
+                .build();
+
+    private final TaskExecutorRegistration registration2 = TaskExecutorRegistration.builder()
+        .taskExecutorID(TASK_EXECUTOR_ID_2)
+        .clusterID(CLUSTER_ID)
+        .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+        .hostname(HOST_NAME)
+        .workerPorts(WORKER_PORTS)
+        .machineDefinition(MACHINE_DEFINITION_2)
+        .taskExecutorAttributes(ATTRIBUTES)
+        .build();
+
+    private final TaskExecutorRegistration registration3 = TaskExecutorRegistration.builder()
+        .taskExecutorID(TASK_EXECUTOR_ID_3)
+        .clusterID(CLUSTER_ID)
+        .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+        .hostname(HOST_NAME)
+        .workerPorts(WORKER_PORTS)
+        .machineDefinition(MACHINE_DEFINITION_2)
+        .taskExecutorAttributes(ATTRIBUTES)
+        .build();
+
+    private final ExecutorStateManager stateManager = new ExecutorStateManagerImpl();
+
+    @Before
+    public void setup() {
+        rpc.registerGateway(TASK_EXECUTOR_ADDRESS, gateway);
+    }
+
+    @Test
+    public void testGetBestFit() {
+        Optional<Pair<TaskExecutorID, TaskExecutorState>> bestFitO =
+            stateManager.findBestFit(new TaskExecutorAssignmentRequest(MACHINE_DEFINITION_2, WORKER_ID, CLUSTER_ID));
+
+        assertFalse(bestFitO.isPresent());
+
+        stateManager.putIfAbsent(TASK_EXECUTOR_ID_1, state1);
+        state1.onRegistration(registration1);
+        state1.onTaskExecutorStatusChange(new TaskExecutorStatusChange(TASK_EXECUTOR_ID_1, CLUSTER_ID,
+            TaskExecutorReport.available()));
+        stateManager.markAvailable(TASK_EXECUTOR_ID_1);
+
+        stateManager.putIfAbsent(TASK_EXECUTOR_ID_2, state2);
+        state2.onRegistration(registration2);
+        state2.onTaskExecutorStatusChange(new TaskExecutorStatusChange(TASK_EXECUTOR_ID_2, CLUSTER_ID,
+            TaskExecutorReport.available()));
+        stateManager.markAvailable(TASK_EXECUTOR_ID_2);
+
+        stateManager.putIfAbsent(TASK_EXECUTOR_ID_3, state3);
+        state3.onRegistration(registration3);
+        stateManager.markAvailable(TASK_EXECUTOR_ID_3);
+
+        // test machine def 1
+        bestFitO =
+            stateManager.findBestFit(new TaskExecutorAssignmentRequest(MACHINE_DEFINITION_1, WORKER_ID, CLUSTER_ID));
+        assertTrue(bestFitO.isPresent());
+        assertEquals(TASK_EXECUTOR_ID_1, bestFitO.get().getLeft());
+        assertEquals(state1, bestFitO.get().getRight());
+
+        bestFitO =
+            stateManager.findBestFit(new TaskExecutorAssignmentRequest(MACHINE_DEFINITION_2, WORKER_ID, CLUSTER_ID));
+
+        assertTrue(bestFitO.isPresent());
+        assertEquals(TASK_EXECUTOR_ID_2, bestFitO.get().getLeft());
+        assertEquals(state2, bestFitO.get().getRight());
+
+        // enable e3 and disable e2
+        state3.onTaskExecutorStatusChange(new TaskExecutorStatusChange(TASK_EXECUTOR_ID_3, CLUSTER_ID,
+            TaskExecutorReport.available()));
+        state2.onTaskExecutorStatusChange(new TaskExecutorStatusChange(TASK_EXECUTOR_ID_2, CLUSTER_ID,
+            TaskExecutorReport.occupied(WORKER_ID)));
+
+        bestFitO =
+            stateManager.findBestFit(new TaskExecutorAssignmentRequest(MACHINE_DEFINITION_2, WORKER_ID, CLUSTER_ID));
+
+        assertTrue(bestFitO.isPresent());
+        assertEquals(TASK_EXECUTOR_ID_3, bestFitO.get().getLeft());
+        assertEquals(state3, bestFitO.get().getRight());
+
+        // test mark as unavailable
+        stateManager.markUnavailable(TASK_EXECUTOR_ID_3);
+        bestFitO =
+            stateManager.findBestFit(new TaskExecutorAssignmentRequest(MACHINE_DEFINITION_2, WORKER_ID, CLUSTER_ID));
+
+        assertFalse(bestFitO.isPresent());
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorStateTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.mock;
 
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.common.util.DelegateClock;
-import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorState;
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.server.core.TestingRpcService;
 import io.mantisrx.server.core.domain.WorkerId;


### PR DESCRIPTION
### Context

Currently, the TE allocation is greedy and uses the first TE with a machine size big enough for the request. Switching the allocation logic to use the min size available for the request instead.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
