### PR TITLE
Refactor RuntimeTask Dependencies

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -87,6 +87,10 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("1000")
     long getMasterApiAskTimeoutMs();
 
+    @Config("mantis.master.api.route.ask.longOperation.timeout.millis")
+    @Default("2500")
+    long getMasterApiLongOperationAskTimeoutMs();
+
     @Config("mesos.master.location")
     @Default("localhost:5050")
     String getMasterLocation();

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/RuntimeTask.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/RuntimeTask.java
@@ -16,25 +16,21 @@
 
 package io.mantisrx.runtime.loader;
 
-import io.mantisrx.runtime.loader.SinkSubscriptionStateHandler.Factory;
-import io.mantisrx.runtime.loader.config.WorkerConfiguration;
-import io.mantisrx.server.core.Status;
-import io.mantisrx.server.core.WrappedExecuteStageRequest;
-import io.mantisrx.server.core.domain.WorkerId;
-import io.mantisrx.server.master.client.MantisMasterGateway;
 import io.mantisrx.shaded.com.google.common.util.concurrent.Service;
 import org.apache.flink.util.UserCodeClassLoader;
-import rx.Observable;
 
+/**
+ * Interface to load core runtime work load from external host (mesos or TaskExecutor).
+ * [Note] To avoid dependency conflicts in TaskExecutors running in custom structure
+ * e.g. SpringBoot based runtime, adding dependency here shall be carefully reviewed.
+ * Do not have any shared Mantis library that will be used on both TaskExecutor and implementations of
+ * RuntimeTask in here and use primitive types in general.
+ */
 public interface RuntimeTask extends Service {
+    void initialize(
+        String executeStageRequestString,
+        String workerConfigurationString,
+        UserCodeClassLoader userCodeClassLoader);
 
-    void initialize(WrappedExecuteStageRequest request,
-                    WorkerConfiguration config,
-                    MantisMasterGateway masterMonitor,
-                    UserCodeClassLoader userCodeClassLoader,
-                    Factory sinkSubscriptionStateHandlerFactory);
-
-    Observable<Status> getStatus();
-
-    WorkerId getWorkerId();
+    String getWorkerId();
 }

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
@@ -17,6 +17,7 @@
 package io.mantisrx.runtime.loader.config;
 
 import io.mantisrx.server.core.CoreConfiguration;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnore;
 import io.mantisrx.shaded.com.google.common.base.Splitter;
 import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import java.io.File;
