### PR TITLE
[Not to be merged] PR to demonstrate build success for #304

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ ext.libraries = [
                 "org.junit.jupiter:junit-jupiter-engine:${versions.junit5}",
                 "org.junit.jupiter:junit-jupiter-params:${versions.junit5}",
         ],
-        mantisShaded   : "io.mantisrx:mantis-shaded:2.0.0",
+        mantisShaded   : "io.mantisrx:mantis-shaded:0.1.0-20230127.001534-71",
         mockitoAll     : "org.mockito:mockito-all:${versions.mockito}",
         mockitoCore    : "org.mockito:mockito-core:${versions.mockito}",
         mockitoCore3   : "org.mockito:mockito-core:${versions.mockito3}",
@@ -133,6 +133,9 @@ subprojects {
         mavenCentral()
         maven {
             url "https://netflixoss.jfrog.io/artifactory/maven-oss-candidates"
+        }
+        maven {
+            url "https://artifacts-oss.netflix.net/artifactory/maven-oss-snapshots"
         }
     }
 


### PR DESCRIPTION
### Context

#304 bumps guava to 31.+ for mantis-shaded. This PR demonstrates a successful build using updated guava.
I verified that guava is actually bumped to 31 in the indexed packages and is present in [this build scan](https://scans.gradle.com/s/u6rpuiics2zv6/dependencies?dependencies=guava&expandAll&focusedDependency=WzI5LDAsMTQsWzE1LDAsWzY0XV1d&focusedDependencyView=versions) 

Note again, that this PR isn't intended to be merged.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
