### PR TITLE
Making sure caching works properly in the BlobStore

### DIFF
--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/HadoopFileSystemBlobStore.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/HadoopFileSystemBlobStore.java
@@ -41,11 +41,11 @@ public class HadoopFileSystemBlobStore implements BlobStore {
     public File get(URI blobUrl) throws IOException {
         final Path src = new Path(blobUrl);
         final Path dest = new Path(getStorageLocation(blobUrl));
-        if (!fileSystem.exists(dest)) {
+        File destFile = new File(dest.toUri().getPath());
+        if (!destFile.exists()) {
             fileSystem.copyToLocalFile(src, dest);
         }
-
-        return new File(dest.toUri().getPath());
+        return destFile;
     }
 
     @Override


### PR DESCRIPTION
### Context
When downloading artifacts, we should check if the file exists in the target filesystem instead of the source filesystem. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