@@ -134,6 +135,7 @@ public interface WorkerConfiguration extends CoreConfiguration {
     @Default(value = "")
     String taskExecutorAttributes();
 
+    @JsonIgnore
     default Map<String, String> getTaskExecutorAttributes() {
         String input = taskExecutorAttributes();
         if (input == null || input.isEmpty()) {

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
@@ -48,6 +48,7 @@ public class WorkerConfigurationUtils {
             .isLocalMode(configSource.isLocalMode())
             .leaderAnnouncementPath(configSource.getLeaderAnnouncementPath())
             .localStorageDir(configSource.getLocalStorageDir())
+            .mesosSlavePort(configSource.getMesosSlavePort())
             .metricsCollector(configSource.getUsageSupplier())
             .metricsPort(configSource.getMetricsPort())
             .metricsPublisher(configSource.getMetricsPublisher())

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
@@ -16,8 +16,10 @@
 
 package io.mantisrx.runtime.loader.config;
 
+import io.mantisrx.common.JsonSerializer;
 import io.mantisrx.server.core.MetricsCoercer;
 import io.mantisrx.server.master.client.config.PluginCoercible;
+import java.io.IOException;
 import java.util.Properties;
 import org.skife.config.ConfigurationObjectFactory;
 
@@ -28,5 +30,42 @@ public class WorkerConfigurationUtils {
         configurationObjectFactory.addCoercible(new MetricsCoercer(properties));
         configurationObjectFactory.addCoercible(new PluginCoercible<>(MetricsCollector.class, properties));
         return configurationObjectFactory.build(tClass);
+    }
+
+    public static <T extends WorkerConfiguration> WorkerConfigurationWritable toWritable(T configSource) {
+        return WorkerConfigurationWritable.builder()
+            .bindAddress(configSource.getBindAddress())
+            .bindPort(configSource.getBindPort())
+            .blobStoreArtifactDir(configSource.getBlobStoreArtifactDir())
+            .consolePort(configSource.getConsolePort())
+            .clusterId(configSource.getClusterId())
+            .customPort(configSource.getCustomPort())
+            .debugPort(configSource.getDebugPort())
+            .externalAddress(configSource.getExternalAddress())
+            .externalPortRange(configSource.getExternalPortRange())
+            .heartbeatInternalInMs(configSource.heartbeatInternalInMs())
+            .heartbeatTimeoutMs(configSource.heartbeatTimeoutMs())
+            .isLocalMode(configSource.isLocalMode())
+            .leaderAnnouncementPath(configSource.getLeaderAnnouncementPath())
+            .localStorageDir(configSource.getLocalStorageDir())
+            .metricsCollector(configSource.getUsageSupplier())
+            .metricsPort(configSource.getMetricsPort())
+            .metricsPublisher(configSource.getMetricsPublisher())
+            .metricsPublisherFrequencyInSeconds(configSource.getMetricsPublisherFrequencyInSeconds())
+            .networkBandwidthInMB(configSource.getNetworkBandwidthInMB())
+            .sinkPort(configSource.getSinkPort())
+            .taskExecutorId(configSource.getTaskExecutorId())
+            .taskExecutorAttributesStr(configSource.taskExecutorAttributes())
+            .zkConnectionMaxRetries(configSource.getZkConnectionMaxRetries())
+            .zkConnectionTimeoutMs(configSource.getZkConnectionTimeoutMs())
+            .zkConnectionString(configSource.getZkConnectionString())
+            .zkConnectionRetrySleepMs(configSource.getZkConnectionRetrySleepMs())
+            .zkRoot(configSource.getZkRoot())
+            .build();
+    }
+
+    public static WorkerConfigurationWritable stringToWorkerConfiguration(String sourceStr) throws IOException {
+        JsonSerializer ser = new JsonSerializer();
+        return ser.fromJSON(sourceStr, WorkerConfigurationWritable.class);
     }
 }

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.runtime.loader.config;
+
+import io.mantisrx.common.metrics.MetricsPublisher;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.File;
+import java.net.URI;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * This is a workaround solution to bridge the worker configuration to a serializable format between worker process
+ * entry and RuntimeTask implementations.
+ */
+@Data
+@Builder
+public class WorkerConfigurationWritable implements WorkerConfiguration {
+
+    int zkConnectionTimeoutMs;
+    int zkConnectionRetrySleepMs;
+    int zkConnectionMaxRetries;
+    String zkConnectionString;
+    String leaderAnnouncementPath;
+    String zkRoot;
+    boolean isLocalMode;
+    int metricsPublisherFrequencyInSeconds;
+    String taskExecutorId;
+
+    String clusterId;
+
+    int metricsPort;
+    int debugPort;
+    int consolePort;
+    int customPort;
+    int sinkPort;
+    int heartbeatInternalInMs;
+    int tolerableConsecutiveHeartbeatFailures;
+    int heartbeatTimeoutMs;
+    String externalAddress;
+    String externalPortRange;
+    String bindAddress;
+    Integer bindPort;
+
+    URI blobStoreArtifactDir;
+    File localStorageDir;
+    double networkBandwidthInMB;
+    String taskExecutorAttributesStr;
+
+    @JsonIgnore
+    MetricsPublisher metricsPublisher;
+
+    @JsonIgnore
+    MetricsCollector metricsCollector;
+
+    @Override
+    public int getZkConnectionTimeoutMs() {
+        return this.zkConnectionTimeoutMs;
+    }
+
+    @Override
+    public int getZkConnectionRetrySleepMs() {
+        return this.zkConnectionRetrySleepMs;
+    }
+
+    @Override
+    public int getZkConnectionMaxRetries() {
+        return this.zkConnectionMaxRetries;
+    }
+
+    @Override
+    public String getZkConnectionString() {
+        return this.zkConnectionString;
+    }
+
+    @Override
+    public String getLeaderAnnouncementPath() {
+        return this.leaderAnnouncementPath;
+    }
+
+    @Override
+    public String getZkRoot() {
+        return this.zkRoot;
+    }
+
+    @Override
+    public boolean isLocalMode() {
+        return this.isLocalMode;
+    }
+
+    @Override
+    public MetricsPublisher getMetricsPublisher() {
+        return this.metricsPublisher;
+    }
+
+    @Override
+    public int getMetricsPublisherFrequencyInSeconds() {
+        return this.metricsPublisherFrequencyInSeconds;
+    }
+
+    @Override
+    public int getMesosSlavePort() {
+        return -1; // deprecated mesos fields
+    }
+
+    @Override
+    public String getTaskExecutorId() {
+        return this.taskExecutorId;
+    }
+
+    @Override
+    public String getClusterId() {
+        return this.clusterId;
+    }
+
+    @Override
+    public int getMetricsPort() {
+        return this.metricsPort;
+    }
+
+    @Override
+    public int getDebugPort() {
+        return this.debugPort;
+    }
+
+    @Override
+    public int getConsolePort() {
+        return this.consolePort;
+    }
+
+    @Override
+    public int getCustomPort() {
+        return this.customPort;
+    }
+
+    @Override
+    public int getSinkPort() {
+        return this.sinkPort;
+    }
+
+    @Override
+    public int heartbeatInternalInMs() {
+        return this.heartbeatInternalInMs;
+    }
+
+    @Override
+    public int getTolerableConsecutiveHeartbeatFailures() {
+        return this.tolerableConsecutiveHeartbeatFailures;
+    }
+
+    @Override
+    public int heartbeatTimeoutMs() {
+        return this.heartbeatTimeoutMs;
+    }
+
+    @Override
+    public String getExternalAddress() {
+        return this.externalAddress;
+    }
+
+    @Override
+    public String getExternalPortRange() {
+        return this.externalPortRange;
+    }
+
+    @Override
+    public String getBindAddress() {
+        return this.bindAddress;
+    }
+
+    @Override
+    public Integer getBindPort() {
+        return this.bindPort;
+    }
+
+    @Override
+    public MetricsCollector getUsageSupplier() {
+        return this.metricsCollector;
+    }
+
+    @Override
+    public URI getBlobStoreArtifactDir() {
+        return this.blobStoreArtifactDir;
+    }
+
+    @Override
+    public File getLocalStorageDir() {
+        return this.localStorageDir;
+    }
+
+    @Override
+    public double getNetworkBandwidthInMB() {
+        return this.networkBandwidthInMB;
+    }
+
+    @Override
+    public String taskExecutorAttributes() {
+        return this.taskExecutorAttributesStr;
+    }
+}

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
@@ -31,6 +31,7 @@ import lombok.Data;
 @Builder
 public class WorkerConfigurationWritable implements WorkerConfiguration {
 
+    int mesosSlavePort;
     int zkConnectionTimeoutMs;
     int zkConnectionRetrySleepMs;
     int zkConnectionMaxRetries;
@@ -114,7 +115,7 @@ public class WorkerConfigurationWritable implements WorkerConfiguration {
 
     @Override
     public int getMesosSlavePort() {
-        return -1; // deprecated mesos fields
+        return this.mesosSlavePort;
     }
 
     @Override

--- a/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/WorkerConfigurationWritableTest.java
+++ b/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/WorkerConfigurationWritableTest.java
@@ -18,6 +18,7 @@ package io.mantisrx.server.agent;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import io.mantisrx.common.JsonSerializer;
 import io.mantisrx.runtime.loader.config.WorkerConfiguration;
@@ -56,6 +57,7 @@ public class WorkerConfigurationWritableTest {
         assertEquals("testId1", configurationWritable.getTaskExecutorId());
         assertEquals(999, configurationWritable.getHeartbeatInternalInMs());
         assertEquals(998, configurationWritable.getMesosSlavePort());
+        assertNotNull(configurationWritable.getUsageSupplier());
 
         String configStr = ConfigWritableToString(configurationWritable);
         WorkerConfigurationWritable configurationWritable2 =
@@ -64,5 +66,6 @@ public class WorkerConfigurationWritableTest {
         assertEquals("testId1", configurationWritable2.getTaskExecutorId());
         assertEquals(999, configurationWritable2.getHeartbeatInternalInMs());
         assertEquals(998, configurationWritable2.getMesosSlavePort());
+        assertNull(configurationWritable2.getUsageSupplier());
     }
 }

--- a/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/WorkerConfigurationWritableTest.java
+++ b/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/WorkerConfigurationWritableTest.java
@@ -47,6 +47,7 @@ public class WorkerConfigurationWritableTest {
 
         props.setProperty("mantis.taskexecutor.id", "testId1");
         props.setProperty("mantis.taskexecutor.heartbeats.interval", "999");
+        props.setProperty("mantis.agent.mesos.slave.port", "998");
 
         WorkerConfiguration configSource = new StaticPropertiesConfigurationFactory(props).getConfig();
 
@@ -54,6 +55,7 @@ public class WorkerConfigurationWritableTest {
         assertNotNull(configurationWritable);
         assertEquals("testId1", configurationWritable.getTaskExecutorId());
         assertEquals(999, configurationWritable.getHeartbeatInternalInMs());
+        assertEquals(998, configurationWritable.getMesosSlavePort());
 
         String configStr = ConfigWritableToString(configurationWritable);
         WorkerConfigurationWritable configurationWritable2 =
@@ -61,5 +63,6 @@ public class WorkerConfigurationWritableTest {
         assertNotNull(configurationWritable);
         assertEquals("testId1", configurationWritable2.getTaskExecutorId());
         assertEquals(999, configurationWritable2.getHeartbeatInternalInMs());
+        assertEquals(998, configurationWritable2.getMesosSlavePort());
     }
 }

--- a/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/WorkerConfigurationWritableTest.java
+++ b/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/WorkerConfigurationWritableTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.agent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.mantisrx.common.JsonSerializer;
+import io.mantisrx.runtime.loader.config.WorkerConfiguration;
+import io.mantisrx.runtime.loader.config.WorkerConfigurationUtils;
+import io.mantisrx.runtime.loader.config.WorkerConfigurationWritable;
+import io.mantisrx.server.worker.config.StaticPropertiesConfigurationFactory;
+import java.io.IOException;
+import java.util.Properties;
+import org.junit.Test;
+
+public class WorkerConfigurationWritableTest {
+    static String ConfigWritableToString(WorkerConfigurationWritable configurationWritable) throws IOException {
+        JsonSerializer ser = new JsonSerializer();
+        return ser.toJson(configurationWritable);
+    }
+
+    @Test
+    public void testWorkerConfigurationConversion() throws IOException {
+        final Properties props = new Properties();
+        props.setProperty("mantis.zookeeper.root", "");
+
+        props.setProperty("mantis.taskexecutor.cluster.storage-dir", "");
+        props.setProperty("mantis.taskexecutor.local.storage-dir", "");
+        props.setProperty("mantis.taskexecutor.cluster-id", "default");
+        props.setProperty("mantis.taskexecutor.heartbeats.interval", "100");
+        props.setProperty("mantis.taskexecutor.metrics.collector", "io.mantisrx.server.agent.DummyMetricsCollector");
+
+        props.setProperty("mantis.taskexecutor.id", "testId1");
+        props.setProperty("mantis.taskexecutor.heartbeats.interval", "999");
+
+        WorkerConfiguration configSource = new StaticPropertiesConfigurationFactory(props).getConfig();
+
+        WorkerConfigurationWritable configurationWritable = WorkerConfigurationUtils.toWritable(configSource);
+        assertNotNull(configurationWritable);
+        assertEquals("testId1", configurationWritable.getTaskExecutorId());
+        assertEquals(999, configurationWritable.getHeartbeatInternalInMs());
+
+        String configStr = ConfigWritableToString(configurationWritable);
+        WorkerConfigurationWritable configurationWritable2 =
+            WorkerConfigurationUtils.stringToWorkerConfiguration(configStr);
+        assertNotNull(configurationWritable);
+        assertEquals("testId1", configurationWritable2.getTaskExecutorId());
+        assertEquals(999, configurationWritable2.getHeartbeatInternalInMs());
+    }
+}

--- a/mantis-server/mantis-server-worker/build.gradle
+++ b/mantis-server/mantis-server-worker/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     api project(":mantis-runtime")
     api project(":mantis-runtime-loader")
     api project(":mantis-server:mantis-server-worker-client")
+    api project(":mantis-server:mantis-server-agent")
 
     implementation "org.apache.mesos:mesos:$mesosVersion"
     implementation libraries.slf4jApi

--- a/mantis-server/mantis-server-worker/dependencies.lock
+++ b/mantis-server/mantis-server-worker/dependencies.lock
@@ -248,12 +248,21 @@
             "project": true
         },
         "io.mantisrx:mantis-runtime-loader": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "project": true
         },
         "io.mantisrx:mantis-rxcontrol": {
             "locked": "1.3.20"
         },
+        "io.mantisrx:mantis-server-agent": {
+            "project": true
+        },
         "io.mantisrx:mantis-server-worker-client": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "project": true
         },
         "io.mantisrx:mantis-shaded": {
@@ -408,7 +417,8 @@
         },
         "com.spotify:completable-futures": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
+                "io.mantisrx:mantis-control-plane-client",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "0.3.1"
         },
@@ -417,7 +427,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "2.11.0"
         },
@@ -467,12 +478,21 @@
             "project": true
         },
         "io.mantisrx:mantis-runtime-loader": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "project": true
         },
         "io.mantisrx:mantis-rxcontrol": {
             "locked": "1.3.20"
         },
