### PR TITLE
Add flink-rpc-akka custom classloader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ ext.versions = [
         spectator: "1.3.+",
         slf4j    : "1.7.0",
         vavr     : "0.9.2",
+        jsr305   : "3.0.1",
 ]
 
 ext.libraries = [
@@ -83,6 +84,7 @@ ext.libraries = [
         vavrJackson    : "io.vavr:vavr-jackson:${versions.vavr}",
         vavrTest       : "io.vavr:vavr-test:${versions.vavr}",
         zip4j          : "net.lingala.zip4j:zip4j:2.9.0",
+        jsr305         : "com.google.code.findbugs:jsr305" // For Nonnull annotation
 ]
 
 allprojects {

--- a/mantis-client/dependencies.lock
+++ b/mantis-client/dependencies.lock
@@ -11,6 +11,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.spectator:spectator-api": {
             "locked": "1.3.10"
         },
@@ -115,12 +121,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -174,7 +174,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -195,6 +195,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.spectator:spectator-api": {
             "locked": "1.3.10"
         },
@@ -299,12 +305,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -361,7 +361,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -376,6 +376,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-remote-observable"
@@ -518,12 +524,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -585,7 +585,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -599,6 +599,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "1.3.10"
@@ -705,12 +711,6 @@
             "locked": "4.11"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -775,7 +775,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -784,6 +784,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -933,12 +939,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -1003,7 +1003,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-common/dependencies.lock
+++ b/mantis-common/dependencies.lock
@@ -102,7 +102,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -152,7 +152,7 @@
             "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -207,7 +207,7 @@
             "locked": "1.7.0"
         },
         "org.xerial.snappy:snappy-java": {
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -314,7 +314,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testFixturesAnnotationProcessor": {
@@ -394,7 +394,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testFixturesRuntimeClasspath": {
@@ -484,7 +484,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -595,7 +595,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-connectors/mantis-connector-iceberg/dependencies.lock
+++ b/mantis-connectors/mantis-connector-iceberg/dependencies.lock
@@ -99,7 +99,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -247,7 +247,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -384,7 +384,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "shadow": {
@@ -552,7 +552,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -720,7 +720,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-connectors/mantis-connector-job/dependencies.lock
+++ b/mantis-connectors/mantis-connector-job/dependencies.lock
@@ -11,6 +11,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.google.code.gson:gson": {
             "locked": "2.8.9"
         },
@@ -18,7 +24,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -124,12 +130,6 @@
             "locked": "2.12.2"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -188,7 +188,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -198,6 +198,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.google.code.gson:gson": {
             "locked": "2.8.9"
         },
@@ -205,7 +211,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -311,12 +317,6 @@
             "locked": "2.12.2"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -378,7 +378,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -393,6 +393,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.google.code.gson:gson": {
             "locked": "2.8.9"
         },
@@ -400,13 +406,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -582,12 +588,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -651,7 +651,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -666,6 +666,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.google.code.gson:gson": {
             "locked": "2.8.9"
         },
@@ -673,7 +679,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -784,12 +790,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -846,7 +846,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -856,6 +856,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.google.code.gson:gson": {
             "locked": "2.8.9"
         },
@@ -863,13 +869,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -1045,12 +1051,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -1114,7 +1114,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-connectors/mantis-connector-kafka/dependencies.lock
+++ b/mantis-connectors/mantis-connector-kafka/dependencies.lock
@@ -99,7 +99,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -118,10 +118,10 @@
     },
     "compileClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.82.0"
@@ -226,7 +226,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -236,10 +236,10 @@
     },
     "runtimeClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -375,7 +375,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -388,10 +388,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.82.0"
