### PR TITLE
Close RpcSystem on TE shutdown

### DIFF
--- a/mantis-client/dependencies.lock
+++ b/mantis-client/dependencies.lock
@@ -107,7 +107,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -285,7 +285,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -387,7 +387,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -492,7 +493,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -678,7 +679,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -784,7 +785,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -889,7 +891,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"

--- a/mantis-connectors/mantis-connector-job/dependencies.lock
+++ b/mantis-connectors/mantis-connector-job/dependencies.lock
@@ -18,7 +18,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -121,7 +121,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -199,7 +199,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -302,7 +302,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -388,13 +388,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -429,7 +429,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -556,7 +557,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -655,7 +656,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -758,7 +759,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -839,13 +840,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -880,7 +881,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -1007,7 +1009,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [

--- a/mantis-connectors/mantis-connector-kafka/dependencies.lock
+++ b/mantis-connectors/mantis-connector-kafka/dependencies.lock
@@ -118,10 +118,10 @@
     },
     "compileClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.82.0"
@@ -236,10 +236,10 @@
     },
     "runtimeClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -362,7 +362,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.25"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
@@ -388,10 +388,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.82.0"
@@ -513,10 +513,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -648,7 +648,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.25"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [

--- a/mantis-connectors/mantis-connector-publish/dependencies.lock
+++ b/mantis-connectors/mantis-connector-publish/dependencies.lock
@@ -124,7 +124,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -221,7 +221,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -304,13 +304,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -338,7 +338,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -441,7 +442,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -498,7 +499,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
@@ -530,7 +531,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -627,7 +628,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -714,13 +715,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -748,7 +749,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -851,7 +853,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -917,7 +919,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.32"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [

--- a/mantis-control-plane/mantis-control-plane-client/dependencies.lock
+++ b/mantis-control-plane/mantis-control-plane-client/dependencies.lock
@@ -168,7 +168,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -266,7 +266,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -336,7 +337,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -488,7 +489,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -593,7 +594,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -664,7 +666,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"

--- a/mantis-control-plane/mantis-control-plane-core/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-core/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     api "org.skife.config:config-magic:$configMagicVersion"
     api libraries.flinkRpcApi
     api libraries.flinkCore
+    implementation libraries.commonsIo
     compileOnly libraries.jsr305
     compileOnly libraries.flinkRpcImpl // Provided by copyLibs task
 

--- a/mantis-control-plane/mantis-control-plane-core/dependencies.lock
+++ b/mantis-control-plane/mantis-control-plane-core/dependencies.lock
@@ -4,6 +4,11 @@
             "locked": "1.18.20"
         }
     },
+    "baseline-exact-dependencies-main": {
+        "commons-io:commons-io": {
+            "locked": "2.11.0"
+        }
+    },
     "baseline-exact-dependencies-test": {
         "com.github.spullara.cli-parser:cli-parser": {
             "firstLevelTransitive": [
@@ -70,7 +75,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -160,6 +165,9 @@
             ],
             "locked": "0.4.19.1"
         },
+        "commons-io:commons-io": {
+            "locked": "2.11.0"
+        },
         "io.mantisrx:mantis-common": {
             "project": true
         },
@@ -201,7 +209,7 @@
             "locked": "1.3.8"
         },
         "joda-time:joda-time": {
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "locked": "1.14.2"
@@ -320,7 +328,7 @@
             "locked": "0.9.2"
         },
         "joda-time:joda-time": {
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -389,6 +397,9 @@
             ],
             "locked": "0.4.19.1"
         },
+        "commons-io:commons-io": {
+            "locked": "2.11.0"
+        },
         "io.mantisrx:mantis-common": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -442,7 +453,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -585,7 +596,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -669,7 +680,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -729,7 +741,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -816,7 +828,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -879,7 +892,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CleanupOnCloseRpcSystem.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CleanupOnCloseRpcSystem.java
