### PR TITLE
Fix unexpected worker resubmission from out of order start signals

### DIFF
--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RunningWorker.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RunningWorker.java
@@ -136,7 +136,7 @@ public class RunningWorker {
         requestSubject.onNext(true);
         requestSubject.onCompleted();
         jobStatus.onNext(new Status(jobId, stageNum, workerIndex, workerNum
-                , TYPE.DEBUG, "Beginning job execution " +
+                , TYPE.INFO, "Beginning job execution " +
                 workerIndex, MantisJobState.StartInitiated));
     }
 

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/WorkerExecutionOperationsNetworkStage.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/WorkerExecutionOperationsNetworkStage.java
@@ -499,7 +499,8 @@ public class WorkerExecutionOperationsNetworkStage implements WorkerExecutionOpe
 
             if (rw.getStageNum() == rw.getTotalStagesNet()) {
                 // last+sink stage
-                logger.info("JobId: " + rw.getJobId() + ", executing sink stage: " + rw.getStageNum());
+                logger.info(
+                    "JobId: {}, executing sink stage: {}, signaling started", rw.getJobId(), rw.getStageNum());
                 rw.getJobStatus().onNext(new Status(rw.getJobId(), rw.getStageNum(), rw.getWorkerIndex(),
                         rw.getWorkerNum(),
                         TYPE.INFO, getWorkerStringPrefix(rw.getStageNum(), rw.getWorkerIndex(), rw.getWorkerNum()) + " running",


### PR DESCRIPTION
### Context

[User reported issue]
Some job nodes (mainly from non-source stage nodes) can produce out-of-order started -> start initiated signal sequence and cause unexpected node resubmission repeatedly.

Update the logic so that invalid state transition errors will only be warnings.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