@@ -505,7 +505,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -513,10 +513,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -661,7 +661,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-connectors/mantis-connector-publish/dependencies.lock
+++ b/mantis-connectors/mantis-connector-publish/dependencies.lock
@@ -99,7 +99,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -120,11 +120,17 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -229,12 +235,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -291,7 +291,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -306,17 +306,23 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -461,12 +467,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -523,7 +523,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -538,11 +538,17 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -647,12 +653,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -718,7 +718,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -728,17 +728,23 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -883,12 +889,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -954,7 +954,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-control-plane/mantis-control-plane-client/dependencies.lock
+++ b/mantis-control-plane/mantis-control-plane-client/dependencies.lock
@@ -96,7 +96,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -105,6 +105,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -176,12 +182,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -240,7 +240,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -254,6 +254,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -356,12 +362,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -419,7 +419,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -433,6 +433,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "1.3.10"
@@ -509,12 +515,6 @@
             "locked": "4.11"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -581,7 +581,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -590,6 +590,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -697,12 +703,6 @@
             "locked": "1.0"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -768,7 +768,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-control-plane/mantis-control-plane-core/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-core/build.gradle
@@ -32,9 +32,10 @@ dependencies {
     api project(":mantis-common")
 
     api "org.skife.config:config-magic:$configMagicVersion"
+    api libraries.jsr305
     api libraries.flinkRpcApi
-    api libraries.flinkRpcImpl
     api libraries.flinkCore
+    compileOnly libraries.flinkRpcImpl // Provided by copyLibs task
 
     api "org.apache.mesos:mesos:$mesosVersion"
     api "org.json:json:$jsonVersion"
@@ -42,7 +43,20 @@ dependencies {
     api "com.github.spullara.cli-parser:cli-parser:$cliParserVersion"
     api "joda-time:joda-time:$jodaTimeVersion"
 
-
+    testFixturesImplementation libraries.flinkRpcImpl
     testImplementation libraries.junit4
     testImplementation libraries.mockitoAll
 }
+
+// This task makes flink-rpc-akka.jar available in mantis-control-plane-core classpath,
+// to ensure that all the classes from flink-rpc-akka.jar (like scala and akka) are always
+// loaded through a custom submodule classloader.
+task copyLibs(type: Copy) {
+    from(sourceSets.main.compileClasspath) {
+        rename 'flink-rpc-akka(.*)', 'flink-rpc-akka.jar'
+    }
+    include '*flink-rpc-akka*.jar'
+    into "$buildDir/classes/java/main"
+}
+
+jar.dependsOn copyLibs

--- a/mantis-control-plane/mantis-control-plane-core/dependencies.lock
+++ b/mantis-control-plane/mantis-control-plane-core/dependencies.lock
@@ -11,6 +11,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -84,12 +90,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -145,12 +145,20 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
+        }
+    },
+    "baseline-exact-dependencies-testFixtures": {
+        "org.apache.flink:flink-rpc-akka": {
+            "locked": "1.14.2"
         }
     },
     "compileClasspath": {
         "com.github.spullara.cli-parser:cli-parser": {
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.1"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -247,7 +255,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -258,6 +266,9 @@
     "runtimeClasspath": {
         "com.github.spullara.cli-parser:cli-parser": {
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "locked": "3.0.1"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -329,9 +340,6 @@
         "org.apache.flink:flink-core": {
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "locked": "1.14.2"
         },
@@ -369,7 +377,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -384,6 +392,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -457,12 +471,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -521,7 +529,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testFixturesAnnotationProcessor": {
@@ -536,6 +544,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -601,9 +615,6 @@
             "locked": "1.14.2"
         },
         "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
             "locked": "1.14.2"
         },
         "org.apache.flink:flink-rpc-core": {
@@ -661,7 +672,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testFixturesRuntimeClasspath": {
@@ -670,6 +681,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -754,9 +771,6 @@
             "locked": "1.14.2"
         },
         "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
             "locked": "1.14.2"
         },
         "org.apache.flink:flink-rpc-core": {
@@ -811,7 +825,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -820,6 +834,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -973,7 +993,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CleanupOnCloseRpcSystem.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CleanupOnCloseRpcSystem.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.core;
+
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.file.Path;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.classloading.ComponentClassLoader;
+import org.apache.flink.runtime.rpc.AddressResolution;
+import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.Preconditions;
+
+/** An {@link RpcSystem} wrapper that cleans up resources after the RPC system has been closed. */
+@Slf4j
+class CleanupOnCloseRpcSystem implements RpcSystem {
+    private final RpcSystem rpcSystem;
+    private final ComponentClassLoader pluginLoader;
+    @Nullable private final Path tempDirectory;
+
+    public CleanupOnCloseRpcSystem(
+            RpcSystem rpcSystem, ComponentClassLoader pluginLoader, @Nullable Path tempDirectory) {
+        this.rpcSystem = Preconditions.checkNotNull(rpcSystem);
+        this.pluginLoader = Preconditions.checkNotNull(pluginLoader);
+        this.tempDirectory = tempDirectory;
+    }
+
+    @Override
+    public void close() {
+        rpcSystem.close();
+
+        try {
+            pluginLoader.close();
+        } catch (Exception e) {
+            log.warn("Could not close RpcSystem classloader.", e);
+        }
+        if (tempDirectory != null) {
+            try {
+                FileUtils.deleteFileOrDirectory(tempDirectory.toFile());
+            } catch (Exception e) {
+                log.warn("Could not delete temporary rpc system file {}.", tempDirectory, e);
+            }
+        }
+    }
+
+    @Override
+    public RpcServiceBuilder localServiceBuilder(Configuration config) {
+        return rpcSystem.localServiceBuilder(config);
+    }
+
+    @Override
+    public RpcServiceBuilder remoteServiceBuilder(
+            Configuration configuration,
+            @Nullable String externalAddress,
+            String externalPortRange) {
+        return rpcSystem.remoteServiceBuilder(configuration, externalAddress, externalPortRange);
+    }
+
+    @Override
+    public String getRpcUrl(
+            String hostname,
+            int port,
+            String endpointName,
+            AddressResolution addressResolution,
+            Configuration config)
+            throws UnknownHostException {
+        return rpcSystem.getRpcUrl(hostname, port, endpointName, addressResolution, config);
+    }
+
+    @Override
+    public InetSocketAddress getInetSocketAddressFromRpcUrl(String url) throws Exception {
+        return rpcSystem.getInetSocketAddressFromRpcUrl(url);
+    }
+
+    @Override
+    public long getMaximumMessageSizeInBytes(Configuration config) {
+        return rpcSystem.getMaximumMessageSizeInBytes(config);
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/MantisAkkaRpcSystemLoader.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/MantisAkkaRpcSystemLoader.java
@@ -16,10 +16,20 @@
 
 package io.mantisrx.server.core;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ServiceLoader;
+import java.util.UUID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.core.classloading.ComponentClassLoader;
 import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.rpc.RpcSystemLoader;
-import org.apache.flink.runtime.rpc.akka.AkkaRpcSystem;
+import org.apache.flink.util.IOUtils;
 
 /**
  * RpcSystemLoader for mantis task executor and other services that need to expose an RPC API.
@@ -27,13 +37,62 @@ import org.apache.flink.runtime.rpc.akka.AkkaRpcSystem;
  */
 public class MantisAkkaRpcSystemLoader implements RpcSystemLoader {
 
-    private static final RpcSystem INSTANCE = new AkkaRpcSystem();
+    private static final RpcSystem INSTANCE = createRpcSystem();
+
+    public static RpcSystem getInstance() {
+        return INSTANCE;
+    }
+
     @Override
     public RpcSystem loadRpcSystem(Configuration config) {
         return INSTANCE;
     }
 
-    public static RpcSystem getInstance() {
-        return INSTANCE;
+    private static RpcSystem createRpcSystem() {
+        try {
+            final ClassLoader flinkClassLoader = RpcSystem.class.getClassLoader();
+
+            final Path tmpDirectory = Paths.get(System.getProperty("java.io.tmpdir"));
+            Files.createDirectories(tmpDirectory);
+            final Path tempFile =
+                Files.createFile(
+                    tmpDirectory.resolve("flink-rpc-akka_" + UUID.randomUUID() + ".jar"));
+
+            final InputStream resourceStream =
+                flinkClassLoader.getResourceAsStream("flink-rpc-akka.jar");
+            if (resourceStream == null) {
+                throw new RuntimeException(
+                    "Akka RPC system could not be found. If this happened while running a test in the IDE,"
+                        + "run the process-resources phase on flink-rpc/flink-rpc-akka-loader via maven.");
+            }
+
+            IOUtils.copyBytes(resourceStream, Files.newOutputStream(tempFile));
+
+            // The following classloader loads all classes from the submodule jar, except for explicitly white-listed packages.
+            //
+            //  <p>To ensure that classes from the submodule are always loaded through the submodule classloader
+            //  (and thus from the submodule jar), even if the classes are also on the classpath (e.g., during
+            //  tests), all classes from the "org.apache.flink" package are loaded child-first.
+            //
+            //  <p>Classes related to mantis-specific or logging are loaded parent-first.
+            //
+            //  <p>All other classes can only be loaded if they are either available in the submodule jar or the
+            //  bootstrap/app classloader (i.e., provided by the JDK).
+            final ComponentClassLoader componentClassLoader = new ComponentClassLoader(
+                new URL[] {tempFile.toUri().toURL()},
+                flinkClassLoader,
+                // Dependencies which are needed by logic inside flink-rpc-akka (ie AkkaRpcService/System) which
+                // are external to flink-rpc-akka itself (like ExecuteStageRequest in mantis-control-plane).
+                CoreOptions.parseParentFirstLoaderPatterns(
+                    "org.slf4j;org.apache.log4j;org.apache.logging;org.apache.commons.logging;ch.qos.logback;io.mantisrx.server.worker;io.mantisrx.server.core;io.mantisrx", ""),
+                new String[] {"org.apache.flink"});
+
+            return new CleanupOnCloseRpcSystem(
+                ServiceLoader.load(RpcSystem.class, componentClassLoader).iterator().next(),
+                componentClassLoader,
+                tempFile);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not initialize RPC system.", e);
+        }
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/dependencies.lock
+++ b/mantis-control-plane/mantis-control-plane-server/dependencies.lock
@@ -16,6 +16,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -94,12 +100,6 @@
             "locked": "4.11"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -163,7 +163,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -172,6 +172,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.fenzo:fenzo-core": {
             "locked": "0.13.8"
@@ -267,12 +273,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -328,7 +328,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -343,6 +343,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.fenzo:fenzo-core": {
             "locked": "0.13.8"
         },
@@ -455,12 +461,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -513,7 +513,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -527,6 +527,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.fenzo:fenzo-core": {
             "locked": "0.13.8"
@@ -636,12 +642,6 @@
             "locked": "4.11"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -708,7 +708,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -717,6 +717,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.fenzo:fenzo-core": {
             "locked": "0.13.8"
@@ -910,7 +916,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-discovery-proto/dependencies.lock
+++ b/mantis-discovery-proto/dependencies.lock
@@ -10,9 +10,6 @@
         },
         "junit:junit-dep": {
             "locked": "4.11"
-        },
-        "org.mockito:mockito-core": {
-            "locked": "2.0.111-beta"
         }
     },
     "compileClasspath": {
@@ -54,9 +51,6 @@
         "junit:junit-dep": {
             "locked": "4.11"
         },
-        "org.mockito:mockito-core": {
-            "locked": "2.0.111-beta"
-        },
         "org.projectlombok:lombok": {
             "locked": "1.18.20"
         }
@@ -76,9 +70,6 @@
         },
         "junit:junit-dep": {
             "locked": "4.11"
-        },
-        "org.mockito:mockito-core": {
-            "locked": "2.0.111-beta"
         }
     }
 }

--- a/mantis-examples/mantis-examples-core/dependencies.lock
+++ b/mantis-examples/mantis-examples-core/dependencies.lock
@@ -99,7 +99,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -200,7 +200,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -337,7 +337,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -443,7 +443,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -575,7 +575,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-examples/mantis-examples-groupby-sample/dependencies.lock
+++ b/mantis-examples/mantis-examples-groupby-sample/dependencies.lock
@@ -5,6 +5,9 @@
         }
     },
     "baseline-exact-dependencies-main": {
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -102,10 +105,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -206,7 +212,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -221,6 +227,9 @@
             ],
             "locked": "0.20.6"
         },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -333,7 +342,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.6"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