@@ -44,6 +44,7 @@ class CleanupOnCloseRpcSystem implements RpcSystem {
 
     @Override
     public void close() {
+        log.info("Closing MantisAkkaRpcSystemLoader.");
         rpcSystem.close();
 
         try {

--- a/mantis-control-plane/mantis-control-plane-server/dependencies.lock
+++ b/mantis-control-plane/mantis-control-plane-server/dependencies.lock
@@ -85,7 +85,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -253,7 +253,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -366,7 +366,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -429,7 +430,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -609,7 +610,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -735,7 +736,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -802,7 +804,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"

--- a/mantis-examples/mantis-examples-mantis-publish-sample/dependencies.lock
+++ b/mantis-examples/mantis-examples-mantis-publish-sample/dependencies.lock
@@ -12,13 +12,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -71,13 +71,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -141,7 +141,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
@@ -149,13 +149,13 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -261,13 +261,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -326,7 +326,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
@@ -334,13 +334,13 @@
                 "io.mantisrx:mantis-publish-netty",
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-netty-guice"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/mantis-publish/mantis-publish-core/dependencies.lock
+++ b/mantis-publish/mantis-publish-core/dependencies.lock
@@ -6,7 +6,7 @@
     },
     "baseline-exact-dependencies-main": {
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "locked": "0.134.0"
@@ -24,7 +24,7 @@
             "locked": "3.2.2"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.2"
+            "locked": "1.7.0"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -52,10 +52,10 @@
     },
     "compileClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -83,7 +83,7 @@
             "locked": "1.18.20"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.2"
+            "locked": "1.7.0"
         }
     },
     "lombok": {
@@ -93,10 +93,10 @@
     },
     "runtimeClasspath": {
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -127,7 +127,7 @@
             "locked": "0.9.2"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.32"
+            "locked": "1.7.36"
         }
     },
     "testAnnotationProcessor": {
@@ -140,10 +140,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -197,10 +197,10 @@
             "locked": "2.21.0"
         },
         "com.netflix.archaius:archaius2-api": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "locked": "0.134.0"
@@ -246,7 +246,7 @@
             "locked": "2.0.111-beta"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.32"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "locked": "1.7.0"

--- a/mantis-publish/mantis-publish-netty-guice/dependencies.lock
+++ b/mantis-publish/mantis-publish-netty-guice/dependencies.lock
@@ -9,10 +9,10 @@
             "locked": "4.2.2"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-ext-ipc": {
             "locked": "0.96.0"
@@ -52,13 +52,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -110,17 +110,17 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -205,13 +205,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -273,17 +273,17 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-guice": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/mantis-publish/mantis-publish-netty/dependencies.lock
+++ b/mantis-publish/mantis-publish-netty/dependencies.lock
@@ -9,10 +9,10 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -42,7 +42,7 @@
             "locked": "4.1.34.Final"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.2"
+            "locked": "1.7.0"
         }
     },
     "baseline-exact-dependencies-test": {
@@ -67,10 +67,10 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -103,7 +103,7 @@
             "locked": "1.18.20"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.2"
+            "locked": "1.7.0"
         }
     },
     "lombok": {
@@ -116,13 +116,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -190,10 +190,10 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -238,7 +238,7 @@
             "locked": "1.18.20"
         },
         "org.slf4j:slf4j-api": {
-            "locked": "1.7.2"
+            "locked": "1.7.0"
         },
         "org.slf4j:slf4j-log4j12": {
             "locked": "1.7.0"
@@ -249,13 +249,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [

--- a/mantis-runtime-loader/dependencies.lock
+++ b/mantis-runtime-loader/dependencies.lock
@@ -163,7 +163,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -261,7 +261,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -340,7 +341,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -498,7 +499,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -600,7 +601,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -680,7 +682,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"

--- a/mantis-server/mantis-server-agent/dependencies.lock
+++ b/mantis-server/mantis-server-agent/dependencies.lock
@@ -152,7 +152,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -320,7 +320,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.lingala.zip4j:zip4j": {
             "locked": "2.9.0"
@@ -424,7 +424,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -514,7 +515,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -736,7 +737,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -859,6 +860,7 @@
         "commons-io:commons-io": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core",
                 "io.mantisrx:mantis-server-agent"
             ],
             "locked": "2.11.0"
@@ -997,7 +999,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutorStarter.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutorStarter.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.rpc.RpcUtils;
 public class TaskExecutorStarter extends AbstractIdleService {
     private final TaskExecutor taskExecutor;
     private final HighAvailabilityServices highAvailabilityServices;
+    private final RpcSystem rpcSystem;
 
     @Override
     protected void startUp() {
@@ -68,6 +69,7 @@ public class TaskExecutorStarter extends AbstractIdleService {
             .exceptionally(throwable -> null)
             .thenCompose(dontCare -> Services.stopAsync(highAvailabilityServices,
                 MoreExecutors.directExecutor()))
+            .thenRunAsync(rpcSystem::close)
             .get();
     }
 
@@ -193,7 +195,7 @@ public class TaskExecutorStarter extends AbstractIdleService {
                 taskExecutor.addListener(listener._1(), listener._2());
             }
 
-            return new TaskExecutorStarter(taskExecutor, highAvailabilityServices);
+            return new TaskExecutorStarter(taskExecutor, highAvailabilityServices, getRpcSystem());
         }
     }
 }

