### PR TITLE
Adding zookeeper-jute as part of mantis-shaded

### DIFF
--- a/mantis-shaded/build.gradle
+++ b/mantis-shaded/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     shaded "org.apache.curator:curator-framework:$curatorVersion"
     shaded "org.apache.curator:curator-client:$curatorVersion"
     shaded "org.apache.zookeeper:zookeeper:$zookeeperVersion"
+    shaded "org.apache.zookeeper:zookeeper-jute:$zookeeperVersion"
     shaded "jline:jline:$jlineVersion"
     shaded "io.netty:netty:$nettyVersion"
 


### PR DESCRIPTION
### Context

Adding zookeeper-jute since some of the classes required by curator-framework have been moved to this new module.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
