### PR TITLE
Add source client connection pool options

### DIFF
--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/impl/HttpClientFactories.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/impl/HttpClientFactories.java
@@ -41,6 +41,15 @@ public class HttpClientFactories {
         return new SSEClientFactory();
     }
 
+    /**
+     * [Deprecated] read timeouts is not longer supported in SSE client factory.
+     * @param readTimeout
+     */
+    @Deprecated
+    public static HttpClientFactory<ByteBuf, ServerSentEvent> sseClientFactory(int readTimeout) {
+        return new SSEClientFactory(readTimeout);
+    }
+
     public static HttpClientFactory<ByteBuf, ServerSentEvent> sseClientFactory(
         boolean enableConnectionPooling,
         boolean enableIdleConnectionCleanup) {
@@ -85,13 +94,16 @@ public class HttpClientFactories {
 
     private static class SSEClientFactory implements HttpClientFactory<ByteBuf, ServerSentEvent> {
 
-        public static final int DEFAULT_READ_TIMEOUT_SECS = 5;
         private final boolean enableConnectionPooling;
         private final boolean enableIdleConnectionCleanup;
 
         public SSEClientFactory(boolean enableConnectionPooling, boolean enableIdleConnectionCleanup) {
             this.enableConnectionPooling = enableConnectionPooling;
             this.enableIdleConnectionCleanup = enableIdleConnectionCleanup;
+        }
+
+        public SSEClientFactory(int readTimeout) {
+            this();
         }
 
         public SSEClientFactory() {

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/impl/HttpClientFactories.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/http/impl/HttpClientFactories.java
@@ -25,55 +25,78 @@ import mantis.io.reactivex.netty.protocol.http.client.HttpClient;
 import mantis.io.reactivex.netty.protocol.http.client.HttpClientBuilder;
 import mantis.io.reactivex.netty.protocol.http.sse.ServerSentEvent;
 
-
 public class HttpClientFactories {
 
     public static HttpClientFactory<ByteBuf, ByteBuf> defaultFactory() {
         return new DefaultHttpClientFactory();
     }
 
+    public static HttpClientFactory<ByteBuf, ByteBuf> defaultFactory(
+        boolean enableConnectionPooling,
+        boolean enableIdleConnectionCleanup) {
+        return new DefaultHttpClientFactory(enableConnectionPooling, enableIdleConnectionCleanup);
+    }
+
     public static HttpClientFactory<ByteBuf, ServerSentEvent> sseClientFactory() {
         return new SSEClientFactory();
     }
 
-    public static HttpClientFactory<ByteBuf, ServerSentEvent> sseClientFactory(int readTimeout) {
-        return new SSEClientFactory(readTimeout);
+    public static HttpClientFactory<ByteBuf, ServerSentEvent> sseClientFactory(
+        boolean enableConnectionPooling,
+        boolean enableIdleConnectionCleanup) {
+        return new SSEClientFactory(enableConnectionPooling, enableIdleConnectionCleanup);
     }
-
 
     private static class DefaultHttpClientFactory implements HttpClientFactory<ByteBuf, ByteBuf> {
 
         private final HttpClient.ClientConfig clientConfig;
+        private final boolean enableConnectionPooling;
+        private final boolean enableIdleConnectionCleanup;
 
-        public DefaultHttpClientFactory() {
+        public DefaultHttpClientFactory() { this(false, false); }
+
+        public DefaultHttpClientFactory(boolean enableConnectionPooling, boolean enableIdleConnectionCleanup) {
+            this.enableConnectionPooling = enableConnectionPooling;
+            this.enableIdleConnectionCleanup = enableIdleConnectionCleanup;
             clientConfig = new HttpClient.HttpClientConfig.Builder()
                     .setFollowRedirect(true)
                     .userAgent("Netflix Mantis HTTP Source")
-
                     .build();
         }
 
         @Override
         public HttpClient<ByteBuf, ByteBuf> createClient(ServerInfo server) {
-            return new HttpClientBuilder<ByteBuf, ByteBuf>(server.getHost(), server.getPort())
-                    .config(clientConfig)
-                    .build();
+            HttpClientBuilder<ByteBuf, ByteBuf> builder =
+                new HttpClientBuilder<ByteBuf, ByteBuf>(server.getHost(), server.getPort())
+                    .config(clientConfig);
+
+            if (!this.enableConnectionPooling) {
+                builder.withNoConnectionPooling();
+            }
+            else {
+                if (!this.enableIdleConnectionCleanup) {
+                    builder.withNoIdleConnectionCleanup();
+                }
+            }
+
+            return builder.build();
         }
     }
 
     private static class SSEClientFactory implements HttpClientFactory<ByteBuf, ServerSentEvent> {
 
         public static final int DEFAULT_READ_TIMEOUT_SECS = 5;
-        private int readTimeout = DEFAULT_READ_TIMEOUT_SECS;
+        private final boolean enableConnectionPooling;
+        private final boolean enableIdleConnectionCleanup;
 
-        public SSEClientFactory(int readTimeout) {
-            this.readTimeout = readTimeout;
+        public SSEClientFactory(boolean enableConnectionPooling, boolean enableIdleConnectionCleanup) {
+            this.enableConnectionPooling = enableConnectionPooling;
+            this.enableIdleConnectionCleanup = enableIdleConnectionCleanup;
         }
 
         public SSEClientFactory() {
-            this(DEFAULT_READ_TIMEOUT_SECS);
+            this(false, false);
         }
-
 
         @Override
         public HttpClient<ByteBuf, ServerSentEvent> createClient(ServerInfo server) {
@@ -81,11 +104,29 @@ public class HttpClientFactories {
             //                    .readTimeout(this.readTimeout, TimeUnit.SECONDS)
             //                    .userAgent("Netflix Mantis HTTP Source")
             //                    .build();
-            return RxNetty.createHttpClient(
-                    server.getHost(),
-                    server.getPort(),
-                    //PipelineConfigurators.createClientConfigurator(new  SseClientPipelineConfigurator<ByteBuf>(), clientConfig));
-                    PipelineConfigurators.<ByteBuf>clientSseConfigurator());
+
+            // Forking from original RxNetty.createHttpClient to disable ConnectionPooling or IdleConnectionCleanup
+            // tasks.
+            // RxNetty.createHttpClient(
+            //         server.getHost(),
+            //         server.getPort(),
+            //         //PipelineConfigurators.createClientConfigurator(new  SseClientPipelineConfigurator<ByteBuf>(), clientConfig));
+            //         PipelineConfigurators.<ByteBuf>clientSseConfigurator());
+
+            HttpClientBuilder<ByteBuf, ServerSentEvent> builder =
+                RxNetty.<ByteBuf, ServerSentEvent>newHttpClientBuilder(server.getHost(), server.getPort())
+                    .pipelineConfigurator(PipelineConfigurators.<ByteBuf>clientSseConfigurator());
+
+            if (!this.enableConnectionPooling) {
+                builder.withNoConnectionPooling();
+            }
+            else {
+                if (!this.enableIdleConnectionCleanup) {
+                    builder.withNoIdleConnectionCleanup();
+                }
+            }
+
+            return builder.build();
         }
     }
 }


### PR DESCRIPTION
### Context

Add configurable options for the source client connection pool.
Move the default source client to disable the connection pool to avoid memory leak on pool cleanup.


### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
