### PR TITLE
Reverting mantis-shaded back to the old version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext.libraries = [
                 "org.junit.jupiter:junit-jupiter-engine:${versions.junit5}",
                 "org.junit.jupiter:junit-jupiter-params:${versions.junit5}",
         ],
-        mantisShaded   : "io.mantisrx:mantis-shaded:2.0.52",
+        mantisShaded   : "io.mantisrx:mantis-shaded:2.0.8",
         mockitoAll     : "org.mockito:mockito-all:${versions.mockito}",
         mockitoCore    : "org.mockito:mockito-core:${versions.mockito}",
         mockitoCore3   : "org.mockito:mockito-core:${versions.mockito3}",

--- a/mantis-control-plane/mantis-control-plane-core/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-core/build.gradle
@@ -19,7 +19,6 @@ ext {
 
     cliParserVersion = '1.1.1'
     configMagicVersion = '0.11'
-    curatorVersion = '2.11.0'
     hdrHistogramVersion = '2.+'
     jodaTimeVersion = '2.+'
     jsonVersion = '20180813'

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -27,7 +27,6 @@ ext {
     cliParserVersion = '1.1.1'
     configMagicVersion = '0.11'
     rxJavaReactiveStreamsVersion = '1.+'
-    curatorVersion = '2.11.0'
     testngVersion = '6.+'
     scalaBinaryVersion = '2.12'
 }

--- a/mantis-server/mantis-server-worker/build.gradle
+++ b/mantis-server/mantis-server-worker/build.gradle
@@ -20,7 +20,6 @@ ext {
     mantisRxControlVersion = '1.3.+'
     mesosVersion = '1.7.2'
     httpComponentsVersion = '4.5.6'
-    curatorVersion = '2.11.0'
 }
 
 dependencies {


### PR DESCRIPTION
### Context

We found an issue with the curator recipes after the upgrade. As a result, we are rolling back to the older version of mantis-shaded. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