@@ -346,7 +355,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -355,6 +364,9 @@
         }
     },
     "testCompileClasspath": {
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -455,7 +467,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -465,6 +477,9 @@
             ],
             "locked": "0.20.6"
         },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -577,7 +592,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.6"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
@@ -590,7 +605,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-examples/mantis-examples-jobconnector-sample/dependencies.lock
+++ b/mantis-examples/mantis-examples-jobconnector-sample/dependencies.lock
@@ -232,7 +232,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -466,7 +466,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -808,7 +808,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -1065,7 +1065,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -1402,7 +1402,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-examples/mantis-examples-mantis-publish-sample/dependencies.lock
+++ b/mantis-examples/mantis-examples-mantis-publish-sample/dependencies.lock
@@ -12,13 +12,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -71,13 +71,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -141,7 +141,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
@@ -149,19 +149,19 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
@@ -169,7 +169,7 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-nflx-plugin": {
             "firstLevelTransitive": [
@@ -261,13 +261,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -326,7 +326,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
@@ -334,19 +334,19 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
@@ -354,7 +354,7 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-nflx-plugin": {
             "firstLevelTransitive": [

--- a/mantis-examples/mantis-examples-sine-function/dependencies.lock
+++ b/mantis-examples/mantis-examples-sine-function/dependencies.lock
@@ -102,7 +102,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -206,7 +206,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -346,7 +346,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -455,7 +455,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -590,7 +590,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-examples/mantis-examples-synthetic-sourcejob/dependencies.lock
+++ b/mantis-examples/mantis-examples-synthetic-sourcejob/dependencies.lock
@@ -105,7 +105,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -217,7 +217,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -357,7 +357,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -472,7 +472,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -610,7 +610,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-examples/mantis-examples-twitter-sample/dependencies.lock
+++ b/mantis-examples/mantis-examples-twitter-sample/dependencies.lock
@@ -5,6 +5,9 @@
         }
     },
     "baseline-exact-dependencies-main": {
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -102,10 +105,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -206,7 +212,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -221,6 +227,9 @@
             ],
             "locked": "0.20.6"
         },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -333,7 +342,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.6"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
