### PR TITLE
Support SKU spec upgrade

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
@@ -17,11 +17,12 @@
 package io.mantisrx.master.resourcecluster.proto;
 
 import io.mantisrx.server.master.resourcecluster.ClusterID;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
 
 @Value
-@Builder
+@Builder(toBuilder = true)
 public class UpgradeClusterContainersRequest {
     ClusterID clusterId;
 
@@ -36,4 +37,9 @@ public class UpgradeClusterContainersRequest {
     int optionalBatchMaxSize;
 
     boolean forceUpgradeOnSameImage;
+
+    boolean enableSkuSpecUpgrade;
+
+    @Nullable
+    MantisResourceClusterSpec resourceClusterSpec;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/UpgradeClusterContainersRequest.java
@@ -17,7 +17,6 @@
 package io.mantisrx.master.resourcecluster.proto;
 
 import io.mantisrx.server.master.resourcecluster.ClusterID;
-import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
 
@@ -39,7 +38,4 @@ public class UpgradeClusterContainersRequest {
     boolean forceUpgradeOnSameImage;
 
     boolean enableSkuSpecUpgrade;
-
-    @Nullable
-    MantisResourceClusterSpec resourceClusterSpec;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/NoopResourceClusterProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/NoopResourceClusterProvider.java
@@ -20,7 +20,6 @@ import io.mantisrx.master.resourcecluster.proto.ProvisionResourceClusterRequest;
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterProvisionSubmissionResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
-import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -40,7 +39,8 @@ public class NoopResourceClusterProvider implements ResourceClusterProvider {
     }
 
     @Override
-    public CompletionStage<UpgradeClusterContainersResponse> upgradeContainerResource(UpgradeClusterContainersRequest request) {
+    public CompletionStage<UpgradeClusterContainersResponse> upgradeContainerResource(
+        ResourceClusterProviderUpgradeRequest request) {
         return CompletableFuture.completedFuture(null);
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProvider.java
@@ -20,7 +20,6 @@ import io.mantisrx.master.resourcecluster.proto.ProvisionResourceClusterRequest;
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterProvisionSubmissionResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
-import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import java.util.concurrent.CompletionStage;
 
@@ -59,7 +58,7 @@ public interface ResourceClusterProvider {
      * If multiple image digest versions need to be ran/hosted at the same time, it is recommended to create a separate
      * sku id in addition to the existing sku(s).
      */
-    CompletionStage<UpgradeClusterContainersResponse> upgradeContainerResource(UpgradeClusterContainersRequest request);
+    CompletionStage<UpgradeClusterContainersResponse> upgradeContainerResource(ResourceClusterProviderUpgradeRequest request);
 
     ResourceClusterResponseHandler getResponseHandler();
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProviderAdapter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProviderAdapter.java
@@ -21,7 +21,6 @@ import io.mantisrx.master.resourcecluster.proto.ProvisionResourceClusterRequest;
 import io.mantisrx.master.resourcecluster.proto.ResourceClusterProvisionSubmissionResponse;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceRequest;
 import io.mantisrx.master.resourcecluster.proto.ScaleResourceResponse;
-import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
 import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse;
 import java.util.concurrent.CompletionStage;
 import lombok.extern.slf4j.Slf4j;
@@ -76,7 +75,7 @@ public class ResourceClusterProviderAdapter implements ResourceClusterProvider {
 
     @Override
     public CompletionStage<UpgradeClusterContainersResponse> upgradeContainerResource(
-        UpgradeClusterContainersRequest request) {
+        ResourceClusterProviderUpgradeRequest request) {
         return providerImpl.upgradeContainerResource(request);
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProviderUpgradeRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProviderUpgradeRequest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.resourcecluster.resourceprovider;
+
+import io.mantisrx.master.resourcecluster.proto.MantisResourceClusterEnvType;
+import io.mantisrx.master.resourcecluster.proto.MantisResourceClusterSpec;
+import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersRequest;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder(toBuilder = true)
+public class ResourceClusterProviderUpgradeRequest {
+    ClusterID clusterId;
+
+    String region;
+
+    String optionalImageId;
+
+    String optionalSkuId;
+
+    MantisResourceClusterEnvType optionalEnvType;
+
+    int optionalBatchMaxSize;
+
+    boolean forceUpgradeOnSameImage;
+
+    boolean enableSkuSpecUpgrade;
+
+    @Nullable
+    MantisResourceClusterSpec resourceClusterSpec;
+
+    public static ResourceClusterProviderUpgradeRequest from(
+        UpgradeClusterContainersRequest req) {
+        return from(req, null);
+    }
+
+    public static ResourceClusterProviderUpgradeRequest from(
+        UpgradeClusterContainersRequest req,
+        MantisResourceClusterSpec resourceClusterSpec) {
+        return ResourceClusterProviderUpgradeRequest.builder()
+            .clusterId(req.getClusterId())
+            .region(req.getRegion())
+            .optionalImageId(req.getOptionalImageId())
+            .optionalSkuId(req.getOptionalSkuId())
+            .optionalEnvType(req.getOptionalEnvType())
+            .optionalBatchMaxSize(req.getOptionalBatchMaxSize())
+            .forceUpgradeOnSameImage(req.isForceUpgradeOnSameImage())
+            .enableSkuSpecUpgrade(req.isEnableSkuSpecUpgrade())
+            .resourceClusterSpec(resourceClusterSpec)
+            .build();
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProviderUpgradeRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/resourceprovider/ResourceClusterProviderUpgradeRequest.java
@@ -31,8 +31,10 @@ public class ResourceClusterProviderUpgradeRequest {
 
     String region;
 
+    @Nullable
     String optionalImageId;
 
+    @Nullable
     String optionalSkuId;
 
     MantisResourceClusterEnvType optionalEnvType;

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -57,6 +57,7 @@ import io.mantisrx.master.resourcecluster.resourceprovider.InMemoryOnlyResourceC
 import io.mantisrx.master.resourcecluster.resourceprovider.NoopResourceClusterResponseHandler;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProvider;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProviderAdapter;
+import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProviderUpgradeRequest;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterResponseHandler;
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.server.master.config.ConfigurationProvider;
@@ -468,7 +469,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
 
         @Override
         public CompletionStage<UpgradeClusterContainersResponse> upgradeContainerResource(
-            UpgradeClusterContainersRequest request) {
+            ResourceClusterProviderUpgradeRequest request) {
             return CompletableFuture.completedFuture(
                 UpgradeClusterContainersResponse.builder()
                     .message("test scale resp")

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActorTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActorTests.java
@@ -44,6 +44,7 @@ import io.mantisrx.master.resourcecluster.proto.UpgradeClusterContainersResponse
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProvider;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterResponseHandler;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterStorageProvider;
+import io.mantisrx.master.resourcecluster.writable.ResourceClusterSpecWritable;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import java.util.concurrent.CompletableFuture;
@@ -465,6 +466,81 @@ public class ResourceClustersHostManagerActorTests {
         assertEquals(ResponseCode.SUCCESS, createResp.responseCode);
 
         verify(resProvider, times(1)).upgradeContainerResource(any());
+        probe.getSystem().stop(resourceClusterActor);
+    }
+
+    @Test
+    public void testUpgradeRequestEnableSkuSpecUpgrade() {
+        TestKit probe = new TestKit(system);
+        ResourceClusterStorageProvider resStorageProvider = mock(ResourceClusterStorageProvider.class);
+        ResourceClusterProvider resProvider = mock(ResourceClusterProvider.class);
+        ResourceClusterResponseHandler responseHandler = mock(ResourceClusterResponseHandler.class);
+
+        UpgradeClusterContainersResponse upgradeRes =
+            UpgradeClusterContainersResponse.builder().responseCode(ResponseCode.SUCCESS).build();
+        when(resProvider.upgradeContainerResource(any())).thenReturn(CompletableFuture.completedFuture(
+            upgradeRes
+        ));
+
+        ProvisionResourceClusterRequest provisionReq = buildProvisionRequest();
+        when(resStorageProvider.getResourceClusterSpecWritable(any()))
+            .thenReturn(CompletableFuture.completedFuture(
+                ResourceClusterSpecWritable.builder()
+                    .clusterSpec(provisionReq.getClusterSpec())
+                    .id(provisionReq.getClusterId())
+                    .build()));
+
+        when(resProvider.getResponseHandler()).thenReturn(responseHandler);
+
+        ActorRef resourceClusterActor = system.actorOf(
+            ResourceClustersHostManagerActor.props(resProvider, resStorageProvider));
+
+        UpgradeClusterContainersRequest request = UpgradeClusterContainersRequest.builder()
+            .clusterId(provisionReq.getClusterId())
+            .enableSkuSpecUpgrade(true)
+            .build();
+
+        resourceClusterActor.tell(request, probe.getRef());
+        UpgradeClusterContainersResponse createResp = probe.expectMsgClass(UpgradeClusterContainersResponse.class);
+
+        assertEquals(ResponseCode.SUCCESS, createResp.responseCode);
+
+        verify(resProvider, times(1)).upgradeContainerResource(any());
+        probe.getSystem().stop(resourceClusterActor);
+    }
+
+    @Test
+    public void testUpgradeRequestEnableSkuSpecUpgradeConflictSpec() {
+        TestKit probe = new TestKit(system);
+        ResourceClusterStorageProvider resStorageProvider = mock(ResourceClusterStorageProvider.class);
+        ResourceClusterProvider resProvider = mock(ResourceClusterProvider.class);
+        ResourceClusterResponseHandler responseHandler = mock(ResourceClusterResponseHandler.class);
+
+        ProvisionResourceClusterRequest provisionReq = buildProvisionRequest();
+        when(resStorageProvider.getResourceClusterSpecWritable(any()))
+            .thenReturn(CompletableFuture.completedFuture(
+                ResourceClusterSpecWritable.builder()
+                    .clusterSpec(provisionReq.getClusterSpec())
+                    .id(provisionReq.getClusterId())
+                    .build()));
+
+        when(resProvider.getResponseHandler()).thenReturn(responseHandler);
+
+        ActorRef resourceClusterActor = system.actorOf(
+            ResourceClustersHostManagerActor.props(resProvider, resStorageProvider));
+
+        UpgradeClusterContainersRequest request = UpgradeClusterContainersRequest.builder()
+            .clusterId(provisionReq.getClusterId())
+            .enableSkuSpecUpgrade(true)
+            .resourceClusterSpec(provisionReq.getClusterSpec())
+            .build();
+
+        resourceClusterActor.tell(request, probe.getRef());
+        UpgradeClusterContainersResponse createResp = probe.expectMsgClass(UpgradeClusterContainersResponse.class);
+
+        assertEquals(ResponseCode.CLIENT_ERROR_CONFLICT, createResp.responseCode);
+
+        verify(resProvider, times(0)).upgradeContainerResource(any());
         probe.getSystem().stop(resourceClusterActor);
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActorTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClustersHostManagerActorTests.java
@@ -509,41 +509,6 @@ public class ResourceClustersHostManagerActorTests {
         probe.getSystem().stop(resourceClusterActor);
     }
 
-    @Test
-    public void testUpgradeRequestEnableSkuSpecUpgradeConflictSpec() {
-        TestKit probe = new TestKit(system);
-        ResourceClusterStorageProvider resStorageProvider = mock(ResourceClusterStorageProvider.class);
-        ResourceClusterProvider resProvider = mock(ResourceClusterProvider.class);
-        ResourceClusterResponseHandler responseHandler = mock(ResourceClusterResponseHandler.class);
-
-        ProvisionResourceClusterRequest provisionReq = buildProvisionRequest();
-        when(resStorageProvider.getResourceClusterSpecWritable(any()))
-            .thenReturn(CompletableFuture.completedFuture(
-                ResourceClusterSpecWritable.builder()
-                    .clusterSpec(provisionReq.getClusterSpec())
-                    .id(provisionReq.getClusterId())
-                    .build()));
-
-        when(resProvider.getResponseHandler()).thenReturn(responseHandler);
-
-        ActorRef resourceClusterActor = system.actorOf(
-            ResourceClustersHostManagerActor.props(resProvider, resStorageProvider));
-
-        UpgradeClusterContainersRequest request = UpgradeClusterContainersRequest.builder()
-            .clusterId(provisionReq.getClusterId())
-            .enableSkuSpecUpgrade(true)
-            .resourceClusterSpec(provisionReq.getClusterSpec())
-            .build();
-
-        resourceClusterActor.tell(request, probe.getRef());
-        UpgradeClusterContainersResponse createResp = probe.expectMsgClass(UpgradeClusterContainersResponse.class);
-
-        assertEquals(ResponseCode.CLIENT_ERROR_CONFLICT, createResp.responseCode);
-
-        verify(resProvider, times(0)).upgradeContainerResource(any());
-        probe.getSystem().stop(resourceClusterActor);
-    }
-
     private ProvisionResourceClusterRequest buildProvisionRequest() {
         return buildProvisionRequest("mantisTestResCluster1", "dev@mantisrx.io");
     }


### PR DESCRIPTION
### Context
Currently upgrade operation on RC is for the image version.
Support a new flag in upgrade RC to be able to upgrade Sku spec in upgrade operation.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
