### PR TITLE
Make SchedulingInfo builder method naming consistent

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/SchedulingInfo.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/SchedulingInfo.java
@@ -83,7 +83,7 @@ public class SchedulingInfo implements Serializable {
             return this;
         }
 
-        public Builder singleWorkerStageWithConstraints(
+        public Builder addStageWithConstraints(
                 MachineDefinition machineDefinition,
                 List<JobConstraints> hardConstraints,
                 List<JobConstraints> softConstraints) {
@@ -96,7 +96,7 @@ public class SchedulingInfo implements Serializable {
                             .build());
         }
 
-        public Builder singleWorkerStageWithConstraints(
+        public Builder addStageWithConstraints(
             MachineDefinition machineDefinition,
             List<JobConstraints> hardConstraints,
             List<JobConstraints> softConstraints,
@@ -111,7 +111,7 @@ public class SchedulingInfo implements Serializable {
                     .build());
         }
 
-        public Builder singleWorkerStage(MachineDefinition machineDefinition) {
+        public Builder addStageWithMachineDefinition(MachineDefinition machineDefinition) {
             return this.addStage(
                     StageSchedulingInfo.builder()
                             .numberOfInstances(1)
@@ -119,7 +119,7 @@ public class SchedulingInfo implements Serializable {
                             .build());
         }
 
-        public Builder singleWorkerStage(MachineDefinition machineDefinition, Map<String, String> containerAttributes) {
+        public Builder addStageWithMachineDefinition(MachineDefinition machineDefinition, Map<String, String> containerAttributes) {
             return this.addStage(
                 StageSchedulingInfo.builder()
                     .numberOfInstances(1)
@@ -128,9 +128,9 @@ public class SchedulingInfo implements Serializable {
                     .build());
         }
 
-        public Builder multiWorkerScalableStageWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
-                                                               List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints,
-                                                               StageScalingPolicy scalingPolicy) {
+        public Builder addMultiScalableStagesWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
+                                                             List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints,
+                                                             StageScalingPolicy scalingPolicy) {
             StageScalingPolicy ssp = new StageScalingPolicy(currentStage, scalingPolicy.getMin(), scalingPolicy.getMax(),
                     scalingPolicy.getIncrement(), scalingPolicy.getDecrement(), scalingPolicy.getCoolDownSecs(), scalingPolicy.getStrategies());
             return this.addStage(
@@ -144,9 +144,9 @@ public class SchedulingInfo implements Serializable {
                             .build());
         }
 
-        public Builder multiWorkerScalableStageWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
-            List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints,
-            StageScalingPolicy scalingPolicy, Map<String, String> containerAttributes) {
+        public Builder addMultiScalableStagesWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
+                                                             List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints,
+                                                             StageScalingPolicy scalingPolicy, Map<String, String> containerAttributes) {
             StageScalingPolicy ssp = new StageScalingPolicy(currentStage, scalingPolicy.getMin(), scalingPolicy.getMax(),
                 scalingPolicy.getIncrement(), scalingPolicy.getDecrement(), scalingPolicy.getCoolDownSecs(), scalingPolicy.getStrategies());
             return this.addStage(
@@ -161,8 +161,8 @@ public class SchedulingInfo implements Serializable {
                     .build());
         }
 
-        public Builder multiWorkerStageWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
-                                                       List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints) {
+        public Builder addMultiStagesWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
+                                                     List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints) {
             return this.addStage(
                     StageSchedulingInfo.builder()
                             .numberOfInstances(numberOfWorkers)
@@ -172,8 +172,8 @@ public class SchedulingInfo implements Serializable {
                             .build());
         }
 
-        public Builder multiWorkerStageWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
-            List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints, Map<String, String> containerAttributes) {
+        public Builder addMultiStagesWithConstraints(int numberOfWorkers, MachineDefinition machineDefinition,
+                                                     List<JobConstraints> hardConstraints, List<JobConstraints> softConstraints, Map<String, String> containerAttributes) {
             return this.addStage(
                 StageSchedulingInfo.builder()
                     .numberOfInstances(numberOfWorkers)
@@ -184,16 +184,16 @@ public class SchedulingInfo implements Serializable {
                     .build());
         }
 
-        public Builder multiWorkerStage(int numberOfWorkers, MachineDefinition machineDefinition) {
-            return multiWorkerStage(numberOfWorkers, machineDefinition, false);
+        public Builder addMultiStages(int numberOfWorkers, MachineDefinition machineDefinition) {
+            return addMultiStages(numberOfWorkers, machineDefinition, false);
         }
 
-        public Builder multiWorkerStage(
+        public Builder addMultiStages(
             int numberOfWorkers, MachineDefinition machineDefinition, Map<String, String> containerAttributes) {
-            return multiWorkerStage(numberOfWorkers, machineDefinition, false, containerAttributes);
+            return addMultiStages(numberOfWorkers, machineDefinition, false, containerAttributes);
         }
 
-        public Builder multiWorkerStage(int numberOfWorkers, MachineDefinition machineDefinition, boolean scalable) {
+        public Builder addMultiStages(int numberOfWorkers, MachineDefinition machineDefinition, boolean scalable) {
             return this.addStage(
                     StageSchedulingInfo.builder()
                             .numberOfInstances(numberOfWorkers)
@@ -202,7 +202,7 @@ public class SchedulingInfo implements Serializable {
                             .build());
         }
 
-        public Builder multiWorkerStage(
+        public Builder addMultiStages(
             int numberOfWorkers, MachineDefinition machineDefinition, boolean scalable,
             Map<String, String> containerAttributes) {
             return this.addStage(

--- a/mantis-common/src/test/java/io/mantisrx/runtime/descriptor/SchedulingInfoTest.java
+++ b/mantis-common/src/test/java/io/mantisrx/runtime/descriptor/SchedulingInfoTest.java
@@ -149,13 +149,13 @@ public class SchedulingInfoTest {
         smap.put(StageScalingPolicy.ScalingReason.Memory, new StageScalingPolicy.Strategy(StageScalingPolicy.ScalingReason.Memory, 0.1, 0.6, null));
         Builder builder = new Builder()
             .numberOfStages(2)
-            .multiWorkerScalableStageWithConstraints(
+            .addMultiScalableStagesWithConstraints(
                 2,
                 new MachineDefinition(1, 1.24, 0.0, 1, 1),
                 null, null,
                 new StageScalingPolicy(1, 1, 3, 1, 1, 60, smap)
             )
-            .multiWorkerScalableStageWithConstraints(
+            .addMultiScalableStagesWithConstraints(
                 3,
                 new MachineDefinition(1, 1.24, 0.0, 1, 1),
                 null, null,
@@ -260,14 +260,14 @@ public class SchedulingInfoTest {
         smap.put(StageScalingPolicy.ScalingReason.Memory, new StageScalingPolicy.Strategy(StageScalingPolicy.ScalingReason.Memory, 0.1, 0.6, null));
         Builder builder = new Builder()
             .numberOfStages(2)
-            .multiWorkerScalableStageWithConstraints(
+            .addMultiScalableStagesWithConstraints(
                 2,
                 new MachineDefinition(1, 1.24, 0.0, 1, 1),
                 null, null,
                 new StageScalingPolicy(1, 1, 3, 1, 1, 60, smap),
                 ImmutableMap.of("containerSkuID", "sku1")
             )
-            .multiWorkerScalableStageWithConstraints(
+            .addMultiScalableStagesWithConstraints(
                 3,
                 new MachineDefinition(1, 1.24, 0.0, 1, 1),
                 null, null,

--- a/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/core/ExecuteStageRequestTest.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/core/ExecuteStageRequestTest.java
@@ -47,7 +47,7 @@ public class ExecuteStageRequestTest {
             ImmutableList.of(1, 2, 3, 4, 5), 100L, 1,
             ImmutableList.of(new Parameter("name", "value")),
             new SchedulingInfo.Builder().numberOfStages(1)
-                .singleWorkerStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2),
+                .addStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2),
                     Lists.newArrayList(), Lists.newArrayList()).build(),
             MantisJobDurationType.Perpetual,
             1000L,
@@ -60,7 +60,7 @@ public class ExecuteStageRequestTest {
             ImmutableList.of(1, 2, 3, 4, 5), 100L, 1,
             ImmutableList.of(new Parameter("name", "value")),
             new SchedulingInfo.Builder().numberOfStages(1)
-                .singleWorkerStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2),
+                .addStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2),
                     Lists.newArrayList(), Lists.newArrayList()).build(),
             MantisJobDurationType.Perpetual,
             1000L,

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/events/WorkerRegistryV2Test.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/events/WorkerRegistryV2Test.java
@@ -173,7 +173,7 @@ public class WorkerRegistryV2Test {
         smap.put(StageScalingPolicy.ScalingReason.DataDrop, new StageScalingPolicy.Strategy(StageScalingPolicy.ScalingReason.DataDrop, 0.0, 2.0, null));
         SchedulingInfo sInfo = new SchedulingInfo.Builder()
                 .numberOfStages(1)
-                .multiWorkerScalableStageWithConstraints(1,
+                .addMultiScalableStagesWithConstraints(1,
                         new MachineDefinition(1.0,1.0,1.0,3),
                         Lists.newArrayList(),
                         Lists.newArrayList(),
@@ -225,7 +225,7 @@ public class WorkerRegistryV2Test {
         smap.put(StageScalingPolicy.ScalingReason.DataDrop, new StageScalingPolicy.Strategy(StageScalingPolicy.ScalingReason.DataDrop, 0.0, 2.0, null));
         SchedulingInfo sInfo = new SchedulingInfo.Builder()
                 .numberOfStages(1)
-                .multiWorkerScalableStageWithConstraints(2,
+                .addMultiScalableStagesWithConstraints(2,
                         new MachineDefinition(1.0,1.0,1.0,3),
                         Lists.newArrayList(),
                         Lists.newArrayList(),
@@ -281,7 +281,7 @@ public class WorkerRegistryV2Test {
         smap.put(StageScalingPolicy.ScalingReason.DataDrop, new StageScalingPolicy.Strategy(StageScalingPolicy.ScalingReason.DataDrop, 0.0, 2.0, null));
         SchedulingInfo sInfo = new SchedulingInfo.Builder()
                 .numberOfStages(1)
-                .multiWorkerScalableStageWithConstraints(1,
+                .addMultiScalableStagesWithConstraints(1,
                         new MachineDefinition(1.0,1.0,1.0,3),
                         Lists.newArrayList(),
                         Lists.newArrayList(),

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterTest.java
@@ -149,8 +149,8 @@ public class JobClusterTest {
     public static final SLA NO_OP_SLA = new SLA(0, 0, null, null);
 
     public static final MachineDefinition DEFAULT_MACHINE_DEFINITION = new MachineDefinition(1, 10, 10, 10, 2);
-    public static final SchedulingInfo SINGLE_WORKER_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), Lists.newArrayList()).build();
-    public static final SchedulingInfo TWO_WORKER_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).multiWorkerStage(2, DEFAULT_MACHINE_DEFINITION).build();
+    public static final SchedulingInfo SINGLE_WORKER_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), Lists.newArrayList()).build();
+    public static final SchedulingInfo TWO_WORKER_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).addMultiStages(2, DEFAULT_MACHINE_DEFINITION).build();
     public static final JobOwner DEFAULT_JOB_OWNER = new JobOwner("Nick", "Mantis", "desc", "nma@netflix.com", "repo");
     final LifecycleEventPublisher lifecycleEventPublisher = new LifecycleEventPublisherImpl(new AuditEventSubscriberLoggingImpl(), new StatusEventSubscriberLoggingImpl(), new WorkerEventSubscriberLoggingImpl());
     static ActorSystem system;
@@ -1568,7 +1568,7 @@ public class JobClusterTest {
             final String jobId2 = clusterName + "-2";
             final SchedulingInfo schedulingInfo = new SchedulingInfo.Builder()
                     .numberOfStages(1)
-                    .multiWorkerStage(3, DEFAULT_MACHINE_DEFINITION)
+                    .addMultiStages(3, DEFAULT_MACHINE_DEFINITION)
                     .build();
             final JobDefinition jobDefn2Workers = createJob(clusterName, MantisJobDurationType.Transient, schedulingInfo);
             JobTestHelper.submitJobAndVerifySuccess(probe, clusterName, jobClusterActor, jobDefn2Workers, jobId2);
@@ -1620,7 +1620,7 @@ public class JobClusterTest {
             final String jobId2 = clusterName + "-2";
             final SchedulingInfo schedulingInfo = new SchedulingInfo.Builder()
                     .numberOfStages(1)
-                    .multiWorkerStage(3, DEFAULT_MACHINE_DEFINITION)
+                    .addMultiStages(3, DEFAULT_MACHINE_DEFINITION)
                     .build();
             final DeploymentStrategy deploymentStrategy = DeploymentStrategy.builder()
                     .stage(1, StageDeploymentStrategy.builder().inheritInstanceCount(true).build())
@@ -1661,10 +1661,10 @@ public class JobClusterTest {
         // default job with 3 stage == (2 worker)
         final SchedulingInfo schedulingInfo1 = new SchedulingInfo.Builder()
                 .numberOfStages(4)
-                .multiWorkerStage(2, DEFAULT_MACHINE_DEFINITION)
-                .multiWorkerStage(2, DEFAULT_MACHINE_DEFINITION)
-                .multiWorkerStage(2, DEFAULT_MACHINE_DEFINITION)
-                .multiWorkerStage(2, DEFAULT_MACHINE_DEFINITION)
+                .addMultiStages(2, DEFAULT_MACHINE_DEFINITION)
+                .addMultiStages(2, DEFAULT_MACHINE_DEFINITION)
+                .addMultiStages(2, DEFAULT_MACHINE_DEFINITION)
+                .addMultiStages(2, DEFAULT_MACHINE_DEFINITION)
                 .build();
         final JobClusterDefinitionImpl fakeJobCluster =
                 createFakeJobClusterDefn(clusterName, Lists.newArrayList(), NO_OP_SLA, schedulingInfo1);
@@ -1686,10 +1686,10 @@ public class JobClusterTest {
             final String jobId2 = clusterName + "-2";
             final SchedulingInfo schedulingInfo2 = new SchedulingInfo.Builder()
                     .numberOfStages(4)
-                    .multiWorkerStage(3, DEFAULT_MACHINE_DEFINITION)
-                    .multiWorkerStage(4, DEFAULT_MACHINE_DEFINITION)
-                    .multiWorkerStage(5, DEFAULT_MACHINE_DEFINITION)
-                    .multiWorkerStage(6, DEFAULT_MACHINE_DEFINITION)
+                    .addMultiStages(3, DEFAULT_MACHINE_DEFINITION)
+                    .addMultiStages(4, DEFAULT_MACHINE_DEFINITION)
+                    .addMultiStages(5, DEFAULT_MACHINE_DEFINITION)
+                    .addMultiStages(6, DEFAULT_MACHINE_DEFINITION)
                     .build();
             final DeploymentStrategy deploymentStrategy =  DeploymentStrategy.builder()
                     .stage(1, StageDeploymentStrategy.builder().inheritInstanceCount(true).build())
@@ -1739,8 +1739,8 @@ public class JobClusterTest {
         // default job with 3 stage == (2 worker)
         final SchedulingInfo schedulingInfo1 = new SchedulingInfo.Builder()
                 .numberOfStages(2)
-                .multiWorkerStage(1, DEFAULT_MACHINE_DEFINITION, true)
-                .multiWorkerStage(1, DEFAULT_MACHINE_DEFINITION, true)
+                .addMultiStages(1, DEFAULT_MACHINE_DEFINITION, true)
+                .addMultiStages(1, DEFAULT_MACHINE_DEFINITION, true)
                 .build();
         final JobClusterDefinitionImpl fakeJobCluster =
                 createFakeJobClusterDefn(clusterName, Lists.newArrayList(), NO_OP_SLA, schedulingInfo1);
@@ -1768,8 +1768,8 @@ public class JobClusterTest {
             final String jobId2 = clusterName + "-2";
             final SchedulingInfo schedulingInfo2 = new SchedulingInfo.Builder()
                     .numberOfStages(2)
-                    .multiWorkerStage(3, DEFAULT_MACHINE_DEFINITION)
-                    .multiWorkerStage(4, DEFAULT_MACHINE_DEFINITION)
+                    .addMultiStages(3, DEFAULT_MACHINE_DEFINITION)
+                    .addMultiStages(4, DEFAULT_MACHINE_DEFINITION)
                     .build();
             final DeploymentStrategy deploymentStrategy = DeploymentStrategy.builder()
                     .stage(1, StageDeploymentStrategy.builder().inheritInstanceCount(true).build())
@@ -2413,7 +2413,7 @@ public class JobClusterTest {
             smap.put(StageScalingPolicy.ScalingReason.DataDrop, new StageScalingPolicy.Strategy(StageScalingPolicy.ScalingReason.DataDrop, 0.0, 2.0, null));
 
             SchedulingInfo SINGLE_WORKER_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1)
-                    .multiWorkerScalableStageWithConstraints(1,DEFAULT_MACHINE_DEFINITION,Lists.newArrayList(),Lists.newArrayList(),new StageScalingPolicy(1,1,10,1,1,1, smap)).build();
+                    .addMultiScalableStagesWithConstraints(1,DEFAULT_MACHINE_DEFINITION,Lists.newArrayList(),Lists.newArrayList(),new StageScalingPolicy(1,1,10,1,1,1, smap)).build();
 
             final JobDefinition jobDefn = createJob(clusterName, 1, MantisJobDurationType.Transient, "USER_TYPE", SINGLE_WORKER_SCHED_INFO, Lists.newArrayList());
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobDefinitionResolverTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobDefinitionResolverTest.java
@@ -44,8 +44,8 @@ public class JobDefinitionResolverTest {
     public static final SLA NO_OP_SLA = new SLA(0, 0, null, null);
 
     public static final MachineDefinition DEFAULT_MACHINE_DEFINITION = new MachineDefinition(1, 10, 10, 10, 2);
-    public static final SchedulingInfo SINGLE_WORKER_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), Lists.newArrayList()).build();
-    public static final SchedulingInfo TWO_WORKER_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).multiWorkerStage(2, DEFAULT_MACHINE_DEFINITION).build();
+    public static final SchedulingInfo SINGLE_WORKER_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), Lists.newArrayList()).build();
+    public static final SchedulingInfo TWO_WORKER_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).addMultiStages(2, DEFAULT_MACHINE_DEFINITION).build();
     public static final JobOwner DEFAULT_JOB_OWNER = new JobOwner("Nick", "Mantis", "desc", "nma@netflix.com", "repo");
     public static final String DEFAULT_ARTIFACT_NAME = "myart";
     public static final String DEFAULT_VERSION = "0.0.1";
@@ -218,7 +218,7 @@ public class JobDefinitionResolverTest {
         JobConstraints softConstraints = JobConstraints.ExclusiveHost;
         List<JobConstraints> constraintsList = new ArrayList<>();
         constraintsList.add(softConstraints);
-        SchedulingInfo schedulingInfo = new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), constraintsList).build();
+        SchedulingInfo schedulingInfo = new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), constraintsList).build();
 
         try {
             JobDefinition givenJobDefn = new JobDefinition.Builder().withName(clusterName).withSchedulingInfo(schedulingInfo).withVersion(version).build();
@@ -300,7 +300,7 @@ public class JobDefinitionResolverTest {
         JobConstraints softConstraints = JobConstraints.ExclusiveHost;
         List<JobConstraints> constraintsList = new ArrayList<>();
         constraintsList.add(softConstraints);
-        SchedulingInfo schedulingInfo = new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), constraintsList).build();
+        SchedulingInfo schedulingInfo = new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), constraintsList).build();
 
         try {
             // only sched info set.

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobClusterManagerTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobClusterManagerTest.java
@@ -190,7 +190,7 @@ public class JobClusterManagerTest {
                 .withArtifactName("myart")
 
                 .withSchedulingInfo(new SchedulingInfo.Builder().numberOfStages(1)
-                                                                .singleWorkerStageWithConstraints(
+                                                                .addStageWithConstraints(
                                                                         new MachineDefinition(
                                                                                 0,
                                                                                 0,
@@ -224,7 +224,7 @@ public class JobClusterManagerTest {
                 .withParameters(Lists.newArrayList())
                 .withLabels(Lists.newArrayList())
                 .withSchedulingInfo(new SchedulingInfo.Builder().numberOfStages(1)
-                                                                .singleWorkerStageWithConstraints(
+                                                                .addStageWithConstraints(
                                                                         new MachineDefinition(
                                                                                 1,
                                                                                 10,

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
@@ -114,7 +114,7 @@ public class JobScaleUpDownTests {
 		smap.put(ScalingReason.DataDrop, new Strategy(ScalingReason.DataDrop, 0.0, 2.0, null));
 		SchedulingInfo sInfo = new SchedulingInfo.Builder()
 				.numberOfStages(1)
-				.multiWorkerScalableStageWithConstraints(1,
+				.addMultiScalableStagesWithConstraints(1,
 						new MachineDefinition(1.0,1.0,1.0,3),
 						Lists.newArrayList(),
 						Lists.newArrayList(),
@@ -157,7 +157,7 @@ public class JobScaleUpDownTests {
 		smap.put(ScalingReason.DataDrop, new Strategy(ScalingReason.DataDrop, 0.0, 2.0, null));
 		SchedulingInfo sInfo = new SchedulingInfo.Builder()
 				.numberOfStages(1)
-				.multiWorkerScalableStageWithConstraints(2,
+				.addMultiScalableStagesWithConstraints(2,
 						new MachineDefinition(1.0,1.0,1.0,3),
 						Lists.newArrayList(),
 						Lists.newArrayList(),
@@ -215,7 +215,7 @@ public class JobScaleUpDownTests {
         smap.put(ScalingReason.DataDrop, new Strategy(ScalingReason.DataDrop, 0.0, 2.0, null));
         SchedulingInfo sInfo = new SchedulingInfo.Builder()
                 .numberOfStages(1)
-                .multiWorkerScalableStageWithConstraints(1,
+                .addMultiScalableStagesWithConstraints(1,
                         new MachineDefinition(1.0,1.0,1.0,3),
                         Lists.newArrayList(),
                         Lists.newArrayList(),
@@ -496,7 +496,7 @@ SchedulingChange [jobId=testSchedulingInfo-1, workerAssignments={
 
 		SchedulingInfo sInfo = new SchedulingInfo.Builder()
 				.numberOfStages(1)
-				.multiWorkerScalableStageWithConstraints(1,
+				.addMultiScalableStagesWithConstraints(1,
 						new MachineDefinition(1.0,1.0,1.0,3),
 						Lists.newArrayList(),
 						Lists.newArrayList(),
@@ -539,7 +539,7 @@ SchedulingChange [jobId=testSchedulingInfo-1, workerAssignments={
 
 		SchedulingInfo sInfo = new SchedulingInfo.Builder()
 				.numberOfStages(1)
-				.multiWorkerScalableStageWithConstraints(1,
+				.addMultiScalableStagesWithConstraints(1,
 						new MachineDefinition(1.0,1.0,1.0,3),
 						Lists.newArrayList(),
 						Lists.newArrayList(),

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestHelper.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestHelper.java
@@ -134,7 +134,7 @@ public class JobTestHelper {
     }
 
     public static IJobClusterDefinition generateJobClusterDefinition(String name) {
-        return generateJobClusterDefinition(name, new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(new MachineDefinition(0, 0, 0, 0, 0), Lists.newArrayList(), Lists.newArrayList()).build());
+        return generateJobClusterDefinition(name, new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(new MachineDefinition(0, 0, 0, 0, 0), Lists.newArrayList(), Lists.newArrayList()).build());
     }
 
     public static JobDefinition generateJobDefinition(String clusterName, SchedulingInfo schedInfo) throws InvalidJobException {
@@ -152,7 +152,7 @@ public class JobTestHelper {
     }
 
     public static JobDefinition generateJobDefinition(String clusterName) throws InvalidJobException {
-        return generateJobDefinition(clusterName, new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(new MachineDefinition(1.0, 1.0, 1.0, 1.0, 3), Lists.newArrayList(), Lists.newArrayList()).build());
+        return generateJobDefinition(clusterName, new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(new MachineDefinition(1.0, 1.0, 1.0, 1.0, 3), Lists.newArrayList(), Lists.newArrayList()).build());
     }
 
     public static void sendCheckHeartBeat(final TestKit probe, final ActorRef jobActor, Instant now) {

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
@@ -223,7 +223,7 @@ public class JobTestLifecycle {
             MachineDefinition machineDefinition = new MachineDefinition(1.0, 1.0, 1.0, 1.0, 3);
             SchedulingInfo schedInfo = new SchedulingInfo.Builder()
                     .numberOfStages(1)
-                    .singleWorkerStageWithConstraints(machineDefinition,
+                    .addStageWithConstraints(machineDefinition,
                             Lists.newArrayList(),
                             Lists.newArrayList()).build();
             jobDefn  = new JobDefinition.Builder()
@@ -370,7 +370,7 @@ public class JobTestLifecycle {
 		IJobClusterDefinition jobClusterDefn = JobTestHelper.generateJobClusterDefinition(clusterName);
 		JobDefinition jobDefn;
 		try {
-			SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).multiWorkerStageWithConstraints(2, new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
+			SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).addMultiStagesWithConstraints(2, new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
 
 			jobDefn = JobTestHelper.generateJobDefinition(clusterName, sInfo);
 			MantisScheduler schedulerMock = mock(MantisScheduler.class);
@@ -467,13 +467,13 @@ public class JobTestLifecycle {
             smap.put(StageScalingPolicy.ScalingReason.Memory, new StageScalingPolicy.Strategy(StageScalingPolicy.ScalingReason.Memory, 0.1, 0.6, null));
             SchedulingInfo.Builder builder = new SchedulingInfo.Builder()
                     .numberOfStages(2)
-                    .multiWorkerScalableStageWithConstraints(
+                    .addMultiScalableStagesWithConstraints(
                             2,
                             new MachineDefinition(1, 1.24, 0.0, 1, 1),
                             null, null,
                             new StageScalingPolicy(1, 1, 3, 1, 1, 60, smap)
                     )
-                    .multiWorkerScalableStageWithConstraints(
+                    .addMultiScalableStagesWithConstraints(
                             3,
                             new MachineDefinition(1, 1.24, 0.0, 1, 1),
                             null, null,
@@ -590,7 +590,7 @@ public class JobTestLifecycle {
 		IJobClusterDefinition jobClusterDefn = JobTestHelper.generateJobClusterDefinition(clusterName);
 		JobDefinition jobDefn;
 		try {
-			SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).multiWorkerStageWithConstraints(2, new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
+			SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).addMultiStagesWithConstraints(2, new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
 
 			jobDefn = JobTestHelper.generateJobDefinition(clusterName, sInfo);
 			MantisScheduler schedulerMock = mock(MantisScheduler.class);
@@ -737,7 +737,7 @@ public class JobTestLifecycle {
 
 		JobDefinition jobDefn;
 		try {
-			SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).multiWorkerStageWithConstraints(2, new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
+			SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).addMultiStagesWithConstraints(2, new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
 
 			jobDefn = JobTestHelper.generateJobDefinition(clusterName, sInfo);
 
@@ -833,7 +833,7 @@ public class JobTestLifecycle {
 		 ActorRef jobActor = null;
 		JobDefinition jobDefn;
 		try {
-			SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).multiWorkerStageWithConstraints(2, new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
+			SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).addMultiStagesWithConstraints(2, new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
 
 			jobDefn = JobTestHelper.generateJobDefinition(clusterName, sInfo);
 			MantisScheduler schedulerMock = mock(MantisScheduler.class);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestMigrationTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestMigrationTests.java
@@ -89,7 +89,7 @@ public class JobTestMigrationTests {
 
         String clusterName= "testWorkerMigration";
         TestKit probe = new TestKit(system);
-        SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
+        SchedulingInfo sInfo = new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(new MachineDefinition(1.0,1.0,1.0,3), Lists.newArrayList(), Lists.newArrayList()).build();
         IJobClusterDefinition jobClusterDefn = JobTestHelper.generateJobClusterDefinition(clusterName, sInfo, new WorkerMigrationConfig(MigrationStrategyEnum.ONE_WORKER, "{}"));
 
         CountDownLatch scheduleCDL = new CountDownLatch(2);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
@@ -72,7 +72,7 @@ import org.junit.Test;
 
 public class DataFormatAdapterTest {
     public static final MachineDefinition DEFAULT_MACHINE_DEFINITION = new MachineDefinition(1, 10, 10, 10, 2);
-    private static final SchedulingInfo DEFAULT_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), Lists.newArrayList()).build();
+    private static final SchedulingInfo DEFAULT_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(DEFAULT_MACHINE_DEFINITION, Lists.newArrayList(), Lists.newArrayList()).build();
     private final LifecycleEventPublisher eventPublisher = new LifecycleEventPublisherImpl(new AuditEventSubscriberLoggingImpl(), new StatusEventSubscriberLoggingImpl(), new WorkerEventSubscriberLoggingImpl());
     @Test
     public void jobClusterConfigToJarTest() {

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/JobClusterConfigTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/JobClusterConfigTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 
 public class JobClusterConfigTest {
-    private static final SchedulingInfo DEFAULT_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2), Lists.newArrayList(), Lists.newArrayList()).build();
+    private static final SchedulingInfo DEFAULT_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2), Lists.newArrayList(), Lists.newArrayList()).build();
 
     @Test
     public void happyTest() {

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/persistence/FileBasedStoreTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/persistence/FileBasedStoreTest.java
@@ -79,7 +79,7 @@ public class FileBasedStoreTest {
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
                 .withArtifactName("myart")
 
-                .withSchedulingInfo(new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2), Lists.newArrayList(), Lists.newArrayList()).build())
+                .withSchedulingInfo(new SchedulingInfo.Builder().numberOfStages(1).addStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2), Lists.newArrayList(), Lists.newArrayList()).build())
                 .withVersion("0.0.1")
 
                 .build();

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/LocalJobExecutorNetworked.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/LocalJobExecutorNetworked.java
@@ -152,7 +152,7 @@ public class LocalJobExecutorNetworked {
         List<StageConfig> stages = job.getStages();
         SchedulingInfo.Builder builder = new SchedulingInfo.Builder();
         for (@SuppressWarnings("unused") StageConfig stage : stages) {
-            builder.singleWorkerStage(MachineDefinitions.micro());
+            builder.addStageWithMachineDefinition(MachineDefinitions.micro());
         }
         builder.numberOfStages(stages.size());
         execute(job, builder.build(), parameters);

--- a/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/LocalJobExecutorNetworkedTest.java
+++ b/mantis-runtime/src/test/java/io/mantisrx/runtime/executor/LocalJobExecutorNetworkedTest.java
@@ -47,7 +47,7 @@ public class LocalJobExecutorNetworkedTest {
         TestJobSingleStage provider = new TestJobSingleStage();
         SchedulingInfo scheduling = new SchedulingInfo.Builder()
                 .numberOfStages(1)
-                .multiWorkerStage(2, MachineDefinitions.micro())
+                .addMultiStages(2, MachineDefinitions.micro())
                 .build();
 
         LocalJobExecutorNetworked.execute(provider.getJobInstance(), scheduling);
@@ -78,9 +78,9 @@ public class LocalJobExecutorNetworkedTest {
         TestJobThreeStage provider = new TestJobThreeStage(); // 1 instance per stage
         SchedulingInfo scheduling = new SchedulingInfo.Builder()
                 .numberOfStages(3)
-                .singleWorkerStage(MachineDefinitions.micro())
-                .singleWorkerStage(MachineDefinitions.micro())
-                .singleWorkerStage(MachineDefinitions.micro())
+                .addStageWithMachineDefinition(MachineDefinitions.micro())
+                .addStageWithMachineDefinition(MachineDefinitions.micro())
+                .addStageWithMachineDefinition(MachineDefinitions.micro())
                 .build();
         LocalJobExecutorNetworked.execute(provider.getJobInstance(), scheduling);
 
@@ -95,9 +95,9 @@ public class LocalJobExecutorNetworkedTest {
         TestJobThreeStage provider = new TestJobThreeStage(); // 1,2,1 topology
         SchedulingInfo scheduling = new SchedulingInfo.Builder()
                 .numberOfStages(3)
-                .singleWorkerStage(MachineDefinitions.micro())
-                .multiWorkerStage(2, MachineDefinitions.micro())
-                .singleWorkerStage(MachineDefinitions.micro())
+                .addStageWithMachineDefinition(MachineDefinitions.micro())
+                .addMultiStages(2, MachineDefinitions.micro())
+                .addStageWithMachineDefinition(MachineDefinitions.micro())
                 .build();
         LocalJobExecutorNetworked.execute(provider.getJobInstance(), scheduling);
 
@@ -112,9 +112,9 @@ public class LocalJobExecutorNetworkedTest {
         TestJobThreeStage provider = new TestJobThreeStage(); // 2,1,1 topology
         SchedulingInfo scheduling = new SchedulingInfo.Builder()
                 .numberOfStages(3)
-                .multiWorkerStage(2, MachineDefinitions.micro())
-                .singleWorkerStage(MachineDefinitions.micro())
-                .singleWorkerStage(MachineDefinitions.micro())
+                .addMultiStages(2, MachineDefinitions.micro())
+                .addStageWithMachineDefinition(MachineDefinitions.micro())
+                .addStageWithMachineDefinition(MachineDefinitions.micro())
                 .build();
         LocalJobExecutorNetworked.execute(provider.getJobInstance(), scheduling);
 
@@ -129,9 +129,9 @@ public class LocalJobExecutorNetworkedTest {
         TestJobThreeStage provider = new TestJobThreeStage(); // 2,1,1 topology
         SchedulingInfo scheduling = new SchedulingInfo.Builder()
                 .numberOfStages(3)
-                .multiWorkerStage(2, MachineDefinitions.micro())
-                .multiWorkerStage(2, MachineDefinitions.micro())
-                .singleWorkerStage(MachineDefinitions.micro())
+                .addMultiStages(2, MachineDefinitions.micro())
+                .addMultiStages(2, MachineDefinitions.micro())
+                .addStageWithMachineDefinition(MachineDefinitions.micro())
                 .build();
         LocalJobExecutorNetworked.execute(provider.getJobInstance(), scheduling);
 

--- a/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/RuntimeTaskImplExecutorTest.java
+++ b/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/RuntimeTaskImplExecutorTest.java
@@ -208,7 +208,7 @@ public class RuntimeTaskImplExecutorTest {
                 1, 1,
                 ports, 100L, 1, ImmutableList.of(),
                 new SchedulingInfo.Builder().numberOfStages(1)
-                    .singleWorkerStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2),
+                    .addStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2),
                         Lists.newArrayList(), Lists.newArrayList()).build(),
                 MantisJobDurationType.Transient,
                 1000L,


### PR DESCRIPTION
### Context

Explain context and other details for this pull request.

### Checklist

- [x] `./gradlew build` compiles code correctly - [Build output](https://scans.gradle.com/s/gnhs2w3naesdw)
- [x] Added new tests where applicable - N/A
- [x] `./gradlew test` passes all tests - [Test output](https://scans.gradle.com/s/jwjtzxy7gjn2o)
- [x] Extended README or added javadocs where applicable - N/A
