### PR TITLE
Fix double TE registration against RC actor

### DIFF
--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceClusterGatewayClient.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceClusterGatewayClient.java
@@ -26,6 +26,7 @@ import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.asynchttpclient.AsyncHttpClient;
@@ -40,6 +41,7 @@ public class ResourceClusterGatewayClient implements ResourceClusterGateway, Clo
   private final int connectionRequestTimeout = 1000;
   private final int socketTimeout = 2000;
   private final ClusterID clusterID;
+  @Getter
   private final MasterDescription masterDescription;
   private AsyncHttpClient client;
   private final ObjectMapper mapper;


### PR DESCRIPTION
### Context

Looks like the TE registers itself twice with the resource cluster actor in rapid succession which could lead to race conditions on caching artifacts.

* The first registration happens during [onStart](https://github.com/Netflix/mantis/blob/058657080e1341667b0fa38fb04b95d8160d560d/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java#L188)
* The second one when ZK registers the new resource cluster (which in the case of first bootstrap of the TE is the same as the one registered during the first registration

In order to avoid double registration for the same RC the High avail service can simply verify whether the RC has actually changed before trying to reconnect to it.

Note: I'm not sure if there are edge cases I'm not considering. I can't think of anything at the moment.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
