### PR TITLE
Upgrade API: add forceUpgradeOnSameImage flag

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
@@ -34,4 +34,6 @@ public class UpgradeClusterContainersRequest {
     MantisResourceClusterEnvType optionalEnvType;
 
     int optionalBatchMaxSize;
+
+    boolean forceUpgradeOnSameImage;
 }


### PR DESCRIPTION
### Context

Add a flag in upgrade cluster API to support skipping on existing containers on the target image id.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