@@ -346,7 +355,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -355,6 +364,9 @@
         }
     },
     "testCompileClasspath": {
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -455,7 +467,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -465,6 +477,9 @@
             ],
             "locked": "0.20.6"
         },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -577,7 +592,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.6"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
@@ -590,7 +605,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-examples/mantis-examples-wordcount/dependencies.lock
+++ b/mantis-examples/mantis-examples-wordcount/dependencies.lock
@@ -5,6 +5,9 @@
         }
     },
     "baseline-exact-dependencies-main": {
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -105,10 +108,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -212,7 +218,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -227,6 +233,9 @@
             ],
             "locked": "0.20.6"
         },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -346,7 +355,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.6"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
@@ -360,7 +369,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -369,6 +378,9 @@
         }
     },
     "testCompileClasspath": {
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -472,7 +484,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -482,6 +494,9 @@
             ],
             "locked": "0.20.6"
         },
+        "com.netflix.spectator:spectator-api": {
+            "locked": "1.3.10"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -601,7 +616,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.6"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
@@ -615,7 +630,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-network/dependencies.lock
+++ b/mantis-network/dependencies.lock
@@ -110,7 +110,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -211,7 +211,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -312,7 +312,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -423,7 +423,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-publish/mantis-publish-core/dependencies.lock
+++ b/mantis-publish/mantis-publish-core/dependencies.lock
@@ -6,7 +6,7 @@
     },
     "baseline-exact-dependencies-main": {
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "locked": "0.134.0"
@@ -52,10 +52,10 @@
     },
     "compileClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -93,10 +93,10 @@
     },
     "runtimeClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -140,10 +140,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -197,10 +197,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"

