### PR TITLE
replace the metrics in HttpServerListener with Micrometer

### DIFF
--- a/mantis-common/build.gradle
+++ b/mantis-common/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     api libraries.slf4jLog4j12
     implementation libraries.commonsIo
     implementation 'net.jcip:jcip-annotations:1.0'
+    implementation 'io.micrometer:micrometer-core:1.11.0'
 
     testImplementation libraries.spectatorApi
     testImplementation libraries.commonsLang3

--- a/mantis-common/src/main/java/io/mantisrx/common/metrics/netty/HttpServerListener.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/metrics/netty/HttpServerListener.java
@@ -46,15 +46,15 @@ public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>>
 
         String groupName = "httpServer-" + monitorId;
 
-        requestBacklog = Gauge.builder(groupName + "_requestBacklog", requestBacklogValue::get)
+        requestBacklog = Gauge.builder(groupName + ":requestBacklog", requestBacklogValue::get)
             .register(Metrics.globalRegistry);
-        inflightRequests = Gauge.builder(groupName +"_inflightRequests", inflightRequestsValue::get)
+        inflightRequests = Gauge.builder(groupName +":inflightRequests", inflightRequestsValue::get)
             .register(Metrics.globalRegistry);
-        failedRequests = Counter.builder(groupName + "_failedRequests")
+        failedRequests = Counter.builder(groupName + ":failedRequests")
             .register(Metrics.globalRegistry);
-        processedRequests = Counter.builder(groupName + "_processedRequests")
+        processedRequests = Counter.builder(groupName + ":processedRequests")
             .register(Metrics.globalRegistry);
-        responseWriteFailed = Counter.builder(groupName + "_responseWriteFailed")
+        responseWriteFailed = Counter.builder(groupName + ":responseWriteFailed")
             .register(Metrics.globalRegistry);
 
         delegate = new HttpServerMetricEventsListenerImpl();

--- a/mantis-common/src/main/java/io/mantisrx/common/metrics/netty/HttpServerListener.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/metrics/netty/HttpServerListener.java
@@ -118,7 +118,7 @@ public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>>
 
         @Override
         protected void onResponseContentWriteSuccess(long duration, TimeUnit timeUnit) {
-
+            // responseWriteTimes.record(duration, timeUnit);
         }
 
         @Override

