### PR TITLE
Send heartbeat failure before shutting down TE

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/utils/StatusConstants.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/utils/StatusConstants.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.core.utils;
+
+public class StatusConstants {
+    public static final String STATUS_MESSAGE_FORMAT = "stage %s worker index=%s number=%s %s";
+}

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/Heartbeat.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/Heartbeat.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import javax.annotation.Nullable;
+import lombok.Getter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,9 +36,13 @@ import org.slf4j.LoggerFactory;
 class Heartbeat {
 
     private static final Logger logger = LoggerFactory.getLogger(Heartbeat.class);
+    @Getter
     private final String jobId;
+    @Getter
     private final int stageNumber;
+    @Getter
     private final int workerIndex;
+    @Getter
     private final int workerNumber;
     private final ConcurrentMap<String, String> payloads;
     private final BlockingQueue<PayloadPair> singleUsePayloads = new LinkedBlockingQueue<>();

--- a/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RunningWorker.java
+++ b/mantis-server/mantis-server-worker/src/main/java/io/mantisrx/server/worker/RunningWorker.java
@@ -16,6 +16,8 @@
 
 package io.mantisrx.server.worker;
 
+import static io.mantisrx.server.core.utils.StatusConstants.STATUS_MESSAGE_FORMAT;
+
 import io.mantisrx.runtime.Context;
 import io.mantisrx.runtime.Job;
 import io.mantisrx.runtime.MantisJobState;
@@ -121,17 +123,13 @@ public class RunningWorker {
         };
     }
 
-    private String getWorkerStringPrefix(int stageNum, int index, int number) {
-        return "stage " + stageNum + " worker index=" + index + " number=" + number;
-    }
-
     public void signalStartedInitiated() {
         logger.info("JobId: " + jobId + ", stage: " + stageNum + " workerIndex: " + workerIndex + " workerNumber: " + workerNum + ","
                 + " signaling started initiated");
         vmTaskStatusObserver.onNext(new VirtualMachineTaskStatus(
                 new WorkerId(jobId, workerIndex, workerNum).getId(),
                 VirtualMachineTaskStatus.TYPE.STARTED, jobName + ", " +
-                getWorkerStringPrefix(stageNum, workerIndex, workerNum) + " started"));
+                String.format(STATUS_MESSAGE_FORMAT, stageNum, workerIndex, workerNum, "started")));
         // indicate start success
         requestSubject.onNext(true);
         requestSubject.onCompleted();
@@ -141,10 +139,9 @@ public class RunningWorker {
     }
 
     public void signalStarted() {
-        logger.info("JobId: " + jobId + ", " + getWorkerStringPrefix(stageNum, workerIndex, workerNum)
-                + " signaling started");
+        logger.info("JobId: " + jobId + ", " + String.format(STATUS_MESSAGE_FORMAT, stageNum, workerIndex, workerNum, "signaling started"));
         jobStatus.onNext(new Status(jobId, stageNum, workerIndex, workerNum,
-                TYPE.INFO, getWorkerStringPrefix(stageNum, workerIndex, workerNum) + " running",
+                TYPE.INFO, String.format(STATUS_MESSAGE_FORMAT, stageNum, workerIndex, workerNum, "running"),
                 MantisJobState.Started));
     }
 
@@ -152,7 +149,7 @@ public class RunningWorker {
         logger.info("JobId: " + jobId + ", stage: " + stageNum + " workerIndex: " + workerIndex + " workerNumber: " + workerNum + ","
                 + " signaling completed");
         jobStatus.onNext(new Status(jobId, stageNum, workerIndex, workerNum,
-                TYPE.INFO, getWorkerStringPrefix(stageNum, workerIndex, workerNum) + " completed",
+                TYPE.INFO, String.format(STATUS_MESSAGE_FORMAT, stageNum, workerIndex, workerNum, "completed"),
                 MantisJobState.Completed));
         // send complete status
         jobStatus.onCompleted();
@@ -160,7 +157,7 @@ public class RunningWorker {
         vmTaskStatusObserver.onNext(new VirtualMachineTaskStatus(
                 new WorkerId(jobId, workerIndex, workerNum).getId(),
                 VirtualMachineTaskStatus.TYPE.COMPLETED, jobName + ", " +
-                getWorkerStringPrefix(stageNum, workerIndex, workerNum) + " completed"));
+                String.format(STATUS_MESSAGE_FORMAT, stageNum, workerIndex, workerNum, "completed")));
     }
 
     public void signalFailed(Throwable t) {
@@ -168,7 +165,7 @@ public class RunningWorker {
                 + " signaling failed");
         logger.error("Worker failure detected, shutting down job", t);
         jobStatus.onNext(new Status(jobId, stageNum, workerIndex, workerNum,
-                TYPE.INFO, getWorkerStringPrefix(stageNum, workerIndex, workerNum) + " failed. error: " + t.getMessage(),
+                TYPE.INFO, String.format(STATUS_MESSAGE_FORMAT, stageNum, workerIndex, workerNum, "failed. error: " + t.getMessage()),
                 MantisJobState.Failed));
     }
 


### PR DESCRIPTION
### Context

The purpose of this pull request (PR) is to ensure that a worker is promptly resubmitted in two specific situations: when a shutdown signal is detected by the Task Executor (TE) and when an exception occurs before the job enters the Launched state.

The TE can receive shutdown signals in various ways, with one well-known example being during Titus container migration. During container migration, Titus sends a sigkill signal to the running container, allowing it time to gracefully shut down. It is crucial for the TE to communicate with the master in a timely manner, informing it of the need to reschedule the worker due to the impending migration.

Similarly, if an exception is raised during task preparation, the TE must ask the master to reschedule the TE in another container. One such case occurs when caching artifacts fails due to the download of an artifact for a new job request.

Currently, without this change, TEs affected by these two issues are only resubmitted after a heartbeat timeout, which can take up to 15 minutes. However, with this PR, the resubmission for these specific cases will only take a few seconds.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