+        "io.mantisrx:mantis-server-agent": {
+            "project": true
+        },
         "io.mantisrx:mantis-server-worker-client": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "project": true
         },
         "io.mantisrx:mantis-shaded": {
@@ -521,6 +541,7 @@
         },
         "io.vavr:vavr": {
             "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent",
                 "io.mantisrx:mantis-shaded"
             ],
             "locked": "0.9.2"
@@ -536,6 +557,12 @@
                 "io.mantisrx:mantis-common"
             ],
             "locked": "1.0"
+        },
+        "net.lingala.zip4j:zip4j": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
+            "locked": "2.9.0"
         },
         "nz.ac.waikato.cms.moa:moa": {
             "locked": "2017.06"
@@ -557,6 +584,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
+        },
+        "org.apache.hadoop:hadoop-common": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
+            "locked": "2.7.7"
         },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.6"
@@ -601,14 +634,16 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable",
-                "io.mantisrx:mantis-runtime"
+                "io.mantisrx:mantis-runtime",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-remote-observable"
+                "io.mantisrx:mantis-remote-observable",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "1.7.0"
         },
@@ -690,12 +725,21 @@
             "project": true
         },
         "io.mantisrx:mantis-runtime-loader": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "project": true
         },
         "io.mantisrx:mantis-rxcontrol": {
             "locked": "1.3.20"
         },