--- a/mantis-common/src/main/java/io/mantisrx/common/metrics/netty/HttpServerListener.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/metrics/netty/HttpServerListener.java
@@ -45,7 +45,7 @@ public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>>
     protected HttpServerListener(String monitorId) {
         super(monitorId);
 
-        String groupName = "httpServer_" + monitorId;
+        String groupName = "httpServer-" + monitorId;
 
         requestBacklog = Gauge.builder(groupName + "_requestBacklog", this::getRequestBacklog)
             .register(Metrics.globalRegistry);

--- a/mantis-common/src/main/java/io/mantisrx/common/metrics/netty/HttpServerListener.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/metrics/netty/HttpServerListener.java
@@ -16,10 +16,10 @@
 
 package io.mantisrx.common.metrics.netty;
 
-import io.mantisrx.common.metrics.Counter;
-import io.mantisrx.common.metrics.Gauge;
-import io.mantisrx.common.metrics.Metrics;
-import io.mantisrx.common.metrics.MetricsRegistry;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Metrics;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.TimeUnit;
 import mantis.io.reactivex.netty.metrics.HttpServerMetricEventsListener;
 import mantis.io.reactivex.netty.server.ServerMetricsEvent;
@@ -30,37 +30,34 @@ import mantis.io.reactivex.netty.server.ServerMetricsEvent;
  */
 public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>> {
 
+
     private final Gauge requestBacklog;
     private final Gauge inflightRequests;
     private final Counter processedRequests;
     private final Counter failedRequests;
     private final Counter responseWriteFailed;
-    //    private final Timer responseWriteTimes;
-    //    private final Timer requestReadTimes;
+    private AtomicLong inflightRequestsValue = new AtomicLong(0);
+    private AtomicLong requestBacklogValue = new AtomicLong(0);
+
 
     private final HttpServerMetricEventsListenerImpl delegate;
 
     protected HttpServerListener(String monitorId) {
         super(monitorId);
 
-        Metrics m = new Metrics.Builder()
-                .name("httpServer_" + monitorId)
-                .addGauge("requestBacklog")
-                .addGauge("inflightRequests")
-                .addCounter("processedRequests")
-                .addCounter("failedRequests")
-                .addCounter("responseWriteFailed")
+        String groupName = "httpServer_" + monitorId;
 
-                .build();
+        requestBacklog = Gauge.builder(groupName + "_requestBacklog", this::getRequestBacklog)
+            .register(Metrics.globalRegistry);
+        inflightRequests = Gauge.builder(groupName +"_inflightRequests", this::getInflightRequests)
+            .register(Metrics.globalRegistry);
+        failedRequests = Counter.builder(groupName + "_failedRequests")
+            .register(Metrics.globalRegistry);
+        processedRequests = Counter.builder(groupName + "_processedRequests")
+            .register(Metrics.globalRegistry);
+        responseWriteFailed = Counter.builder(groupName + "_responseWriteFailed")
+            .register(Metrics.globalRegistry);
 
-        m = MetricsRegistry.getInstance().registerAndGet(m);
-        requestBacklog = m.getGauge("requestBacklog");
-        inflightRequests = m.getGauge("inflightRequests");
-        //        responseWriteTimes = newTimer("responseWriteTimes");
-        //        requestReadTimes = newTimer("requestReadTimes");
-        processedRequests = m.getCounter("processedRequests");
-        failedRequests = m.getCounter("failedRequests");
-        responseWriteFailed = m.getCounter("responseWriteFailed");
         delegate = new HttpServerMetricEventsListenerImpl();
     }
 
@@ -75,19 +72,20 @@ public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>>
     }
 
     public long getRequestBacklog() {
-        return requestBacklog.value();
+        return requestBacklogValue.get();
     }
 
     public long getInflightRequests() {
-        return inflightRequests.value();
+        return inflightRequestsValue.get();
     }
 
-    public long getProcessedRequests() {
-        return processedRequests.value();
+    public double getProcessedRequests() {
+        return processedRequests.count();
     }
 
-    public long getFailedRequests() {
-        return failedRequests.value();
+
+    public double getFailedRequests() {
+        return failedRequests.count();
     }
 
     //    public Timer getResponseWriteTimes() {
@@ -98,8 +96,9 @@ public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>>
     //        return requestReadTimes;
     //    }
 
-    public long getResponseWriteFailed() {
-        return responseWriteFailed.value();
+
+    public double getResponseWriteFailed() {
+        return responseWriteFailed.count();
     }
 
     private class HttpServerMetricEventsListenerImpl extends HttpServerMetricEventsListener {
@@ -107,19 +106,19 @@ public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>>
         @Override
         protected void onRequestHandlingFailed(long duration, TimeUnit timeUnit, Throwable throwable) {
             processedRequests.increment();
-            inflightRequests.decrement();
+            inflightRequestsValue = new AtomicLong(inflightRequestsValue.get() - 1);
             failedRequests.increment();
         }
 
         @Override
         protected void onRequestHandlingSuccess(long duration, TimeUnit timeUnit) {
-            inflightRequests.decrement();
+            inflightRequestsValue = new AtomicLong(inflightRequestsValue.get() - 1);
             processedRequests.increment();
         }
 
         @Override
         protected void onResponseContentWriteSuccess(long duration, TimeUnit timeUnit) {
-            // responseWriteTimes.record(duration, timeUnit);
+
         }
 
         @Override
@@ -144,13 +143,13 @@ public class HttpServerListener extends TcpServerListener<ServerMetricsEvent<?>>
 
         @Override
         protected void onRequestHandlingStart(long duration, TimeUnit timeUnit) {
-            requestBacklog.decrement();
+            requestBacklogValue = new AtomicLong(requestBacklogValue.get() - 1);
         }
 
         @Override
         protected void onNewRequestReceived() {
-            requestBacklog.increment();
-            inflightRequests.increment();
+            requestBacklogValue = new AtomicLong(requestBacklogValue.get() + 1);
+            inflightRequestsValue = new AtomicLong(inflightRequestsValue.get() + 1);
         }
 
         @Override


### PR DESCRIPTION
### Context

Try to replace the metrics part in HttpServerListener with Micrometer metrics and wanna get some early feedback and advice.

Explanation:
In the previous implementation, we have the concepts GroupId(name, tags) and MetricId(groupname, metricname, tags).
However, in the Micrometer, it cannot name the Metrics with GroupId, so I try to add the group name as a prefix in metric name and connect them with the underscore. 
If we need the group name or the metric(event) name when publishing, we can extract it from the whole metric name.
And we can still use them to form a GroupId(groupname + tags). and MetricId(metricName + tag) if needed.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