--- a/mantis-publish/mantis-publish-netty-guice/dependencies.lock
+++ b/mantis-publish/mantis-publish-netty-guice/dependencies.lock
@@ -9,10 +9,10 @@
             "locked": "4.2.2"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "locked": "0.96.0"
@@ -52,13 +52,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -110,30 +110,30 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-nflx-plugin": {
             "locked": "0.96.0"
@@ -205,13 +205,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -273,30 +273,30 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-nflx-plugin": {
             "locked": "0.96.0"

--- a/mantis-publish/mantis-publish-netty/dependencies.lock
+++ b/mantis-publish/mantis-publish-netty/dependencies.lock
@@ -9,19 +9,19 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "io.mantisrx:mantis-discovery-proto": {
             "firstLevelTransitive": [
@@ -67,19 +67,19 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "io.mantisrx:mantis-discovery-proto": {
             "firstLevelTransitive": [
@@ -116,25 +116,25 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "io.mantisrx:mantis-common-serde": {
             "firstLevelTransitive": [
@@ -190,19 +190,19 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "io.mantisrx:mantis-discovery-proto": {
             "firstLevelTransitive": [
@@ -249,25 +249,25 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "io.mantisrx:mantis-common-serde": {
             "firstLevelTransitive": [

--- a/mantis-remote-observable/dependencies.lock
+++ b/mantis-remote-observable/dependencies.lock
@@ -79,7 +79,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -168,7 +168,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -269,7 +269,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -361,7 +361,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -463,7 +463,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-runtime-loader/dependencies.lock
+++ b/mantis-runtime-loader/dependencies.lock
@@ -85,7 +85,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -94,6 +94,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -171,12 +177,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -232,7 +232,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -247,6 +247,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-remote-observable"
@@ -360,12 +366,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -426,7 +426,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -440,6 +440,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -519,12 +525,6 @@
             "locked": "4.11"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -588,7 +588,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -597,6 +597,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -718,12 +724,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -787,7 +787,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-runtime/dependencies.lock
+++ b/mantis-runtime/dependencies.lock
@@ -108,7 +108,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -234,7 +234,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -341,7 +341,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -474,7 +474,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-server/mantis-server-agent/dependencies.lock
+++ b/mantis-server/mantis-server-agent/dependencies.lock
@@ -34,6 +34,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -90,6 +96,13 @@
         },
         "io.mantisrx:mantis-runtime-loader": {
             "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent",
+                "io.mantisrx:mantis-server-worker"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-server-agent": {
+            "firstLevelTransitive": [
                 "io.mantisrx:mantis-server-worker"
             ],
             "project": true
@@ -99,6 +112,7 @@
         },
         "io.mantisrx:mantis-server-worker-client": {
             "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent",
                 "io.mantisrx:mantis-server-worker"
             ],
             "project": true
@@ -153,12 +167,6 @@
             "locked": "4.11"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -220,7 +228,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -229,6 +237,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -329,12 +343,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -393,7 +401,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -407,6 +415,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -530,12 +544,6 @@
             "locked": "2.9.0"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -604,7 +612,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -618,6 +626,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -681,6 +695,13 @@
         },
         "io.mantisrx:mantis-runtime-loader": {
             "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent",
+                "io.mantisrx:mantis-server-worker"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-server-agent": {
+            "firstLevelTransitive": [
                 "io.mantisrx:mantis-server-worker"
             ],
             "project": true
@@ -690,6 +711,7 @@
         },
         "io.mantisrx:mantis-server-worker-client": {
             "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent",
                 "io.mantisrx:mantis-server-worker"
             ],
             "project": true
@@ -750,12 +772,6 @@
             "locked": "2.9.0"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -823,7 +839,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -832,6 +848,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -853,7 +875,8 @@
         },
         "com.spotify:completable-futures": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-client"
+                "io.mantisrx:mantis-control-plane-client",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "0.3.1"
         },
@@ -865,7 +888,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-server-agent"
             ],
             "locked": "2.11.0"
         },
@@ -920,6 +944,7 @@
         },
         "io.mantisrx:mantis-runtime-loader": {
             "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent",
                 "io.mantisrx:mantis-server-worker"
             ],
             "project": true
@@ -930,11 +955,18 @@
             ],
             "locked": "1.3.20"
         },
+        "io.mantisrx:mantis-server-agent": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-worker"
+            ],
+            "project": true
+        },
         "io.mantisrx:mantis-server-worker": {
             "project": true
         },
         "io.mantisrx:mantis-server-worker-client": {
             "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent",
                 "io.mantisrx:mantis-server-worker"
             ],
             "project": true
