### PR TITLE
Setting preconditions to ensure we don't start mantis with an invalid state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,7 @@ gradle-app.setting
 .project
 .settings
 bin/
+
+# mkdocs Build files
+build
+site

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
@@ -240,18 +240,19 @@ public class MantisJobMetadataImpl implements IMantisJobMetadata {
      public boolean addWorkerMetadata(int stageNum, JobWorker newWorker)
             throws InvalidJobException {
          if(logger.isTraceEnabled()) { logger.trace("Adding workerMetadata {} for stage {}", stageNum, newWorker); }
-        boolean result=true;
         if(!stageMetadataMap.containsKey(stageNum)) {
         	logger.warn("No such stage {}", stageNum);
         }
-        if(!((MantisStageMetadataImpl)stageMetadataMap.get(stageNum)).addWorkerIndex(newWorker))
-            result=false;
-        Integer integer = workerNumberToStageMap.put(newWorker.getMetadata().getWorkerNumber(), stageNum);
-        if(integer != null && integer != stageNum) {
-            logger.error(String.format("Unexpected to put worker number mapping from %d to stage %d for job %s, prev mapping to stage %d",
-            		newWorker.getMetadata().getWorkerNumber(), stageNum, newWorker.getMetadata().getJobId(), integer));
+        final boolean result = ((MantisStageMetadataImpl) stageMetadataMap.get(stageNum)).addWorkerIndex(newWorker);
+
+        if (result) {
+            Integer integer = workerNumberToStageMap.put(newWorker.getMetadata().getWorkerNumber(), stageNum);
+            if(integer != null && integer != stageNum) {
+                logger.error(String.format("Unexpected to put worker number mapping from %d to stage %d for job %s, prev mapping to stage %d",
+                    newWorker.getMetadata().getWorkerNumber(), stageNum, newWorker.getMetadata().getJobId(), integer));
+            }
+            if(logger.isTraceEnabled()) { logger.trace("Exit addworkerMeta {}", workerNumberToStageMap); }
         }
-         if(logger.isTraceEnabled()) { logger.trace("Exit addworkerMeta {}", workerNumberToStageMap); }
         return result;
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
@@ -42,6 +42,7 @@ import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import io.mantisrx.shaded.com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.mantisrx.shaded.com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.mantisrx.shaded.com.google.common.base.Preconditions;
 import io.mantisrx.shaded.com.google.common.collect.ImmutableList;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
 import java.io.IOException;
@@ -371,7 +372,14 @@ public class KeyValueBasedPersistenceProvider implements IMantisPersistenceProvi
                     continue;
                 }
                 for (MantisWorkerMetadataWritable workerMeta : workersByJobId.get(jobId)) {
-                    jobMeta.addWorkerMedata(workerMeta.getStageNum(), workerMeta, null);
+                    Preconditions.checkState(
+                        jobMeta.addWorkerMedata(workerMeta.getStageNum(), workerMeta, null),
+                        "JobID=%s stage=%d workerIdx=%d has existing worker, existing=%s, new=%s",
+                        workerMeta.getJobId(),
+                        workerMeta.getStageNum(),
+                        workerMeta.getWorkerIndex(),
+                        jobMeta.getWorkerByIndex(workerMeta.getStageNum(), workerMeta.getWorkerIndex()).getWorkerId(),
+                        workerMeta.getWorkerId());
                 }
                 jobMetas.add(DataFormatAdapter.convertMantisJobWriteableToMantisJobMetadata(jobMeta, eventPublisher));
             } catch (Exception e) {
@@ -561,7 +569,14 @@ public class KeyValueBasedPersistenceProvider implements IMantisPersistenceProvi
                 for (IMantisWorkerMetadata w : archivedWorkers) {
                     try {
                         MantisWorkerMetadataWritable wmw = DataFormatAdapter.convertMantisWorkerMetadataToMantisWorkerMetadataWritable(w);
-                        jmw.addWorkerMedata(w.getStageNum(), wmw, null);
+                        Preconditions.checkState(
+                            jmw.addWorkerMedata(w.getStageNum(), wmw, null),
+                            "JobID=%s stage=%d workerIdx=%d has existing worker, existing=%s, new=%s",
+                            wmw.getJobId(),
+                            wmw.getStageNum(),
+                            wmw.getWorkerIndex(),
+                            jmw.getWorkerByIndex(wmw.getStageNum(), wmw.getWorkerIndex()).getWorkerId(),
+                            wmw.getWorkerId());
                     } catch (InvalidJobException e) {
                         logger.warn(
                             "Unexpected error adding worker index={}, number={} to job {}",

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
@@ -222,13 +222,16 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
 
     public boolean addWorkerMedata(int stageNum, MantisWorkerMetadata workerMetadata, MantisWorkerMetadata replacedWorker)
             throws InvalidJobException {
-        boolean result = true;
-        if (!stageMetadataMap.get(stageNum).replaceWorkerIndex(workerMetadata, replacedWorker))
-            result = false;
-        Integer integer = workerNumberToStageMap.put(workerMetadata.getWorkerNumber(), stageNum);
-        if (integer != null && integer != stageNum) {
-            logger.error(String.format("Unexpected to put worker number mapping from %d to stage %d for job %s, prev mapping to stage %d",
+        final boolean result =
+            stageMetadataMap.get(stageNum)
+                .replaceWorkerIndex(workerMetadata, replacedWorker);
+
+        if (result) {
+            Integer integer = workerNumberToStageMap.put(workerMetadata.getWorkerNumber(), stageNum);
+            if (integer != null && integer != stageNum) {
+                logger.error(String.format("Unexpected to put worker number mapping from %d to stage %d for job %s, prev mapping to stage %d",
                     workerMetadata.getWorkerNumber(), stageNum, workerMetadata.getJobId(), integer));
+            }
         }
         return result;
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisStageMetadataWritable.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisStageMetadataWritable.java
@@ -214,8 +214,9 @@ public class MantisStageMetadataWritable implements MantisStageMetadata {
         boolean result = true;
         if (!MantisJobState.isErrorState(newWorker.getState())) {
             if (oldWorker == null) {
-                if (workerByIndexMetadataSet.putIfAbsent(index, newWorker) != null)
+                if (workerByIndexMetadataSet.putIfAbsent(index, newWorker) != null) {
                     result = false;
+                }
             } else {
                 if (oldWorker.getWorkerIndex() != index) {
                     throw new InvalidJobException(newWorker.getJobId(), stageNum, oldWorker.getWorkerIndex());


### PR DESCRIPTION
### Context

Currently, we ignore duplicate workers for the same (jobId/stageNum/workerIdx) tuple. However, when we ignore these duplicate workers, we are essentially running a mantis master with a state that may not reflect the previous state of the master. This diff aims to surface these issues and block deployments to make sure we at least know when such problems happen. The current thinking is we should never see these issues. But, if we do see them, then the expectation is that we run state cleaner to clean up the state and then restart the master.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
