### PR TITLE
Ensure JobActor has JobID as part of every emitted log line #384

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -77,6 +77,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import rx.Observable;
 import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
@@ -236,6 +237,7 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
      * @throws InvalidJobException
      */
     void initialize(boolean isSubmit) throws Exception {
+        MDC.put("jobId", jobId.toString());
         LOGGER.info("Initializing Job {}", jobId);
 
         if (isSubmit) {
@@ -1758,6 +1760,7 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
             jobSchedulingInfoBehaviorSubject.onCompleted();
 
             LOGGER.trace("Exit shutdown for Job {}", jobId);
+            MDC.remove("jobId");
         }
 
         private void terminateAllWorkersAsync() {

--- a/mantis-control-plane/mantis-control-plane-server/src/test/resources/log4j.properties
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/resources/log4j.properties
@@ -21,6 +21,6 @@ log4j.rootLogger=INFO, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %-5p [%t] %c{1}:%L - %m %X{akkaSource}%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %X{jobId} %-5p [%t] %c{1}:%L - %m %X{akkaSource}%n
 
 log4j.logger.com.netflix.fenzo=INFO


### PR DESCRIPTION
### Context

Logger adds the jobID to every emitted logline by default.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
