### PR TITLE
Adding a new route to support updating scheduling info

### DIFF
--- a/mantis-common/build.gradle
+++ b/mantis-common/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     // spectatorApi should be packaged at entry point level to avoid version conflicts.
     compileOnly libraries.spectatorApi
 
+    api libraries.jsr305
     api libraries.mantisShaded
     api libraries.rxNettyShaded
     api libraries.rxJava

--- a/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageSchedulingInfo.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/descriptor/StageSchedulingInfo.java
@@ -26,6 +26,7 @@ import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Singular;
 
@@ -38,6 +39,7 @@ public class StageSchedulingInfo implements Serializable {
     private final MachineDefinition machineDefinition;
     @Singular(ignoreNullCollections = true) private final List<JobConstraints> hardConstraints;
     @Singular(ignoreNullCollections = true) private final List<JobConstraints> softConstraints;
+    @Nullable
     private final StageScalingPolicy scalingPolicy;
     private final boolean scalable;
 
@@ -82,6 +84,7 @@ public class StageSchedulingInfo implements Serializable {
         return softConstraints;
     }
 
+    @Nullable
     public StageScalingPolicy getScalingPolicy() {
         return scalingPolicy;
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/IJobClustersManager.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/IJobClustersManager.java
@@ -17,6 +17,7 @@
 package io.mantisrx.master;
 
 
+import io.mantisrx.master.JobClustersManagerActor.UpdateSchedulingInfo;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.CreateJobClusterRequest;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.DeleteJobClusterRequest;
@@ -48,6 +49,8 @@ public interface IJobClustersManager {
     void onJobClusterUpdateSLA(JobClusterManagerProto.UpdateJobClusterSLARequest r);
 
     void onJobClusterUpdateArtifact(JobClusterManagerProto.UpdateJobClusterArtifactRequest r);
+
+    void onJobClusterUpdateSchedulingInfo(UpdateSchedulingInfo r);
 
     void onJobClusterUpdateLabels(JobClusterManagerProto.UpdateJobClusterLabelsRequest r);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobClusterRouteHandler.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobClusterRouteHandler.java
@@ -17,6 +17,8 @@
 package io.mantisrx.master.api.akka.route.handlers;
 
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
+import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.UpdateSchedulingInfoRequest;
+import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.UpdateSchedulingInfoResponse;
 import java.util.concurrent.CompletionStage;
 
 public interface JobClusterRouteHandler {
@@ -31,6 +33,10 @@ public interface JobClusterRouteHandler {
     CompletionStage<JobClusterManagerProto.EnableJobClusterResponse> enable(final JobClusterManagerProto.EnableJobClusterRequest request);
 
     CompletionStage<JobClusterManagerProto.UpdateJobClusterArtifactResponse> updateArtifact(final JobClusterManagerProto.UpdateJobClusterArtifactRequest request);
+
+    CompletionStage<UpdateSchedulingInfoResponse> updateSchedulingInfo(
+            String clusterName,
+            final UpdateSchedulingInfoRequest request);
 
     CompletionStage<JobClusterManagerProto.UpdateJobClusterSLAResponse> updateSLA(final JobClusterManagerProto.UpdateJobClusterSLARequest request);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobClusterRouteHandlerAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobClusterRouteHandlerAkkaImpl.java
@@ -22,7 +22,10 @@ import akka.actor.ActorRef;
 import io.mantisrx.common.metrics.Counter;
 import io.mantisrx.common.metrics.Metrics;
 import io.mantisrx.common.metrics.MetricsRegistry;
+import io.mantisrx.master.JobClustersManagerActor.UpdateSchedulingInfo;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
+import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.UpdateSchedulingInfoRequest;
+import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.UpdateSchedulingInfoResponse;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import java.time.Duration;
 import java.util.Optional;
@@ -88,6 +91,18 @@ public class JobClusterRouteHandlerAkkaImpl implements JobClusterRouteHandler {
     public CompletionStage<JobClusterManagerProto.UpdateJobClusterArtifactResponse> updateArtifact(JobClusterManagerProto.UpdateJobClusterArtifactRequest request) {
         CompletionStage<JobClusterManagerProto.UpdateJobClusterArtifactResponse> response = ask(jobClustersManagerActor, request, timeout)
             .thenApply(JobClusterManagerProto.UpdateJobClusterArtifactResponse.class::cast);
+        return response;
+    }
+
+    @Override
+    public CompletionStage<UpdateSchedulingInfoResponse> updateSchedulingInfo(String clusterName, UpdateSchedulingInfoRequest request) {
+        CompletionStage<UpdateSchedulingInfoResponse> response =
+            ask(
+                jobClustersManagerActor,
+                new UpdateSchedulingInfo(request.requestId, clusterName, request.getSchedulingInfo(),
+                    request.getVersion()),
+                timeout)
+            .thenApply(UpdateSchedulingInfoResponse.class::cast);
         return response;
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/HttpRequestMetrics.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/HttpRequestMetrics.java
@@ -39,6 +39,8 @@ public class HttpRequestMetrics {
         public static final String JOB_CLUSTER_INSTANCE = "api.v1.jobClusters.instance";
         public static final String JOB_CLUSTER_INSTANCE_LATEST_JOB_DISCOVERY_INFO = "api.v1.jobClusters.instance.latestJobDiscoveryInfo";
         public static final String JOB_CLUSTER_INSTANCE_ACTION_UPDATE_ARTIFACT = "api.v1.jobClusters.instance.actions.updateArtifact";
+
+        public static final String JOB_CLUSTER_INSTANCE_SCHEDULING_INFO_UPDATE = "api.v1.jobClusters.instance.actions.updateSchedulingInfo";
         public static final String JOB_CLUSTER_INSTANCE_ACTION_UPDATE_SLA = "api.v1.jobClusters.instance.actions.updateSla";
         public static final String JOB_CLUSTER_INSTANCE_ACTION_UPDATE_MIGRATION_STRATEGY = "api.v1.jobClusters.instance.actions.updateMigrationStrategy";
         public static final String JOB_CLUSTER_INSTANCE_ACTION_UPDATE_LABEL = "api.v1.jobClusters.instance.actions.updateLabel";

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobClustersRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobClustersRoute.java
@@ -128,7 +128,7 @@ public class JobClustersRoute extends BaseRoute {
                         ),
                         // api/v1/jobClusters/{}/actions/updateSchedulingInfo
                         path(
-                            PathMatchers.segment().slash("actions").slash("updateScheduleInfo"),
+                            PathMatchers.segment().slash("actions").slash("updateSchedulingInfo"),
                             (clusterName) -> pathEndOrSingleSlash(() -> concat(
 
                                 // POST

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobClustersRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobClustersRoute.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
  *  api/v1/jobClusters/{}/actions/updateLabel                   (POST)
  *  api/v1/jobClusters/{}/actions/enableCluster                 (POST)
  *  api/v1/jobClusters/{}/actions/disableCluster                (POST)
+ *  api/v1/jobClusters/{}/actions/updateSchedulingInfo          (POST)
  */
 public class JobClustersRoute extends BaseRoute {
     private static final Logger logger = LoggerFactory.getLogger(JobClustersRoute.class);
@@ -124,6 +125,15 @@ public class JobClustersRoute extends BaseRoute {
                                         // POST
                                         post(() -> updateClusterArtifactRoute(clusterName))
                                 ))
+                        ),
+                        // api/v1/jobClusters/{}/actions/updateSchedulingInfo
+                        path(
+                            PathMatchers.segment().slash("actions").slash("updateScheduleInfo"),
+                            (clusterName) -> pathEndOrSingleSlash(() -> concat(
+
+                                // POST
+                                post(() -> updateClusterSchedulingInfo(clusterName))
+                            ))
                         ),
 
                         // api/v1/jobClusters/{}/actions/updateSla
@@ -437,6 +447,25 @@ public class JobClustersRoute extends BaseRoute {
                     resp -> complete(StatusCodes.NO_CONTENT, ""),
                     HttpRequestMetrics.Endpoints.JOB_CLUSTER_INSTANCE_ACTION_UPDATE_ARTIFACT,
                     HttpRequestMetrics.HttpVerb.POST
+            );
+        });
+    }
+
+    private Route updateClusterSchedulingInfo(String clusterName) {
+        return entity(Jackson.unmarshaller(UpdateSchedulingInfoRequest.class), request -> {
+            logger.info(
+                "POST /api/v1/jobClusters/{}/actions/updateSchedulingInfo called {}",
+                clusterName,
+                request);
+
+            CompletionStage<UpdateSchedulingInfoResponse> updateResponse =
+                jobClusterRouteHandler.updateSchedulingInfo(clusterName, request);
+
+            return completeAsync(
+                updateResponse,
+                resp -> complete(StatusCodes.NO_CONTENT, ""),
+                HttpRequestMetrics.Endpoints.JOB_CLUSTER_INSTANCE_ACTION_UPDATE_ARTIFACT,
+                HttpRequestMetrics.HttpVerb.POST
             );
         });
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/IJobClusterManager.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/IJobClusterManager.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.jobcluster;
 
+import io.mantisrx.master.JobClustersManagerActor.UpdateSchedulingInfo;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.DisableJobClusterRequest;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.EnableJobClusterRequest;
@@ -98,6 +99,8 @@ public interface IJobClusterManager {
     void onJobClusterUpdateLabels(UpdateJobClusterLabelsRequest labelRequest);
 
     void onJobClusterUpdateArtifact(UpdateJobClusterArtifactRequest artifactReq);
+
+    void onJobClusterUpdateSchedulingInfo(UpdateSchedulingInfo request);
 
     void onJobClusterUpdateWorkerMigrationConfig(UpdateJobClusterWorkerMigrationStrategyRequest req);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
@@ -30,6 +30,7 @@ import io.mantisrx.master.jobcluster.job.MantisJobMetadataView;
 import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
 import io.mantisrx.master.jobcluster.job.worker.WorkerState;
 import io.mantisrx.runtime.WorkerMigrationConfig;
+import io.mantisrx.runtime.descriptor.SchedulingInfo;
 import io.mantisrx.server.core.JobSchedulingInfo;
 import io.mantisrx.server.master.domain.IJobClusterDefinition;
 import io.mantisrx.server.master.domain.JobClusterDefinitionImpl;
@@ -50,6 +51,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import rx.subjects.BehaviorSubject;
@@ -505,6 +507,21 @@ public class JobClusterManagerProto {
         }
     }
 
+    @ToString
+    @EqualsAndHashCode
+    @Getter
+    public static final class UpdateSchedulingInfoRequest extends BaseRequest {
+        private final SchedulingInfo schedulingInfo;
+        private final String version;
+
+        public UpdateSchedulingInfoRequest(
+            @JsonProperty("schedulingInfo") SchedulingInfo schedulingInfo,
+            @JsonProperty("version") final String version) {
+            this.schedulingInfo = schedulingInfo;
+            this.version = version;
+        }
+    }
+
     public static final class UpdateJobClusterArtifactRequest extends BaseRequest {
         private final String artifactName;
         private final String version;
@@ -568,6 +585,17 @@ public class JobClusterManagerProto {
                    ", clusterName='" + clusterName + '\'' +
                    ", requestId=" + requestId +
                    '}';
+        }
+    }
+
+    @EqualsAndHashCode
+    @ToString
+    public static final class UpdateSchedulingInfoResponse extends BaseResponse {
+        public UpdateSchedulingInfoResponse(
+            final long requestId,
+            final ResponseCode responseCode,
+            final String message) {
+            super(requestId, responseCode, message);
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProtoTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProtoTest.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.jobcluster.proto;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import io.mantisrx.master.api.akka.route.Jackson;
@@ -91,5 +92,12 @@ public class JobClusterManagerProtoTest {
         UpdateSchedulingInfoRequest result =
             Jackson.fromJSON(json, UpdateSchedulingInfoRequest.class);
         assertNotNull(result);
+        assertEquals(result.getVersion(), "0.0.1-snapshot.202303220002+fdichiara.runtimeV2.d16a200 2023-05-09 09:10:42");
+
+        result.getSchedulingInfo().getStages().values().forEach(stage -> {
+            assertNotNull(stage.getMachineDefinition());
+            assertNotNull(stage.getHardConstraints());
+            assertNotNull(stage.getSoftConstraints());
+        });
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProtoTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProtoTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.jobcluster.proto;
+
+import static org.junit.Assert.assertNotNull;
+
+import io.mantisrx.master.api.akka.route.Jackson;
+import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto.UpdateSchedulingInfoRequest;
+import org.junit.Test;
+
+public class JobClusterManagerProtoTest {
+    @Test
+    public void testDeserialization() throws Exception {
+        String json = "{\n"
+            + "    \"schedulingInfo\":\n"
+            + "    {\n"
+            + "        \"stages\":\n"
+            + "        {\n"
+            + "            \"1\":\n"
+            + "            {\n"
+            + "                \"numberOfInstances\": 1,\n"
+            + "                \"machineDefinition\":\n"
+            + "                {\n"
+            + "                    \"cpuCores\": 1.0,\n"
+            + "                    \"memoryMB\": 4094.0,\n"
+            + "                    \"networkMbps\": 128.0,\n"
+            + "                    \"diskMB\": 6000.0,\n"
+            + "                    \"numPorts\": 1\n"
+            + "                },\n"
+            + "                \"hardConstraints\":\n"
+            + "                [],\n"
+            + "                \"softConstraints\":\n"
+            + "                [],\n"
+            + "                \"scalingPolicy\": null,\n"
+            + "                \"scalable\": false\n"
+            + "            },\n"
+            + "            \"2\":\n"
+            + "            {\n"
+            + "                \"numberOfInstances\": 1,\n"
+            + "                \"machineDefinition\":\n"
+            + "                {\n"
+            + "                    \"cpuCores\": 1.0,\n"
+            + "                    \"memoryMB\": 4096.0,\n"
+            + "                    \"networkMbps\": 128.0,\n"
+            + "                    \"diskMB\": 6000.0,\n"
+            + "                    \"numPorts\": 1\n"
+            + "                },\n"
+            + "                \"hardConstraints\":\n"
+            + "                [],\n"
+            + "                \"softConstraints\":\n"
+            + "                [],\n"
+            + "                \"scalingPolicy\": null,\n"
+            + "                \"scalable\": false\n"
+            + "            },\n"
+            + "            \"3\":\n"
+            + "            {\n"
+            + "                \"numberOfInstances\": 1,\n"
+            + "                \"machineDefinition\":\n"
+            + "                {\n"
+            + "                    \"cpuCores\": 1.0,\n"
+            + "                    \"memoryMB\": 4096.0,\n"
+            + "                    \"networkMbps\": 128.0,\n"
+            + "                    \"diskMB\": 6000.0,\n"
+            + "                    \"numPorts\": 1\n"
+            + "                },\n"
+            + "                \"hardConstraints\":\n"
+            + "                [],\n"
+            + "                \"softConstraints\":\n"
+            + "                [],\n"
+            + "                \"scalingPolicy\": null,\n"
+            + "                \"scalable\": false\n"
+            + "            }\n"
+            + "        }\n"
+            + "    },\n"
+            + "    \"version\": \"0.0.1-snapshot.202303220002+fdichiara.runtimeV2.d16a200 2023-05-09 09:10:42\"\n"
+            + "}";
+        UpdateSchedulingInfoRequest result =
+            Jackson.fromJSON(json, UpdateSchedulingInfoRequest.class);
+        assertNotNull(result);
+    }
+}


### PR DESCRIPTION
### Context

This diff supports updating a job cluster's scheduling info property. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