+        "io.mantisrx:mantis-server-agent": {
+            "project": true
+        },
         "io.mantisrx:mantis-server-worker-client": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "project": true
         },
         "io.mantisrx:mantis-shaded": {
@@ -860,7 +904,8 @@
         },
         "com.spotify:completable-futures": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
+                "io.mantisrx:mantis-control-plane-client",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "0.3.1"
         },
@@ -869,7 +914,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "2.11.0"
         },
@@ -921,12 +967,21 @@
             "project": true
         },
         "io.mantisrx:mantis-runtime-loader": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "project": true
         },
         "io.mantisrx:mantis-rxcontrol": {
             "locked": "1.3.20"
         },
+        "io.mantisrx:mantis-server-agent": {
+            "project": true
+        },
         "io.mantisrx:mantis-server-worker-client": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "project": true
         },
         "io.mantisrx:mantis-shaded": {
@@ -975,6 +1030,7 @@
         },
         "io.vavr:vavr": {
             "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent",
                 "io.mantisrx:mantis-shaded"
             ],
             "locked": "0.9.2"
@@ -1000,6 +1056,12 @@
             ],
             "locked": "1.0"
         },
+        "net.lingala.zip4j:zip4j": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
+            "locked": "2.9.0"
+        },
         "nz.ac.waikato.cms.moa:moa": {
             "locked": "2017.06"
         },
