### PR TITLE
Update NoResource error metric tags

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -463,8 +463,8 @@ class ResourceClusterActor extends AbstractActorWithTimers {
                     request.getAllocationRequest().getWorkerId().getId(),
                     "jobCluster",
                     request.getAllocationRequest().getWorkerId().getJobCluster(),
-                    "jobId",
-                    request.getAllocationRequest().getWorkerId().getJobId())));
+                    "cpuCores",
+                    String.valueOf(request.getAllocationRequest().getMachineDefinition().getCpuCores()))));
             sender().tell(new Status.Failure(new NoResourceAvailableException(
                 String.format("No resource available for request %s: resource overview: %s", request,
                     getResourceOverview()))), self());


### PR DESCRIPTION
### Context

Add CPU cores as an extra tag to help track the no resource available error. (Preferably I want the SKU id here but it's not directly available atm).

Remove "jobId" as it's redundant between "jobCluster" and "WorkerID".

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
