### PR TITLE
Exclude disabled TE in resource cluster usage

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
@@ -251,6 +251,11 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager{
                 return;
             }
 
+            // do not count the disabled TEs.
+            if (value.isDisabled()) {
+                return;
+            }
+
             Optional<String> groupKeyO =
                 req.getGroupKeyFunc().apply(value.getRegistration());
 


### PR DESCRIPTION
### Context

Disabled TEs are counted in cluster usages, which causes scaler not to respond properly when there are disabled TEs.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
