### PR TITLE
RC Scaler: Delta Calculation instead of Desired Cluster Size

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -247,7 +247,9 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             .instanceIds(instanceList)
             .clusterId(this.clusterID)
             .skuId(req.getSkuId())
-            .scaleDownCount(req.getMaxInstanceCount())
+            .scaleDownCount(req.getScaleDownCount())
+            .registeredCount(req.getRegisteredCount())
+            .idleCount(req.getIdleCount())
             .build();
         log.info("Return idle instance list: {}", res);
         return res;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -247,6 +247,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             .instanceIds(instanceList)
             .clusterId(this.clusterID)
             .skuId(req.getSkuId())
+            .scaleDownCount(req.getMaxInstanceCount())
             .build();
         log.info("Return idle instance list: {}", res);
         return res;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -207,8 +207,11 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                                 GetClusterIdleInstancesRequest.builder()
                                     .clusterID(this.clusterId)
                                     .skuId(skuId)
-                                    .maxInstanceCount(
+                                    .scaleDownCount(
                                         Math.max(0, decisionO.get().getScaleDownCount()))
+                                    .scaleUpCount(0)
+                                    .registeredCount(decisionO.get().getRegisteredCount())
+                                    .idleCount(decisionO.get().getIdleCount())
                                     .build(),
                                 self());
                             break;
@@ -244,6 +247,8 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                 .skuId(response.getSkuId())
                 .scaleDownCount(response.getScaleDownCount())
                 .scaleUpCount(0)
+                .registeredCount(response.getRegisteredCount())
+                .idleCount(response.getIdleCount())
                 .idleInstances(response.getInstanceIds())
                 .build(),
             self());
@@ -332,6 +337,8 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
             .skuId(decision.getSkuId())
             .scaleUpCount(decision.getScaleUpCount())
             .scaleDownCount(decision.getScaleDownCount())
+            .registeredCount(decision.getRegisteredCount())
+            .idleCount(decision.getIdleCount())
             .build();
     }
 
@@ -424,6 +431,8 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                         .skuId(this.scaleSpec.getSkuId())
                         .scaleUpCount(0)
                         .scaleDownCount(step)
+                        .registeredCount(usage.getTotalCount())
+                        .idleCount(usage.getIdleCount())
                         .type(scaleType)
                         .build());
             }
@@ -445,6 +454,8 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                         .skuId(this.scaleSpec.getSkuId())
                         .scaleUpCount(step)
                         .scaleDownCount(0)
+                        .registeredCount(usage.getTotalCount())
+                        .idleCount(usage.getIdleCount())
                         .type(scaleType)
                         .build());
             }
@@ -475,6 +486,8 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
         ClusterID clusterId;
         int scaleUpCount;
         int scaleDownCount;
+        int registeredCount;
+        int idleCount;
         ScaleType type;
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
@@ -28,5 +28,4 @@ public class GetClusterIdleInstancesRequest {
     ContainerSkuID skuId;
 
     int maxInstanceCount;
-    int desireSize;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesRequest.java
@@ -26,6 +26,8 @@ import lombok.Value;
 public class GetClusterIdleInstancesRequest {
     ClusterID clusterID;
     ContainerSkuID skuId;
-
-    int maxInstanceCount;
+    int scaleUpCount;
+    int scaleDownCount;
+    int registeredCount;
+    int idleCount;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesResponse.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesResponse.java
@@ -34,4 +34,6 @@ public class GetClusterIdleInstancesResponse {
     List<TaskExecutorID> instanceIds;
 
     int scaleDownCount;
+    int registeredCount;
+    int idleCount;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesResponse.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/GetClusterIdleInstancesResponse.java
@@ -33,5 +33,5 @@ public class GetClusterIdleInstancesResponse {
     @Singular
     List<TaskExecutorID> instanceIds;
 
-    int desireSize;
+    int scaleDownCount;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
@@ -41,6 +41,10 @@ public class ScaleResourceRequest {
 
     int scaleDownCount;
 
+    int registeredCount;
+
+    int idleCount;
+
     @Singular
     List<TaskExecutorID> idleInstances;
 
@@ -50,7 +54,8 @@ public class ScaleResourceRequest {
             this.region == null ? "" : this.region,
             this.envType != null && this.envType.isPresent() ? this.getEnvType().get().name() : "",
             this.skuId.getResourceID(),
-            this.scaleUpCount, this.scaleDownCount);
+            this.scaleUpCount, this.scaleDownCount,
+            this.registeredCount, this.idleCount);
     }
 
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/ScaleResourceRequest.java
@@ -37,7 +37,9 @@ public class ScaleResourceRequest {
 
     Optional<MantisResourceClusterEnvType> envType;
 
-    int desireSize;
+    int scaleUpCount;
+
+    int scaleDownCount;
 
     @Singular
     List<TaskExecutorID> idleInstances;
@@ -48,7 +50,7 @@ public class ScaleResourceRequest {
             this.region == null ? "" : this.region,
             this.envType != null && this.envType.isPresent() ? this.getEnvType().get().name() : "",
             this.skuId.getResourceID(),
-            this.desireSize);
+            this.scaleUpCount, this.scaleDownCount);
     }
 
 }


### PR DESCRIPTION
### Context

The intention of this PR is to modify the functionality of the RC scaler. Instead of determining the desired cluster size, the proposed change suggests that it should calculate the delta based on the available nodes. The provider implementation would then determine the final desired cluster size.

The primary motivation behind this change is that the scaler currently lacks an accurate perception of the ASG size. Specifically, the total worker count doesn't account for ghost workers, resulting in a computed cluster size that is smaller than the actual size. Let me provide an example to illustrate this:

- Current cluster size: 100
- Number of ghost workers: 10
- Number of available workers: 0
- Cluster scale rule, minimum idle count: 10

Based on these figures, we anticipate the scaler to adjust the cluster to a desired size of 110. However, that is not the case. Let's examine why:

- Cluster size observed by the scaler: 90
- Computed desired size: current_cluster_size + min_idle_count = 90 + 10 = 100

The computed desired cluster size is 100, which coincides with the current size. Consequently, no changes will be applied to the cluster.

By allowing the provider to determine the actual cluster size based on the delta (in this instance, 10), the provider has the ability to fetch the actual ASG state and accurately update its desired size.

While resolving the issue of ghost workers and being able to replenish them is undoubtedly necessary, it is possible that the replacement of a worker using this mechanism would take several minutes, rendering autoscaling ineffective during this period. Therefore, I believe there is merit in pursuing this proposal even after addressing the ghost workers issue.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