--- a/mantis-server/mantis-server-worker-client/dependencies.lock
+++ b/mantis-server/mantis-server-worker-client/dependencies.lock
@@ -96,7 +96,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -194,7 +194,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -273,7 +274,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -433,7 +434,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -541,7 +542,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -620,7 +622,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"

--- a/mantis-server/mantis-server-worker/dependencies.lock
+++ b/mantis-server/mantis-server-worker/dependencies.lock
@@ -103,7 +103,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -303,7 +303,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "nz.ac.waikato.cms.moa:moa": {
             "locked": "2017.06"
@@ -416,6 +416,7 @@
         "commons-io:commons-io": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core",
                 "io.mantisrx:mantis-server-agent"
             ],
             "locked": "2.11.0"
@@ -538,7 +539,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -771,7 +772,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"
@@ -891,6 +892,7 @@
         "commons-io:commons-io": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core",
                 "io.mantisrx:mantis-server-agent"
             ],
             "locked": "2.11.0"
@@ -1018,7 +1020,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "junit:junit": {
             "locked": "4.11"

--- a/mantis-source-jobs/mantis-source-job-kafka/dependencies.lock
+++ b/mantis-source-jobs/mantis-source-job-kafka/dependencies.lock
@@ -9,13 +9,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -138,13 +138,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -275,13 +275,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -418,7 +418,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.25"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [
@@ -444,13 +444,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -576,13 +576,13 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-connector-kafka"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -719,7 +719,7 @@
                 "io.mantisrx:mantis-remote-observable",
                 "io.mantisrx:mantis-runtime"
             ],
-            "locked": "1.7.25"
+            "locked": "1.7.36"
         },
         "org.slf4j:slf4j-log4j12": {
             "firstLevelTransitive": [

--- a/mantis-source-jobs/mantis-source-job-publish/dependencies.lock
+++ b/mantis-source-jobs/mantis-source-job-publish/dependencies.lock
@@ -15,7 +15,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -124,7 +124,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -213,7 +213,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -322,7 +322,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -405,14 +405,14 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -441,7 +441,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -567,7 +568,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [
@@ -657,7 +658,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.spectator:spectator-api": {
             "firstLevelTransitive": [
@@ -766,7 +767,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -856,14 +857,14 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.archaius:archaius2-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-publish-core",
                 "io.mantisrx:mantis-publish-netty"
             ],
-            "locked": "2.3.19"
+            "locked": "2.3.20"
         },
         "com.netflix.rxjava:rxjava-math": {
             "firstLevelTransitive": [
@@ -892,7 +893,8 @@
         },
         "commons-io:commons-io": {
             "firstLevelTransitive": [
-                "io.mantisrx:mantis-common"
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
             ],
             "locked": "2.11.0"
         },
@@ -1018,7 +1020,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
             ],
-            "locked": "2.12.2"
+            "locked": "2.12.4"
         },
         "net.jcip:jcip-annotations": {
             "firstLevelTransitive": [


### PR DESCRIPTION
### Context

This PR aims to cleanup the temp folder where flink-rpc-akka jar is stored by `MantisAkkaRpcSystemLoader`. Both graceful and abrupt shutdown should be covered.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