@@ -985,6 +1017,7 @@
         },
         "io.vavr:vavr": {
             "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent",
                 "io.mantisrx:mantis-server-worker",
                 "io.mantisrx:mantis-shaded"
             ],
@@ -1009,6 +1042,9 @@
             "locked": "1.0"
         },
         "net.lingala.zip4j:zip4j": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "locked": "2.9.0"
         },
         "nz.ac.waikato.cms.moa:moa": {
@@ -1036,6 +1072,9 @@
             "locked": "1.14.2"
         },
         "org.apache.hadoop:hadoop-common": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-agent"
+            ],
             "locked": "2.7.7"
         },
         "org.apache.httpcomponents:httpclient": {
@@ -1089,6 +1128,7 @@
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime",
+                "io.mantisrx:mantis-server-agent",
                 "io.mantisrx:mantis-server-worker"
             ],
             "locked": "1.7.36"
@@ -1097,6 +1137,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
                 "io.mantisrx:mantis-remote-observable",
+                "io.mantisrx:mantis-server-agent",
                 "io.mantisrx:mantis-server-worker"
             ],
             "locked": "1.7.10"
@@ -1105,7 +1146,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-server/mantis-server-worker-client/dependencies.lock
+++ b/mantis-server/mantis-server-worker-client/dependencies.lock
@@ -28,6 +28,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -104,12 +110,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -165,7 +165,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -179,6 +179,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -293,12 +299,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -359,7 +359,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -373,6 +373,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "1.3.10"
@@ -454,12 +460,6 @@
             "locked": "4.11"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -526,7 +526,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -535,6 +535,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -653,12 +659,6 @@
             "locked": "1.0"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -730,7 +730,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-server/mantis-server-worker/dependencies.lock