@@ -1020,6 +1082,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.14.2"
+        },
+        "org.apache.hadoop:hadoop-common": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
+            "locked": "2.7.7"
         },
         "org.apache.httpcomponents:httpclient": {
             "locked": "4.5.6"
@@ -1070,14 +1138,16 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable",
-                "io.mantisrx:mantis-runtime"
+                "io.mantisrx:mantis-runtime",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
-                "io.mantisrx:mantis-remote-observable"
+                "io.mantisrx:mantis-remote-observable",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "1.7.0"
         },

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
@@ -138,7 +138,9 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
     protected void startUp() throws Exception {
         try {
             log.info("Starting current task {}", this);
-            this.highAvailabilityServices.startAsync().awaitRunning();
+            if (!this.highAvailabilityServices.isRunning()) {
+                this.highAvailabilityServices.startAsync().awaitRunning();
+            }
             doRun();
         } catch (Exception e) {
             log.error("Failed executing the task {}", executeStageRequest, e);

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
@@ -105,7 +105,7 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
             // todo: temp workaournd to pick host metrics collector.
             if (Strings.isNullOrEmpty(this.config.getTaskExecutorId())) {
                 log.info("Picking mesos metrics collector.");
-                configWritable.setMetricsCollector(MesosMetricsCollector.valueOf(System.getProperties()));
+                configWritable.setMetricsCollector(MesosMetricsCollector.valueOf(this.config));
             }
             else {
                 log.info("Picking Cgroups metrics collector.");

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
@@ -15,20 +15,30 @@
  */
 package io.mantisrx.server.worker;
 
+import io.mantisrx.common.JsonSerializer;
 import io.mantisrx.runtime.Job;
 import io.mantisrx.runtime.loader.RuntimeTask;
 import io.mantisrx.runtime.loader.SinkSubscriptionStateHandler;
 import io.mantisrx.runtime.loader.config.WorkerConfiguration;
+import io.mantisrx.runtime.loader.config.WorkerConfigurationUtils;
+import io.mantisrx.runtime.loader.config.WorkerConfigurationWritable;
+import io.mantisrx.server.agent.metrics.cgroups.CgroupsMetricsCollector;
 import io.mantisrx.server.core.ExecuteStageRequest;
 import io.mantisrx.server.core.Service;
 import io.mantisrx.server.core.Status;
 import io.mantisrx.server.core.WrappedExecuteStageRequest;
-import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.core.metrics.MetricsFactory;
+import io.mantisrx.server.master.client.HighAvailabilityServices;
+import io.mantisrx.server.master.client.HighAvailabilityServicesUtil;
 import io.mantisrx.server.master.client.MantisMasterGateway;
+import io.mantisrx.server.master.client.TaskStatusUpdateHandler;
 import io.mantisrx.server.worker.client.WorkerMetricsClient;
+import io.mantisrx.server.worker.mesos.MesosMetricsCollector;
 import io.mantisrx.server.worker.mesos.VirtualMachineTaskStatus;
+import io.mantisrx.shaded.com.google.common.base.Strings;
 import io.mantisrx.shaded.com.google.common.util.concurrent.AbstractIdleService;
+import java.io.IOException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +46,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.flink.util.UserCodeClassLoader;
 import rx.Observable;
 import rx.functions.Func1;
+import rx.schedulers.Schedulers;
 import rx.subjects.PublishSubject;
 
 @Slf4j
@@ -46,6 +57,10 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
     private WorkerConfiguration config;
 
     private final List<Service> mantisServices = new ArrayList<>();
+
+    private HighAvailabilityServices highAvailabilityServices;
+
+    private TaskStatusUpdateHandler taskStatusUpdateHandler;
 
     private MantisMasterGateway masterMonitor;
 
@@ -69,19 +84,50 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
         this.tasksStatusSubject = tasksStatusSubject;
     }
 
+    public void initialize(
+        String executeStageRequestString, // request string + publishSubject replace?
+        String workerConfigurationString, // config string
+        UserCodeClassLoader userCodeClassLoader) {
 
-    @Override
-    public void initialize(WrappedExecuteStageRequest wrappedExecuteStageRequest,
-                           WorkerConfiguration config,
-                           MantisMasterGateway masterMonitor,
-                           UserCodeClassLoader userCodeClassLoader,
-                           SinkSubscriptionStateHandler.Factory sinkSubscriptionStateHandlerFactory) {
-        this.wrappedExecuteStageRequest = wrappedExecuteStageRequest;
+        try {
+            log.info("Creating runtimeTaskImpl.");
+            log.info("runtimeTaskImpl workerConfigurationString: {}", workerConfigurationString);
+            log.info("runtimeTaskImpl executeStageRequestString: {}", executeStageRequestString);
+            JsonSerializer ser = new JsonSerializer();
+            WorkerConfigurationWritable configWritable =
+                WorkerConfigurationUtils.stringToWorkerConfiguration(workerConfigurationString);
+            this.config = configWritable;
+            ExecuteStageRequest executeStageRequest =
+                ser.fromJSON(executeStageRequestString, ExecuteStageRequest.class);
+            this.wrappedExecuteStageRequest =
+                new WrappedExecuteStageRequest(PublishSubject.create(), executeStageRequest);
+
+            // todo: temp workaournd to pick host metrics collector.
+            if (Strings.isNullOrEmpty(this.config.getTaskExecutorId())) {
+                log.info("Picking mesos metrics collector.");
+                configWritable.setMetricsCollector(MesosMetricsCollector.valueOf(System.getProperties()));
+            }
+            else {
+                log.info("Picking Cgroups metrics collector.");
+                configWritable.setMetricsCollector(CgroupsMetricsCollector.valueOf(System.getProperties()));
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        this.highAvailabilityServices = HighAvailabilityServicesUtil.createHAServices(config);
         this.executeStageRequest = wrappedExecuteStageRequest.getRequest();
-        this.config = config;
-        this.masterMonitor = masterMonitor;
+        this.masterMonitor = this.highAvailabilityServices.getMasterClientApi();
         this.userCodeClassLoader = userCodeClassLoader;
-        this.sinkSubscriptionStateHandlerFactory = sinkSubscriptionStateHandlerFactory;
+        this.sinkSubscriptionStateHandlerFactory =
+            SinkSubscriptionStateHandler.Factory.forEphemeralJobsThatNeedToBeKilledInAbsenceOfSubscriber(
+                this.highAvailabilityServices.getMasterClientApi(),
+                Clock.systemDefaultZone());
+
+        // link task status to status updateHandler
+        this.taskStatusUpdateHandler = TaskStatusUpdateHandler.forReportingToGateway(masterMonitor);
+        this.getStatus().observeOn(Schedulers.io())
+            .subscribe(status -> this.taskStatusUpdateHandler.onStatusUpdate(status));
     }
 
     public void setJob(Optional<Job> job) {
@@ -92,6 +138,7 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
     protected void startUp() throws Exception {
         try {
             log.info("Starting current task {}", this);
+            this.highAvailabilityServices.startAsync().awaitRunning();
             doRun();
         } catch (Exception e) {
             log.error("Failed executing the task {}", executeStageRequest, e);
@@ -155,7 +202,7 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
         return executeStageRequest.getNameOfJobProviderClass();
     }
 
-    public Observable<Status> getStatus() {
+    protected Observable<Status> getStatus() {
         return tasksStatusSubject
             .flatMap((Func1<Observable<Status>, Observable<Status>>) status -> status);
     }
@@ -164,7 +211,7 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
         return vmTaskStatusSubject;
     }
 
-    public WorkerId getWorkerId() {
-        return executeStageRequest.getWorkerId();
+    public String getWorkerId() {
+        return executeStageRequest.getWorkerId().getId();
     }
 }

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
@@ -142,6 +142,11 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
         this.masterMonitor = masterMonitor;
         this.userCodeClassLoader = userCodeClassLoader;
         this.sinkSubscriptionStateHandlerFactory = sinkSubscriptionStateHandlerFactory;
+
+        // link task status to status updateHandler
+        this.taskStatusUpdateHandler = TaskStatusUpdateHandler.forReportingToGateway(masterMonitor);
+        this.getStatus().observeOn(Schedulers.io())
+            .subscribe(status -> this.taskStatusUpdateHandler.onStatusUpdate(status));
     }
 
     public void setJob(Optional<Job> job) {

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
@@ -56,6 +56,7 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
 
     private final List<Service> mantisServices = new ArrayList<>();
 
+    // HA service instance on TaskExecutor path. Could be null in mesos task.
     private HighAvailabilityServices highAvailabilityServices;
 
     private TaskStatusUpdateHandler taskStatusUpdateHandler;
@@ -151,7 +152,7 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
     protected void startUp() throws Exception {
         try {
             log.info("Starting current task {}", this);
-            if (!this.highAvailabilityServices.isRunning()) {
+            if (this.highAvailabilityServices != null && !this.highAvailabilityServices.isRunning()) {
                 this.highAvailabilityServices.startAsync().awaitRunning();
             }
             doRun();

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/mesos/MesosMetricsCollector.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/mesos/MesosMetricsCollector.java
@@ -69,6 +69,7 @@ public class MesosMetricsCollector implements MetricsCollector {
     }
 
     MesosMetricsCollector(int slavePort, String taskId) {
+        logger.info("Creating MesosMetricsCollector to port {} of taskId: {}", slavePort, taskId);
         this.slavePort = slavePort;
         this.taskId = taskId;
     }
@@ -89,13 +90,17 @@ public class MesosMetricsCollector implements MetricsCollector {
             .firstOrDefault("");
     }
 
+    @Override
     public Usage get() {
         return getCurentUsage(taskId, getUsageJson());
     }
 
     static Usage getCurentUsage(String taskId, String usageJson) {
-        if (usageJson == null || usageJson.isEmpty())
+        if (usageJson == null || usageJson.isEmpty()) {
+            logger.warn("Empty usage on task {}", taskId);
             return null;
+        }
+
         JSONArray array = new JSONArray(usageJson);
         if (array.length() == 0)
             return null;

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/mesos/MesosMetricsCollector.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/mesos/MesosMetricsCollector.java
@@ -19,6 +19,7 @@ package io.mantisrx.server.worker.mesos;
 import io.mantisrx.runtime.loader.config.MetricsCollector;
 import io.mantisrx.runtime.loader.config.Usage;
 import io.mantisrx.runtime.loader.config.WorkerConfiguration;
+import io.mantisrx.shaded.com.google.common.base.Strings;
 import io.netty.buffer.ByteBuf;
 import io.reactivx.mantis.operators.OperatorOnErrorResumeNextViaFunction;
 import java.nio.charset.Charset;
@@ -70,6 +71,11 @@ public class MesosMetricsCollector implements MetricsCollector {
 
     MesosMetricsCollector(int slavePort, String taskId) {
         logger.info("Creating MesosMetricsCollector to port {} of taskId: {}", slavePort, taskId);
+
+        if (Strings.isNullOrEmpty(taskId)) {
+            // only log error to avoid breaking tests.
+            logger.error("Invalid task id for MesosMetricsCollector");
+        }
         this.slavePort = slavePort;
         this.taskId = taskId;
     }

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/mesos/MesosMetricsCollector.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/mesos/MesosMetricsCollector.java
@@ -41,7 +41,7 @@ import rx.functions.Func2;
  * <a href="https://mesos.readthedocs.io/en/latest/endpoints/slave/monitor/statistics.json/">mesos statics endpoint link</a>
  */
 public class MesosMetricsCollector implements MetricsCollector {
-
+    private static final String MESOS_TASK_EXECUTOR_ID_KEY = "MESOS_EXECUTOR_ID";
     private static final Logger logger = LoggerFactory.getLogger(MesosMetricsCollector.class);
     private static final long GET_TIMEOUT_SECS = 5;
     private static final int MAX_REDIRECTS = 10;
@@ -58,13 +58,13 @@ public class MesosMetricsCollector implements MetricsCollector {
     @SuppressWarnings("unused")
     public static MesosMetricsCollector valueOf(Properties properties) {
         int slavePort = Integer.parseInt(properties.getProperty("mantis.agent.mesos.slave.port", "5051"));
-        String taskId = System.getenv("MESOS_TASK_ID");
+        String taskId = System.getenv(MESOS_TASK_EXECUTOR_ID_KEY);
         return new MesosMetricsCollector(slavePort, taskId);
     }
 
     public static MesosMetricsCollector valueOf(WorkerConfiguration workerConfiguration) {
         int slavePort = workerConfiguration.getMesosSlavePort();
-        String taskId = System.getenv("MESOS_TASK_ID");
+        String taskId = System.getenv(MESOS_TASK_EXECUTOR_ID_KEY);
         return new MesosMetricsCollector(slavePort, taskId);
     }
 

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/mesos/MesosMetricsCollector.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/mesos/MesosMetricsCollector.java
@@ -18,6 +18,7 @@ package io.mantisrx.server.worker.mesos;
 
 import io.mantisrx.runtime.loader.config.MetricsCollector;
 import io.mantisrx.runtime.loader.config.Usage;
+import io.mantisrx.runtime.loader.config.WorkerConfiguration;
 import io.netty.buffer.ByteBuf;
 import io.reactivx.mantis.operators.OperatorOnErrorResumeNextViaFunction;
 import java.nio.charset.Charset;
@@ -57,6 +58,12 @@ public class MesosMetricsCollector implements MetricsCollector {
     @SuppressWarnings("unused")
     public static MesosMetricsCollector valueOf(Properties properties) {
         int slavePort = Integer.parseInt(properties.getProperty("mantis.agent.mesos.slave.port", "5051"));
+        String taskId = System.getenv("MESOS_TASK_ID");
+        return new MesosMetricsCollector(slavePort, taskId);
+    }
+
+    public static MesosMetricsCollector valueOf(WorkerConfiguration workerConfiguration) {
+        int slavePort = workerConfiguration.getMesosSlavePort();
         String taskId = System.getenv("MESOS_TASK_ID");
         return new MesosMetricsCollector(slavePort, taskId);
     }


### PR DESCRIPTION
### Context

To support customized task executor hosts e.g. Springboot the `RuntimeTask` interface dependencies need to have as thin dependencies as possible to avoid conflicts on the class loaders. This PR aims at removing most of the dependencies on this interface to have the parameters required in init to be mostly serializable to only rely on primitive types during class loading.

The impact of the change includes:
* RuntimeTask implementations will need to re-construct and manage components like HA services. (e.g. MantisMaster client).
* Bridging worker configuration handling to make it serializable until full config refactor. Picking metrics collector inside runtime task.
* Maintaining back compatibility for both Mesos and task executor hosts.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
