### PR TITLE
Cache job artifacts on TE right after registration (to speed up job initialization time)

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CacheJobArtifactsRequest.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CacheJobArtifactsRequest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.core;
+
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
+import java.net.URI;
+import java.util.List;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+public class CacheJobArtifactsRequest implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @NonNull
+    final List<URI> artifacts;
+
+    @JsonCreator
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public CacheJobArtifactsRequest(@JsonProperty("artifacts") List<URI> artifacts) {
+        this.artifacts = artifacts;
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -17,6 +17,7 @@
 package io.mantisrx.server.master.resourcecluster;
 
 import io.mantisrx.common.Ack;
+import io.mantisrx.server.core.domain.ArtifactID;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.worker.TaskExecutorGateway;
 import java.time.Instant;
@@ -62,6 +63,8 @@ public interface ResourceCluster extends ResourceClusterGateway {
     CompletableFuture<List<TaskExecutorID>> getUnregisteredTaskExecutors();
 
     CompletableFuture<ResourceOverview> resourceOverview();
+
+    CompletableFuture<Ack> addNewJobArtifactsToCache(ClusterID clusterID, List<ArtifactID> artifacts);
 
     /**
      * Can throw {@link NoResourceAvailableException} wrapped within the CompletableFuture in case there

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/worker/TaskExecutorGateway.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/worker/TaskExecutorGateway.java
@@ -16,6 +16,7 @@
 package io.mantisrx.server.worker;
 
 import io.mantisrx.common.Ack;
+import io.mantisrx.server.core.CacheJobArtifactsRequest;
 import io.mantisrx.server.core.ExecuteStageRequest;
 import io.mantisrx.server.core.domain.WorkerId;
 import java.util.concurrent.CompletableFuture;
@@ -35,6 +36,14 @@ public interface TaskExecutorGateway extends RpcGateway {
      *                                     in case there's already an existing task that's running on the task executor.
      */
     CompletableFuture<Ack> submitTask(ExecuteStageRequest request);
+
+    /**
+     * instruct the task executor on which job artifact to cache in order to speed up job initialization time.
+     *
+     * @param request List of job artifacts that need to be cached.
+     * @return Ack in any case (this task is best effort).
+     */
+    CompletableFuture<Ack> cacheJobArtifacts(CacheJobArtifactsRequest request);
 
     /**
      * cancel the currently running task and get rid of all of the associated resources.

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobArtifactsRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobArtifactsRoute.java
@@ -116,8 +116,6 @@ public class JobArtifactsRoute extends BaseRoute {
                 try {
                     final CompletionStage<UpsertJobArtifactResponse> response = jobArtifactRouteHandler.upsert(new JobArtifactProto.UpsertJobArtifactRequest(jobArtifact));
 
-                    // TODO(fdichiara): introduce job artifact pre-fetching in task executors.
-
                     return completeAsync(
                         response,
                         resp -> complete(

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -19,6 +19,7 @@ package io.mantisrx.master.resourcecluster;
 import akka.actor.ActorRef;
 import akka.pattern.Patterns;
 import io.mantisrx.common.Ack;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.AddNewJobArtifactsToCacheRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAssignedTaskExecutorRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAvailableTaskExecutorsRequest;
@@ -35,6 +36,7 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorInfoR
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorsList;
 import io.mantisrx.master.resourcecluster.ResourceClusterScalerActor.TriggerClusterRuleRefreshRequest;
 import io.mantisrx.master.resourcecluster.proto.SetResourceClusterScalerStatusRequest;
+import io.mantisrx.server.core.domain.ArtifactID;
 import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
@@ -132,6 +134,17 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
                 .ask(resourceClusterManagerActor, new ResourceOverviewRequest(clusterID), askTimeout)
                 .thenApply(ResourceOverview.class::cast)
                 .toCompletableFuture();
+    }
+
+    @Override
+    public CompletableFuture<Ack> addNewJobArtifactsToCache(ClusterID clusterID, List<ArtifactID> artifacts) {
+        return Patterns
+            .ask(
+                resourceClusterManagerActor,
+                new AddNewJobArtifactsToCacheRequest(clusterID, artifacts),
+                askTimeout)
+            .thenApply(Ack.class::cast)
+            .toCompletableFuture();
     }
 
     @Override

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -22,6 +22,7 @@ import akka.actor.Props;
 import akka.actor.SupervisorStrategy;
 import akka.japi.pf.ReceiveBuilder;
 import io.mantisrx.master.akka.MantisActorSupervisorStrategy;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.AddNewJobArtifactsToCacheRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAssignedTaskExecutorRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAvailableTaskExecutorsRequest;
@@ -141,6 +142,8 @@ class ResourceClustersManagerActor extends AbstractActor {
                 .match(TaskExecutorGatewayRequest.class, req ->
                     getRCActor(req.getClusterID()).forward(req, context()))
                 .match(DisableTaskExecutorsRequest.class, req ->
+                    getRCActor(req.getClusterID()).forward(req, context()))
+                .match(AddNewJobArtifactsToCacheRequest.class, req ->
                     getRCActor(req.getClusterID()).forward(req, context()))
                 .match(TriggerClusterRuleRefreshRequest.class, req ->
                     getRCScalerActor(req.getClusterID()).forward(req, context()))

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterScaleRuleProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ResourceClusterScaleRuleProto.java
@@ -16,13 +16,17 @@
 
 package io.mantisrx.master.resourcecluster.proto;
 
+import com.netflix.spectator.impl.Preconditions;
+import io.mantisrx.master.jobcluster.proto.BaseRequest;
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
+import io.mantisrx.server.core.domain.ArtifactID;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import lombok.Singular;
 import lombok.Value;
@@ -87,5 +91,23 @@ public class ResourceClusterScaleRuleProto {
         int maxIdleToKeep;
         int maxSize;
         long coolDownSecs;
+    }
+
+    @EqualsAndHashCode(callSuper = true)
+    @Value
+    public static class JobArtifactToCacheRequest extends BaseRequest {
+        ClusterID clusterID;
+
+        @Singular
+        @NonNull
+        List<ArtifactID> artifacts;
+
+        public JobArtifactToCacheRequest(@JsonProperty("clusterID") ClusterID clusterID, @JsonProperty("artifacts") List<ArtifactID> artifacts) {
+            super();
+            Preconditions.checkNotNull(clusterID, "clusterID cannot be null");
+            Preconditions.checkNotNull(artifacts, "artifacts cannot be null");
+            this.clusterID = clusterID;
+            this.artifacts = artifacts;
+        }
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/IMantisPersistenceProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/IMantisPersistenceProvider.java
@@ -21,6 +21,7 @@ import io.mantisrx.master.jobcluster.job.IMantisJobMetadata;
 import io.mantisrx.master.jobcluster.job.IMantisStageMetadata;
 import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
 import io.mantisrx.master.resourcecluster.DisableTaskExecutorsRequest;
+import io.mantisrx.server.core.domain.ArtifactID;
 import io.mantisrx.server.core.domain.JobArtifact;
 import io.mantisrx.server.master.domain.JobClusterDefinitionImpl.CompletedJob;
 import io.mantisrx.server.master.persistence.exceptions.InvalidJobException;
@@ -164,6 +165,10 @@ public interface IMantisPersistenceProvider {
     JobArtifact getArtifactById(String resourceId) throws IOException;
 
     List<JobArtifact> listJobArtifacts(String name, String version) throws IOException;
+
+    void addNewJobArtifactsToCache(ClusterID clusterID, List<ArtifactID> artifacts) throws IOException;
+
+    List<String> listJobArtifactsToCache(ClusterID clusterID) throws IOException;
 
     List<String> listJobArtifactsByName(String prefix, String contains) throws IOException;
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/MantisJobStore.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/MantisJobStore.java
@@ -23,6 +23,7 @@ import io.mantisrx.master.jobcluster.job.MantisStageMetadataImpl;
 import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
 import io.mantisrx.master.jobcluster.job.worker.JobWorker;
 import io.mantisrx.master.resourcecluster.DisableTaskExecutorsRequest;
+import io.mantisrx.server.core.domain.ArtifactID;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.domain.JobClusterDefinitionImpl.CompletedJob;
 import io.mantisrx.server.master.persistence.exceptions.InvalidJobException;
@@ -260,6 +261,14 @@ public class MantisJobStore {
 
     public List<IMantisWorkerMetadata> getArchivedWorkers(String jobId) throws Exception {
         return ImmutableList.copyOf(archivedWorkersCache.getArchivedWorkerMap(jobId).values());
+    }
+
+    public void addNewJobArtifactsToCache(ClusterID clusterID, List<ArtifactID> artifacts) throws IOException {
+        storageProvider.addNewJobArtifactsToCache(clusterID, artifacts);
+    }
+
+    public List<String> getJobArtifactsToCache(ClusterID clusterID) throws IOException {
+        return storageProvider.listJobArtifactsToCache(clusterID);
     }
 
     private static class TerminatedJob implements Comparable<TerminatedJob> {

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/ClassLoaderHandle.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/ClassLoaderHandle.java
@@ -47,6 +47,8 @@ public interface ClassLoaderHandle extends Closeable {
     UserCodeClassLoader getOrResolveClassLoader(Collection<URI> requiredJarFiles,
                                                 Collection<URL> requiredClasspaths) throws IOException;
 
+    void cacheJobArtifacts(Collection<URI> artifacts);
+
     /**
      * ClassLoaderHandle that just returns the classloader field that's assigned at the time of construction
      * on query for any new handles.
@@ -59,6 +61,9 @@ public interface ClassLoaderHandle extends Closeable {
             public UserCodeClassLoader getOrResolveClassLoader(Collection<URI> requiredJarFiles, Collection<URL> requiredClasspaths) throws IOException {
                 return SimpleUserCodeClassLoader.create(classLoader);
             }
+
+            @Override
+            public void cacheJobArtifacts(Collection<URI> artifacts) {}
 
             @Override
             public void close() throws IOException {

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/BlobStoreAwareClassLoaderHandle.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/BlobStoreAwareClassLoaderHandle.java
@@ -93,6 +93,15 @@ public class BlobStoreAwareClassLoaderHandle implements ClassLoaderHandle {
         return SimpleUserCodeClassLoader.create(classLoader);
     }
 
+    @Override
+    public void cacheJobArtifacts(Collection<URI> artifacts) {
+        try {
+            getResolvedUrls(artifacts, blobStore);
+        } catch (IOException | URISyntaxException e) {
+            log.warn("Failed to download artifacts: {}", artifacts);
+        }
+    }
+
     public static class ParentFirstClassLoader extends FlinkUserCodeClassLoader {
 
         ParentFirstClassLoader(

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
@@ -29,6 +29,7 @@ import io.mantisrx.runtime.loader.SinkSubscriptionStateHandler;
 import io.mantisrx.runtime.loader.TaskFactory;
 import io.mantisrx.runtime.loader.config.WorkerConfiguration;
 import io.mantisrx.runtime.loader.config.WorkerConfigurationUtils;
+import io.mantisrx.server.core.CacheJobArtifactsRequest;
 import io.mantisrx.server.core.ExecuteStageRequest;
 import io.mantisrx.server.core.Status;
 import io.mantisrx.server.core.WrappedExecuteStageRequest;
@@ -467,6 +468,14 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
         // do not wait for task processing (e.g. artifact download).
         getIOExecutor().execute(() -> this.prepareTask(wrappedRequest));
+        return CompletableFuture.completedFuture(Ack.getInstance());
+    }
+
+    @Override
+    public CompletableFuture<Ack> cacheJobArtifacts(CacheJobArtifactsRequest request) {
+
+        log.info("Received request {} for downloading artifact", request);
+        getIOExecutor().execute(() -> this.classLoaderHandle.cacheJobArtifacts(request.getArtifacts()));
         return CompletableFuture.completedFuture(Ack.getInstance());
     }
 


### PR DESCRIPTION
### Context

The goal of this PR is to introduce a way to "pre"-cache job artifacts into Task Executors before jobs get scheduled in order to speed up job launch times (currently ~1 minute).

## Details 

The idea is to inform TEs of which job artifacts to download from blobstore right after they registered themselves with the resource cluster. The detailed semantic follows these steps:

1. We tell the RC actor the set of artifacts to be cached on a given cluster (in the future we will add a new endpoint for this, but for now the information is stored in kvdal manually)
2. The TEs registers itself to the RC
3. The RC actor tells the TE which artifacts to cache (right now this process is best-effort, I think it's totally fine if some TEs fail to pre-cache and end-up with longer than expected job launch latencies).

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
