### PR TITLE
Support NotWritable timeout on SSE connection

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/MantisProperties.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/MantisProperties.java
@@ -28,17 +28,18 @@ public class MantisProperties {
         env = System.getenv();
     }
 
+    @Deprecated
     public static MantisProperties getInstance() {
         return instance;
     }
 
+    @Deprecated
+    /**
+     * Use {@link #getProperty(String)} instead.
+     */
     public String getStringValue(String name) {
         if (name != null) {
-            if (env.containsKey(name)) {
-                return getProperty(name, env.get(name));
-            } else {
-                return getProperty(name);
-            }
+            return getProperty(name, env.get(name));
         } else {
             return null;
         }
@@ -46,10 +47,13 @@ public class MantisProperties {
     }
 
     public static String getProperty(String key) {
-        return System.getProperty(key, System.getenv(key));
+        return getProperty(key, null);
     }
 
     public static String getProperty(String key, String defaultVal) {
+        if (key == null) {
+            return null;
+        }
         String value = System.getProperty(key);
         if (value != null) {
             return value;

--- a/mantis-common/src/main/java/io/mantisrx/common/MantisProperties.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/MantisProperties.java
@@ -33,8 +33,12 @@ public class MantisProperties {
     }
 
     public String getStringValue(String name) {
-        if (name != null && env.containsKey(name)) {
-            return System.getProperty(name, env.get(name));
+        if (name != null) {
+            if (env.containsKey(name)) {
+                return getProperty(name, env.get(name));
+            } else {
+                return getProperty(name);
+            }
         } else {
             return null;
         }

--- a/mantis-common/src/main/java/io/mantisrx/common/MantisProperties.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/MantisProperties.java
@@ -50,6 +50,14 @@ public class MantisProperties {
     }
 
     public static String getProperty(String key, String defaultVal) {
-        return System.getProperty(key, defaultVal);
+        String value = System.getProperty(key);
+        if (value != null) {
+            return value;
+        }
+        value = System.getenv(key);
+        if (value != null) {
+            return value;
+        }
+        return defaultVal;
     }
 }

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
@@ -269,23 +269,11 @@ public abstract class PushServer<T, R> {
             .addCounter("channelWritable")
             .addCounter("channelNotWritable")
             .addCounter("channelNotWritableTimeout")
-            .addCounter("channelActive")
-            .addCounter("channelNotActive")
-            .addCounter("channelOpen")
-            .addCounter("channelNotOpen")
-            .addCounter("channelRegistered")
-            .addCounter("channelNotRegistered")
             .build();
         metricsRegistry.registerAndGet(writableMetrics);
         Counter channelWritableCounter = writableMetrics.getCounter("channelWritable");
         Counter channelNotWritableCounter = writableMetrics.getCounter("channelNotWritable");
         Counter channelNotWritableTimeoutCounter = writableMetrics.getCounter("channelNotWritableTimeout");
-        Counter channelActiveCounter = writableMetrics.getCounter("channelActive");
-        Counter channelNotActiveCounter = writableMetrics.getCounter("channelNotActive");
-        Counter channelOpenCounter = writableMetrics.getCounter("channelOpen");
-        Counter channelNotOpenCounter = writableMetrics.getCounter("channelNotOpen");
-        Counter channelRegisteredCounter = writableMetrics.getCounter("channelRegistered");
-        Counter channelNotRegisteredCounter = writableMetrics.getCounter("channelNotRegistered");
 
         final Future<?> writableCheck;
         AtomicLong lastWritableTS = new AtomicLong(System.currentTimeMillis());
@@ -293,21 +281,6 @@ public abstract class PushServer<T, R> {
             writableCheck = scheduledExecutorService.scheduleAtFixedRate(
                 () -> {
                     long currentTime = System.currentTimeMillis();
-                    if (writer.getChannel().isActive()) {
-                        channelActiveCounter.increment();
-                    } else {
-                        channelNotActiveCounter.increment();
-                    }
-                    if (writer.getChannel().isOpen()) {
-                        channelOpenCounter.increment();
-                    } else {
-                        channelNotOpenCounter.increment();
-                    }
-                    if (writer.getChannel().isRegistered()) {
-                        channelRegisteredCounter.increment();
-                    } else {
-                        channelNotRegisteredCounter.increment();
-                    }
                     if (writer.getChannel().isWritable()) {
                         channelWritableCounter.increment();
                         lastWritableTS.set(currentTime);

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
@@ -263,6 +263,7 @@ public abstract class PushServer<T, R> {
                     );
         }
 
+        final BasicTag clientIdTag = new BasicTag(CLIENT_ID_TAG_NAME, Optional.ofNullable(groupId).orElse("none"));
         Metrics writableMetrics = new Metrics.Builder()
             .id("PushServer", clientIdTag)
             .addCounter("channelWritable")

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
@@ -27,6 +27,7 @@ import io.mantisrx.common.metrics.Gauge;
 import io.mantisrx.common.metrics.Metrics;
 import io.mantisrx.common.metrics.MetricsRegistry;
 import io.mantisrx.common.metrics.spectator.MetricGroupId;
+import io.mantisrx.shaded.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.Channel;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.reactivx.mantis.operators.DisableBackPressureOperator;
@@ -155,7 +156,8 @@ public abstract class PushServer<T, R> {
 
         port = config.getPort();
         writeRetryCount = config.getWriteRetryCount();
-        scheduledExecutorService = new ScheduledThreadPoolExecutor(10);
+        scheduledExecutorService = new ScheduledThreadPoolExecutor(10,
+            new ThreadFactoryBuilder().setNameFormat("netty-channel-checker-%d").build());
     }
 
     private void registerMetrics(MetricsRegistry registry, Metrics serverMetrics,
@@ -311,6 +313,7 @@ public abstract class PushServer<T, R> {
             public void operationComplete(io.netty.util.concurrent.Future<Void> future) throws Exception {
                 connectionManager.remove(connection);
                 connectionCleanup(heartbeatSubscription, connectionClosedCallback, metaMsgSubscription);
+                // Callback from the channel is closed, we don't need to check channel status anymore.
                 if (writableCheck != null) {
                     writableCheck.cancel(false);
                 }

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
@@ -263,17 +263,28 @@ public abstract class PushServer<T, R> {
                     );
         }
 
-        final BasicTag clientIdTag = new BasicTag(CLIENT_ID_TAG_NAME, Optional.ofNullable(groupId).orElse("none"));
         Metrics writableMetrics = new Metrics.Builder()
             .id("PushServer", clientIdTag)
             .addCounter("channelWritable")
             .addCounter("channelNotWritable")
             .addCounter("channelNotWritableTimeout")
+            .addCounter("channelActive")
+            .addCounter("channelNotActive")
+            .addCounter("channelOpen")
+            .addCounter("channelNotOpen")
+            .addCounter("channelRegistered")
+            .addCounter("channelNotRegistered")
             .build();
         metricsRegistry.registerAndGet(writableMetrics);
         Counter channelWritableCounter = writableMetrics.getCounter("channelWritable");
         Counter channelNotWritableCounter = writableMetrics.getCounter("channelNotWritable");
         Counter channelNotWritableTimeoutCounter = writableMetrics.getCounter("channelNotWritableTimeout");
+        Counter channelActiveCounter = writableMetrics.getCounter("channelActive");
+        Counter channelNotActiveCounter = writableMetrics.getCounter("channelNotActive");
+        Counter channelOpenCounter = writableMetrics.getCounter("channelOpen");
+        Counter channelNotOpenCounter = writableMetrics.getCounter("channelNotOpen");
+        Counter channelRegisteredCounter = writableMetrics.getCounter("channelRegistered");
+        Counter channelNotRegisteredCounter = writableMetrics.getCounter("channelNotRegistered");
 
         final Future<?> writableCheck;
         AtomicLong lastWritableTS = new AtomicLong(System.currentTimeMillis());
@@ -281,6 +292,21 @@ public abstract class PushServer<T, R> {
             writableCheck = scheduledExecutorService.scheduleAtFixedRate(
                 () -> {
                     long currentTime = System.currentTimeMillis();
+                    if (writer.getChannel().isActive()) {
+                        channelActiveCounter.increment();
+                    } else {
+                        channelNotActiveCounter.increment();
+                    }
+                    if (writer.getChannel().isOpen()) {
+                        channelOpenCounter.increment();
+                    } else {
+                        channelNotOpenCounter.increment();
+                    }
+                    if (writer.getChannel().isRegistered()) {
+                        channelRegisteredCounter.increment();
+                    } else {
+                        channelNotRegisteredCounter.increment();
+                    }
                     if (writer.getChannel().isWritable()) {
                         channelWritableCounter.increment();
                         lastWritableTS.set(currentTime);

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/ServerConfig.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/ServerConfig.java
@@ -31,6 +31,7 @@ public class ServerConfig<T> {
     private int writeRetryCount = 2; // num retries before fail to write
     private int maxChunkSize = 25;  // max items to read from queue, for a single chunk
     private int maxChunkTimeMSec = 100; // max time to read from queue, for a single chunk
+    private int maxNotWritableTimeSec = -1; // max time the channel can stay not writable, <= 0 means unlimited
     private ChunkProcessor<T> chunkProcessor; // logic to process chunk
     private MetricsRegistry metricsRegistry; // registry used to store metrics
     private Func1<Map<String, List<String>>, Func1<T, Boolean>> predicate;
@@ -48,6 +49,7 @@ public class ServerConfig<T> {
         this.numQueueConsumers = builder.numQueueConsumers;
         this.predicate = builder.predicate;
         this.useSpscQueue = builder.useSpscQueue;
+        this.maxNotWritableTimeSec = builder.maxNotWritableTimeSec;
     }
 
     public Func1<Map<String, List<String>>, Func1<T, Boolean>> getPredicate() {
@@ -82,6 +84,10 @@ public class ServerConfig<T> {
         return maxChunkTimeMSec;
     }
 
+    public int getMaxNotWritableTimeSec() {
+        return maxNotWritableTimeSec;
+    }
+
     public ChunkProcessor<T> getChunkProcessor() {
         return chunkProcessor;
     }
@@ -103,6 +109,7 @@ public class ServerConfig<T> {
         private int writeRetryCount = 2; // num retries before fail to write
         private int maxChunkSize = 25;  // max items to read from queue, for a single chunk
         private int maxChunkTimeMSec = 100; // max time to read from queue, for a single chunk
+        private int maxNotWritableTimeSec = -1; // max time the channel can stay not writable, <= 0 means unlimited
         private ChunkProcessor<T> chunkProcessor; // logic to process chunk
         private MetricsRegistry metricsRegistry; // registry used to store metrics
         private Func1<Map<String, List<String>>, Func1<T, Boolean>> predicate;
@@ -150,6 +157,11 @@ public class ServerConfig<T> {
 
         public Builder<T> maxChunkTimeMSec(int maxChunkTimeMSec) {
             this.maxChunkTimeMSec = maxChunkTimeMSec;
+            return this;
+        }
+
+        public Builder<T> maxNotWritableTimeSec(int maxNotWritableTimeSec) {
+            this.maxNotWritableTimeSec = maxNotWritableTimeSec;
             return this;
         }
 

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/ParameterUtils.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/ParameterUtils.java
@@ -144,6 +144,16 @@ public class ParameterUtils {
                 .build();
         systemParams.put(sse_numConsumerThreads.getName(), sse_numConsumerThreads);
 
+        // mantis.sse.maxNotWritableTimeSec", "-1"
+
+        ParameterDefinition<Integer> maxNotWritableTimeSec = new IntParameter()
+            .name("mantis.sse.maxNotWritableTimeSec")
+            .validator(Validators.range(-1, 100000))
+            .description("maximum time the SSE connection can remain not writable before we proactively terminated it on server side. <= 0 means unlimited.")
+            .defaultValue(-1)
+            .build();
+        systemParams.put(maxNotWritableTimeSec.getName(), maxNotWritableTimeSec);
+
         // mantis.jobmaster.autoscale.metric
         ParameterDefinition<String> jobMasterAutoScaleMetric = new StringParameter()
                 .name(JOB_MASTER_AUTOSCALE_METRIC_SYSTEM_PARAM)

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/sink/ServerSentEventsSink.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/sink/ServerSentEventsSink.java
@@ -64,8 +64,8 @@ public class ServerSentEventsSink<T> implements SelfDocumentingSink<T> {
     }
 
     ServerSentEventsSink(Func1<T, String> encoder,
-        Func1<Throwable, String> errorEncoder,
-        Predicate<T> predicate) {
+                         Func1<Throwable, String> errorEncoder,
+                         Predicate<T> predicate) {
         if (errorEncoder == null) {
             // default
             errorEncoder = Throwable::getMessage;
@@ -127,6 +127,11 @@ public class ServerSentEventsSink<T> implements SelfDocumentingSink<T> {
         return Integer.parseInt(maxChunkSize);
     }
 
+    private int maxNotWritableTimeSec() {
+        String maxNotWritableTimeSec = propService.getStringValue("mantis.sse.maxNotWritableTimeSec", "-1");
+        return Integer.parseInt(maxNotWritableTimeSec);
+    }
+
     private int bufferCapacity() {
         String bufferCapacityString = propService.getStringValue("mantis.sse.bufferCapacity", "25000");
         return Integer.parseInt(bufferCapacityString);
@@ -154,7 +159,8 @@ public class ServerSentEventsSink<T> implements SelfDocumentingSink<T> {
                 .bufferCapacity(bufferCapacity())
                 .numQueueConsumers(numConsumerThreads())
                 .useSpscQueue(useSpsc())
-                .maxChunkTimeMSec(getBatchInterval());
+                .maxChunkTimeMSec(getBatchInterval())
+                .maxNotWritableTimeSec(maxNotWritableTimeSec());
             if (predicate != null) {
                 config.predicate(predicate.getPredicate());
             }


### PR DESCRIPTION
### Context

This is an attempt to mitigate the stale connection issue from SSE server side. From observation, a stale connection is still reported as `active` but NOT `writable`. Therefore, we can allow the server to close the connection proactively if the channel remains not writable for an configurable amount of time.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
