### PR TITLE
fix typo in getting started with docker documentation

### DIFF
--- a/docs/docs/getting-started/tutorials/docker.md
+++ b/docs/docs/getting-started/tutorials/docker.md
@@ -26,7 +26,7 @@ This starts up the following Docker containers:
 - Mantis API
 - Mesos Slave and Mantis Worker run on a single container (mantisagent)
 - A simple hello world web application that sends events to Mantis
-- A simple Java application that sends events to Manits
+- A simple Java application that sends events to Mantis
 
 ### Mantis Admin UI
 


### PR DESCRIPTION
### Context

Hi! While going through the docs, I found a typo in the "Explore using Docker" section, so I thought I should submit a PR :)