### PR TITLE
fix issue#446

### DIFF
--- a/mantis-common/build.gradle
+++ b/mantis-common/build.gradle
@@ -30,8 +30,7 @@ dependencies {
     api "org.xerial.snappy:snappy-java:$snappyVersion"
     api "org.jctools:jctools-core:$jctoolsVersion"
 
-    // spectatorApi should be packaged at entry point level to avoid version conflicts.
-    compileOnly libraries.spectatorApi
+    implementation libraries.spectatorApi
 
     api libraries.mantisShaded
     api libraries.rxNettyShaded


### PR DESCRIPTION
### Context
When running the source job example by following the Mantis document, error happened.

Exception in thread "main" java.lang.NoClassDefFoundError: com/netflix/spectator/api/Registry
Caused by: java.lang.ClassNotFoundException: com.netflix.spectator.api.Registr

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