+++ b/mantis-server/mantis-server-worker/dependencies.lock
@@ -40,6 +40,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -117,12 +123,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -181,7 +181,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -190,6 +190,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "1.3.10"
@@ -320,12 +326,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -385,7 +385,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -400,6 +400,12 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-remote-observable"
@@ -573,12 +579,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -645,13 +645,13 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-server-agent"
             ],
-            "locked": "1.7.0"
+            "locked": "1.7.10"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -665,6 +665,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "1.3.10"
@@ -801,12 +807,6 @@
             "locked": "2017.06"
         },
         "org.apache.flink:flink-core": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
-        "org.apache.flink:flink-rpc-akka": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
@@ -877,7 +877,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -886,6 +886,12 @@
                 "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -1149,13 +1155,13 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-server-agent"
             ],
-            "locked": "1.7.0"
+            "locked": "1.7.10"
         },
         "org.xerial.snappy:snappy-java": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-source-jobs/mantis-source-job-kafka/dependencies.lock
+++ b/mantis-source-jobs/mantis-source-job-kafka/dependencies.lock
@@ -9,13 +9,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -130,7 +130,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "compileClasspath": {
@@ -138,13 +138,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -262,7 +262,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -275,13 +275,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -431,7 +431,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -444,13 +444,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -568,7 +568,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -576,13 +576,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -732,7 +732,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }

--- a/mantis-source-jobs/mantis-source-job-publish/dependencies.lock
+++ b/mantis-source-jobs/mantis-source-job-publish/dependencies.lock
@@ -11,11 +11,17 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -132,12 +138,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -191,7 +191,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -215,11 +215,17 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -336,12 +342,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -398,7 +398,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "lombok": {
@@ -413,18 +413,24 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -436,14 +442,14 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -593,12 +599,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -656,7 +656,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testAnnotationProcessor": {
@@ -671,11 +671,17 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -792,12 +798,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -866,7 +866,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     },
     "testRuntimeClasspath": {
@@ -876,18 +876,24 @@
             ],
             "locked": "1.1.1"
         },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "3.0.1"
