### PR TITLE
Jdk migration of mantis-common to compile on JDK 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,19 @@ subprojects {
         options.compilerArgs << "-Xlint:deprecation"
     }
 
+    if(JavaVersion.current() != JavaVersion.VERSION_1_8) {
+        targetCompatibility = JavaVersion.VERSION_17
+        tasks.withType(JavaCompile) {
+            options.compilerArgs += [
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED',
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED',
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED',
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED',
+                '--add-exports', 'jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED'
+            ]
+        }
+    }
+
     project.plugins.withType(MavenPublishPlugin) {
         def printReleasedArtifact = project.tasks.create('printReleasedArtifact')
         printReleasedArtifact.doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ ext.versions = [
         jsr305   : "3.0.1",
         junit4   : "4.11",
         junit5   : "5.4.+",
-        mockito  : "2.0.+",
+        mockito  : "2.23.4",
         mockito3 : "3.+",
         spectator: "1.3.+",
         slf4j    : "1.7.0",
@@ -102,7 +102,7 @@ subprojects {
     apply plugin: "io.freefair.lombok"
     generateLombokConfig.enabled = false
     lombok {
-        version = "1.18.20"
+        version = "1.18.22"
     }
 
     group = 'io.mantisrx'

--- a/mantis-common-serde/dependencies.lock
+++ b/mantis-common-serde/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         }
     },
     "compileClasspath": {
@@ -9,12 +9,12 @@
             "project": true
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         }
     },
     "lombok": {
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         }
     },
     "runtimeClasspath": {
@@ -30,7 +30,7 @@
     },
     "testAnnotationProcessor": {
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         }
     },
     "testCompileClasspath": {
@@ -38,7 +38,7 @@
             "project": true
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         }
     },
     "testRuntimeClasspath": {

--- a/mantis-common/dependencies.lock
+++ b/mantis-common/dependencies.lock
@@ -1,7 +1,7 @@
 {
     "annotationProcessor": {
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         }
     },
     "baseline-exact-dependencies-main": {
@@ -90,7 +90,7 @@
             "locked": "1.2.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "2.0.111-beta"
+            "locked": "2.23.4"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -152,7 +152,7 @@
             "locked": "1.2.1"
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.6"
@@ -166,7 +166,7 @@
     },
     "lombok": {
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         }
     },
     "runtimeClasspath": {
@@ -224,7 +224,7 @@
     },
     "testAnnotationProcessor": {
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         }
     },
     "testCompileClasspath": {
@@ -311,10 +311,10 @@
             "locked": "1.2.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "2.0.111-beta"
+            "locked": "2.23.4"
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -337,7 +337,7 @@
     },
     "testFixturesAnnotationProcessor": {
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         }
     },
     "testFixturesCompileClasspath": {
@@ -400,7 +400,7 @@
             "locked": "1.2.1"
         },
         "org.projectlombok:lombok": {
-            "locked": "1.18.20"
+            "locked": "1.18.22"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [
@@ -613,7 +613,7 @@
             "locked": "1.2.1"
         },
         "org.mockito:mockito-core": {
-            "locked": "2.0.111-beta"
+            "locked": "2.23.4"
         },
         "org.slf4j:slf4j-api": {
             "firstLevelTransitive": [


### PR DESCRIPTION
### Context

Upgrade JDK version to 17. This PR upgrades the mantis-common module.
Part of https://github.com/Netflix/mantis/issues/355

- `../gradlew build` in the `mantis-common` module fails `org.mockito.exceptions.base.MockitoException at OperatorGroupByTest.java:1039 Caused by: java.lang.reflect.InaccessibleObjectException at OperatorGroupByTest.java` error.
- The reason for the error is using a version of the `Mockito` package not supported by JDK 17.
- Therefore, updated the dependency from `2.0.+` to `2.23.4` which solves this problem.

Attaching screenshot of success build of the `mantis-common` module using JDK 17.
<img width="1425" alt="image" src="https://user-images.githubusercontent.com/56926966/228659072-b5ca0b89-59a6-4a05-8341-fc52a8c2799a.png">

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
