### PR TITLE
Add API to enable/disable RC scaler

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandler.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandler.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.api.akka.route.handlers;
 
+import io.mantisrx.common.Ack;
 import io.mantisrx.master.resourcecluster.proto.GetResourceClusterSpecRequest;
 import io.mantisrx.master.resourcecluster.proto.ListResourceClusterRequest;
 import io.mantisrx.master.resourcecluster.proto.ProvisionResourceClusterRequest;
@@ -28,9 +29,11 @@ import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.Ge
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.GetResourceClusterScaleRulesResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
+import io.mantisrx.master.resourcecluster.proto.SetResourceClusterScalerStatusRequest;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 public interface ResourceClusterRouteHandler {
@@ -54,4 +57,13 @@ public interface ResourceClusterRouteHandler {
 
     CompletionStage<GetResourceClusterScaleRulesResponse> getClusterScaleRules(
         GetResourceClusterScaleRulesRequest request);
+
+    /**
+     * Enables/Disables scaler for a given skuID of a given clusterID
+     *
+     * @param skuID skuID whom scaler will be enabled/disabled.
+     * @param enabled whether the scaler will be enabled/disabled.
+     * @return a future that completes when the underlying operation is registered by the system
+     */
+    CompletableFuture<Ack> setScalerStatus(final SetResourceClusterScalerStatusRequest request);
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandlerAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/ResourceClusterRouteHandlerAkkaImpl.java
@@ -19,6 +19,7 @@ package io.mantisrx.master.api.akka.route.handlers;
 import static akka.pattern.Patterns.ask;
 
 import akka.actor.ActorRef;
+import io.mantisrx.common.Ack;
 import io.mantisrx.master.resourcecluster.proto.GetResourceClusterSpecRequest;
 import io.mantisrx.master.resourcecluster.proto.ListResourceClusterRequest;
 import io.mantisrx.master.resourcecluster.proto.ProvisionResourceClusterRequest;
@@ -32,11 +33,13 @@ import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.Ge
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterScaleRuleProto.GetResourceClusterScaleRulesResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
+import io.mantisrx.master.resourcecluster.proto.SetResourceClusterScalerStatusRequest;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import lombok.extern.slf4j.Slf4j;
 
@@ -124,5 +127,12 @@ public class ResourceClusterRouteHandlerAkkaImpl implements ResourceClusterRoute
         GetResourceClusterScaleRulesRequest request) {
         return ask(this.resourceClustersHostManagerActor, request, timeout)
             .thenApply(GetResourceClusterScaleRulesResponse.class::cast);
+    }
+
+    @Override
+    public CompletableFuture<Ack> setScalerStatus(SetResourceClusterScalerStatusRequest request) {
+        return ask(resourceClustersHostManagerActor, request,timeout)
+            .thenApply(Ack.class::cast)
+            .toCompletableFuture();
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -34,6 +34,7 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssig
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorInfoRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterScalerActor.TriggerClusterRuleRefreshRequest;
+import io.mantisrx.master.resourcecluster.proto.SetResourceClusterScalerStatusRequest;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterStorageProvider;
 import io.mantisrx.server.master.config.MasterConfiguration;
 import io.mantisrx.server.master.persistence.MantisJobStore;
@@ -142,6 +143,8 @@ class ResourceClustersManagerActor extends AbstractActor {
                 .match(DisableTaskExecutorsRequest.class, req ->
                     getRCActor(req.getClusterID()).forward(req, context()))
                 .match(TriggerClusterRuleRefreshRequest.class, req ->
+                    getRCScalerActor(req.getClusterID()).forward(req, context()))
+                .match(SetResourceClusterScalerStatusRequest.class, req ->
                     getRCScalerActor(req.getClusterID()).forward(req, context()))
                 .build();
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/SetResourceClusterScalerStatusRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/SetResourceClusterScalerStatusRequest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.resourcecluster.proto;
+
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
+
+
+@Builder
+@Value
+public class SetResourceClusterScalerStatusRequest {
+    @NonNull
+    ContainerSkuID skuId;
+
+    @NonNull
+    Boolean enabled;
+
+    @NonNull
+    ClusterID clusterID;
+
+    @NonNull
+    Long expirationDurationInSeconds;
+}


### PR DESCRIPTION
### Context

The goal of this PR is to introduce a new API to enable/disable scaler actor for a given SKU. This is useful when for example a new ASG is being provisioned to replace an existing one. During such operation we want to disable autoscaling for these ASGs until provisioning is done and the old ASG is marked as disabled. 

A timer is also added to re-enable the scaler in case something goes wrong and ASG provisioning couldn't complete successfully.  

This PR also aims to increase the cool down period for scaling down operations. The approach taken here is simplest possible which is hardcoding a factor of 5 over the configured cool down only for scale down operations.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
