### PR TITLE
Fix consistent test failure

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -185,8 +185,8 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
         when(resourceCluster.disableTaskExecutorsFor(
             ArgumentMatchers.eq(RESOURCE_CLUSTER_DISABLE_TASK_EXECUTORS_ATTRS),
             ArgumentMatchers.argThat(expiry ->
-                expiry.isAfter(Instant.now().plus(Duration.ofHours(18))) &&
-                    expiry.isBefore(Instant.now().plus(Duration.ofHours(19))))))
+                expiry.isAfter(Instant.now().plus(Duration.ofHours(17))) &&
+                    expiry.isBefore(Instant.now().plus(Duration.ofHours(20))))))
             .thenReturn(CompletableFuture.completedFuture(Ack.getInstance()));
         when(resourceClusters.getClusterFor(ClusterID.of("myCluster"))).thenReturn(resourceCluster);
 


### PR DESCRIPTION
### Context
ResourceClusterNonLeaderRedirectRouteTest -> testDisableTaskExecutorsRoute fails consistently in CI due to cache conflict. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
