### PR TITLE
Handle TE invalid unAssigned state error

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -472,18 +472,19 @@ class ResourceClusterActor extends AbstractActorWithTimers {
     }
 
     private void onTaskExecutorAssignmentTimeout(TaskExecutorAssignmentTimeout request) {
-        try {
-            TaskExecutorState state = this.executorStateManager.get(request.getTaskExecutorID());
-            if (state.isRunningTask()) {
-                log.debug("TaskExecutor {} entered running state alraedy; no need to act", request.getTaskExecutorID());
-            } else {
+        TaskExecutorState state = this.executorStateManager.get(request.getTaskExecutorID());
+        if (state.isRunningTask()) {
+            log.debug("TaskExecutor {} entered running state alraedy; no need to act", request.getTaskExecutorID());
+        } else {
+            try
+            {
                 boolean stateChange = state.onUnassignment();
                 if (stateChange) {
                     this.executorStateManager.markAvailable(request.getTaskExecutorID());
                 }
+            } catch (IllegalStateException e) {
+                log.warn("Failed to un-assign taskExecutor {}", request.getTaskExecutorID(), e);
             }
-        } catch (IllegalStateException e) {
-            log.error("Failed to un-assign taskExecutor {}", request.getTaskExecutorID(), e);
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -483,7 +483,11 @@ class ResourceClusterActor extends AbstractActorWithTimers {
                     this.executorStateManager.markAvailable(request.getTaskExecutorID());
                 }
             } catch (IllegalStateException e) {
-                log.warn("Failed to un-assign taskExecutor {}", request.getTaskExecutorID(), e);
+                if (state.isRegistered()) {
+                    log.error("Failed to un-assign registered taskExecutor {}", request.getTaskExecutorID(), e);
+                } else {
+                    log.debug("Failed to un-assign unRegistered taskExecutor {}", request.getTaskExecutorID(), e);
+                }
             }
         }
     }


### PR DESCRIPTION
### Context
[Found from prod log scan]
In the control plane transition, in-error/crashed TE can have an initially empty state and gets an illegal state error if the control plane decides to unassign its current work. There is no action to take for the control plane at that point as it hasn't been able to re-establish a connection with TE. If the TE has a discrepancy on task assignment state if it should get handled when it gets back in the heartbeat message instead.

Reduced the catch scope and move the error log into a warning.


### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