+        },
         "com.netflix.archaius:archaius2-api": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.18"
+            "locked": "2.3.19"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -899,14 +905,14 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "1.5.2"
+            "locked": "1.5.4"
         },
         "com.netflix:mantis-rxnetty": {
             "firstLevelTransitive": [
@@ -1056,12 +1062,6 @@
             ],
             "locked": "1.14.2"
         },
-        "org.apache.flink:flink-rpc-akka": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-control-plane-core"
-            ],
-            "locked": "1.14.2"
-        },
         "org.apache.flink:flink-rpc-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -1131,7 +1131,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.9.0"
+            "locked": "1.1.9.1"
         }
     }
 }


### PR DESCRIPTION
### Context

Before this change, `flink-rpc-akka` (which shades but doesn't relocate scala) would be leaked onto Mantis applications classpath causing version conflicts with different versions of scala required to run application code. The following is a runtime error of one of our apps which relies on scala 2.13 that conflicts with flink-rpc-akka scala 2.12:

```
***************************
APPLICATION FAILED TO START
***************************

Description:

An attempt was made to call a method that does not exist. The attempt was made from the following location:

    akka.remote.serialization.MiscMessageSerializer.<init>(MiscMessageSerializer.scala:32)

The following method did not exist:

    scala.reflect.ClassTag$.Byte()Lscala/reflect/ClassTag;

The calling method's class, akka.remote.serialization.MiscMessageSerializer, was loaded from the following location:

    jar:file:/data/mantisrc_sbn1/temp/mantis-artifacts/nfmantis-runtime-spring-boot-1.530.2-snapshot.202302062142+2439a29.zip-unzipped/nfmantis-runtime-spring-boot-1.530.2-snapshot.202302062142+2439a29/lib/flink-rpc-akka-1.14.2.jar!/akka/remote/serialization/MiscMessageSerializer.class

The called method's class, scala.reflect.ClassTag$, is available from the following locations:

    jar:file:/data/mantisrc_sbn1/temp/mantis-artifacts/nfmantis-sources-lwc-source-spring-boot-thin-100.0.1.zip-unzipped/nfmantis-sources-lwc-source-spring-boot-thin-100.0.1/lib/scala-library-2.13.10.jar!/scala/reflect/ClassTag$.class
    jar:file:/data/mantisrc_sbn1/temp/mantis-artifacts/nfmantis-runtime-spring-boot-1.530.2-snapshot.202302062142+2439a29.zip-unzipped/nfmantis-runtime-spring-boot-1.530.2-snapshot.202302062142+2439a29/lib/flink-rpc-akka-1.14.2.jar!/scala/reflect/ClassTag$.class

The called method's class hierarchy was loaded from the following locations:

    scala.reflect.ClassTag$: file:/data/mantisrc_sbn1/temp/mantis-artifacts/nfmantis-sources-lwc-source-spring-boot-thin-100.0.1.zip-unzipped/nfmantis-sources-lwc-source-spring-boot-thin-100.0.1/lib/scala-library-2.13.10.jar


Action:

Correct the classpath of your application so that it contains compatible versions of the classes akka.remote.serialization.MiscMessageSerializer and scala.reflect.ClassTag$
```

The classloader has both scala versions on its classpath and doesn't know which one to use, so it picks the first one it encounters in the dependencies urls list).

### Solution

The solution proposed here mimics what Flink does with flink-rpc-akka lib. In particular:

* It removes flink-rpc-akka from the classpath 
* At build time, It simply copies flink-rpc-akka (and all its transitive deps, like scala and akka) into mantis-control-plane-core jar so it will still be available at runtime
* At startup, the TE instantiates a submodule classloader after moving the flink-rpc-akka jar into a separate location (for isolation). Note that this submodule classloader needs also visibility into mantis core code.

### Tests

Successfully tested on the same app it was failing before.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
