### PR TITLE
Updated build.gradle to allow mantis-common-serde to be compiled using JDK 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -146,6 +146,19 @@ subprojects {
         options.compilerArgs << "-Xlint:deprecation"
     }
 
+    if(JavaVersion.current() != JavaVersion.VERSION_1_8) {
+        targetCompatibility = JavaVersion.VERSION_17
+        tasks.withType(JavaCompile) {
+            options.compilerArgs += [
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED',
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED',
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED',
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED'
+            ]
+        }
+    }
+
     project.plugins.withType(MavenPublishPlugin) {
         def printReleasedArtifact = project.tasks.create('printReleasedArtifact')
         printReleasedArtifact.doLast {


### PR DESCRIPTION
### Context

Upgrade JDK version to 17. This PR upgrades the `mantis-common-serde` module.
Part of #355 

- When using JDK 17, the gradle build process fails since `spotlessJava` fails. This is because `google-java-format` is broken on JDK 16+, and we use this package indirectly while formatting the code.
- The reason for the error is because a few packages that `google-java-format` uses are not exported by the JDK from JDK 16 onwards. 
- A work around for this has been proposed [here](https://github.com/diffplug/spotless/issues/834#issuecomment-819118761) which I've implemented on the build.gradle file. 
- Since this workaround specifically targets JDK 16+, the build process fails when compiling the whole project using JDK 8, when we run `./gradlew build`. Therefore, to ensure the flags are added only when target is JDK 17, `if(JavaVersion.current() != JavaVersion.VERSION_1_8)` has been created inside of which we add the required workaround flags.

### Screenshot of successful building of `mantis-common-serde` module using JDK 17
<img width="1426" alt="Screenshot 2023-03-29 at 3 30 29 PM" src="https://user-images.githubusercontent.com/56926966/228503615-7670f93e-d1b8-4d4f-aa63-3c969b1e6f59.png">



### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
