### PR TITLE
Support TE generation in scheduler 

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
@@ -21,4 +21,5 @@ public class WorkerConstants {
     public static final String WORKER_TASK_ATTRIBUTE_ENV_KEY = "MANTIS_WORKER_CONTAINER_ATTRIBUTE";
     // TODO(fdichiara): make this configurable.
     public static final String AUTO_SCALE_GROUP_KEY = "NETFLIX_AUTO_SCALE_GROUP";
+    public static final String MANTIS_WORKER_CONTAINER_GENERATION = "MANTIS_WORKER_CONTAINER_GENERATION";
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
@@ -35,9 +35,23 @@ import org.apache.commons.lang3.tuple.Pair;
  * A component to manage the states of {@link TaskExecutorState} for a given {@link ResourceClusterActor}.
  */
 public interface ExecutorStateManager {
-    void putIfAbsent(TaskExecutorID taskExecutorID, TaskExecutorState state);
-    void markAvailable(TaskExecutorID taskExecutorID);
-    void markUnavailable(TaskExecutorID taskExecutorID);
+    /**
+     * Store and track the given task executor's state inside this {@link ExecutorStateManager} if there is no existing
+     * state already. Ignore the given state instance if there is already a state associated with the given ID.
+     * @param taskExecutorID TaskExecutorID
+     * @param state new task executor state
+     * @return whether the given task executor becomes available.
+     */
+    boolean onTaskExecutorStateAssigned(TaskExecutorID taskExecutorID, TaskExecutorState state);
+
+    /**
+     * Try to mark the given task executor as available if its tracked state is available.
+     * @param taskExecutorID TaskExecutorID
+     * @return whether the given task executor becomes available.
+     */
+    boolean tryMarkAvailable(TaskExecutorID taskExecutorID);
+
+    void tryMarkUnavailable(TaskExecutorID taskExecutorID);
 
     @Nullable
     TaskExecutorState get(TaskExecutorID taskExecutorID);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.resourcecluster;
 
+import io.mantisrx.common.WorkerConstants;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetClusterUsageRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssignmentRequest;
@@ -27,21 +28,26 @@ import io.mantisrx.server.core.domain.WorkerId;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorRegistration;
 import io.mantisrx.shaded.com.google.common.cache.Cache;
 import io.mantisrx.shaded.com.google.common.cache.CacheBuilder;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NavigableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -53,7 +59,7 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
      * Cache the available executors ready to accept assignments. Note these executors' state are not strongly
      * synchronized and requires state level check when matching.
      */
-    private final SortedMap<Double, Set<TaskExecutorID>> executorByCores = new ConcurrentSkipListMap<>();
+    private final SortedMap<Double, NavigableSet<TaskExecutorHolder>> executorByCores = new ConcurrentSkipListMap<>();
 
     private final Cache<TaskExecutorID, TaskExecutorState> archivedState = CacheBuilder.newBuilder()
         .maximumSize(10000)
@@ -63,55 +69,63 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
         .build();
 
     @Override
-    public void putIfAbsent(TaskExecutorID taskExecutorID, TaskExecutorState state) {
+    public boolean onTaskExecutorStateAssigned(TaskExecutorID taskExecutorID, TaskExecutorState state) {
         this.taskExecutorStateMap.putIfAbsent(taskExecutorID, state);
         if (this.archivedState.getIfPresent(taskExecutorID) != null) {
             log.info("Reviving archived executor: {}", taskExecutorID);
             this.archivedState.invalidate(taskExecutorID);
         }
 
-        // add to buckets. however new executors won't have valid registration at this moment and requires marking
-        // again later when registration is ready.
+        return tryMarkAvailable(taskExecutorID, state);
+    }
+
+    /**
+     * Add to buckets. however new executors won't have valid registration at this moment and requires marking
+     * again later when registration is ready.
+     * @param taskExecutorID taskExecutorID
+     * @param state state
+     * @return whether the target executor is marked as available.
+     */
+    public boolean tryMarkAvailable(TaskExecutorID taskExecutorID, TaskExecutorState state) {
         if (state.isAvailable() && state.getRegistration() != null) {
-            log.info("Marking executor {} as available for matching.", taskExecutorID);
+            TaskExecutorHolder teHolder = TaskExecutorHolder.of(taskExecutorID, state.getRegistration());
+            log.debug("Marking executor {} as available for matching.", teHolder);
             double cpuCores = state.getRegistration().getMachineDefinition().getCpuCores();
             if (!this.executorByCores.containsKey(cpuCores)) {
-                this.executorByCores.putIfAbsent(cpuCores, new HashSet<>());
+                this.executorByCores.putIfAbsent(
+                    cpuCores,
+                    new TreeSet<>(TaskExecutorHolder.generationFirstComparator));
             }
 
-            this.executorByCores.get(cpuCores).add(taskExecutorID);
+            log.info("Assign {} to available.", teHolder.getId());
+            return this.executorByCores.get(cpuCores).add(teHolder);
+        }
+        else {
+            log.warn("Ignore unavailable TE: {}", taskExecutorID);
+            return false;
         }
     }
 
     @Override
-    public void markAvailable(TaskExecutorID taskExecutorID) {
+    public boolean tryMarkAvailable(TaskExecutorID taskExecutorID) {
         if (!this.taskExecutorStateMap.containsKey(taskExecutorID)) {
             log.warn("marking invalid executor as available: {}", taskExecutorID);
-            return;
+            return false;
         }
 
         TaskExecutorState taskExecutorState = this.taskExecutorStateMap.get(taskExecutorID);
-        if (taskExecutorState.getRegistration() == null) {
-            log.warn("marking invalid executor registration as available: {}", taskExecutorID);
-            return;
-        }
-
-        double cpuCores = taskExecutorState.getRegistration().getMachineDefinition().getCpuCores();
-        if (!this.executorByCores.containsKey(cpuCores)) {
-            this.executorByCores.putIfAbsent(cpuCores, new HashSet<>());
-        }
-
-        this.executorByCores.get(cpuCores).add(taskExecutorID);
+        return tryMarkAvailable(taskExecutorID, taskExecutorState);
     }
 
     @Override
-    public void markUnavailable(TaskExecutorID taskExecutorID) {
+    public void tryMarkUnavailable(TaskExecutorID taskExecutorID) {
         if (this.taskExecutorStateMap.containsKey(taskExecutorID)) {
             TaskExecutorState taskExecutorState = this.taskExecutorStateMap.get(taskExecutorID);
             if (taskExecutorState.getRegistration() != null) {
                 double cpuCores = taskExecutorState.getRegistration().getMachineDefinition().getCpuCores();
                 if (this.executorByCores.containsKey(cpuCores)) {
-                    this.executorByCores.get(cpuCores).remove(taskExecutorID);
+                    this.executorByCores.get(cpuCores)
+                        .remove(TaskExecutorHolder.of(taskExecutorID, taskExecutorState.getRegistration()));
                 }
                 return;
             }
@@ -209,7 +223,7 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
     @Override
     public Optional<Pair<TaskExecutorID, TaskExecutorState>> findBestFit(TaskExecutorAssignmentRequest request) {
         // only allow allocation in the lowest CPU cores matching group.
-        SortedMap<Double, Set<TaskExecutorID>> targetMap =
+        SortedMap<Double, NavigableSet<TaskExecutorHolder>> targetMap =
             this.executorByCores.tailMap(request.getAllocationRequest().getMachineDefinition().getCpuCores());
 
         if (targetMap.size() < 1) {
@@ -220,19 +234,21 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
         log.trace("Applying assignmentReq: {} to {} cores.", request, targetCoreCount);
 
         return this.executorByCores.get(targetCoreCount)
+            .descendingSet()
             .stream()
-            .filter(tid -> {
-                if (!this.taskExecutorStateMap.containsKey(tid)) {
+            .filter(teHolder -> {
+                if (!this.taskExecutorStateMap.containsKey(teHolder.getId())) {
                     return false;
                 }
 
-                TaskExecutorState st = this.taskExecutorStateMap.get(tid);
+                TaskExecutorState st = this.taskExecutorStateMap.get(teHolder.getId());
                 return st.isAvailable() &&
                     st.getRegistration() != null &&
                     st.getRegistration().getMachineDefinition().canFit(
                         request.getAllocationRequest().getMachineDefinition());
             })
-            .findAny()
+            .findFirst()
+            .map(TaskExecutorHolder::getId)
             .map(taskExecutorID -> Pair.of(taskExecutorID, this.taskExecutorStateMap.get(taskExecutorID)));
     }
 
@@ -294,5 +310,25 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
         GetClusterUsageResponse res = resBuilder.build();
         log.info("Usage result: {}", res);
         return res;
+    }
+
+    @Builder
+    @Value
+    protected static class TaskExecutorHolder {
+        TaskExecutorID Id;
+        String generation;
+
+        public static TaskExecutorHolder of(TaskExecutorID id, TaskExecutorRegistration reg) {
+            String generation = reg.getAttributeByKey(WorkerConstants.MANTIS_WORKER_CONTAINER_GENERATION)
+                .orElse(reg.getAttributeByKey(WorkerConstants.AUTO_SCALE_GROUP_KEY).orElse("empty-generation"));
+            return TaskExecutorHolder.builder()
+                .Id(id)
+                .generation(generation)
+                .build();
+        }
+
+        public static Comparator<TaskExecutorHolder> generationFirstComparator =
+            Comparator.comparing(TaskExecutorHolder::getGeneration)
+                .thenComparing(teh -> teh.getId().getResourceId());
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -450,7 +450,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             mantisJobStore.storeNewTaskExecutor(registration);
             if (stateChange) {
                 if (state.isAvailable()) {
-                    this.executorStateManager.markAvailable(taskExecutorID);
+                    this.executorStateManager.tryMarkAvailable(taskExecutorID);
                 }
                 // check if the task executor has been marked as 'Disabled'
                 for (DisableTaskExecutorsRequest request: activeDisableTaskExecutorsRequests) {
@@ -479,7 +479,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             boolean stateChange = state.onHeartbeat(heartbeat);
             if (stateChange) {
                 if (state.isAvailable()) {
-                    this.executorStateManager.markAvailable(taskExecutorID);
+                    this.executorStateManager.tryMarkAvailable(taskExecutorID);
                 }
             }
 
@@ -498,9 +498,9 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             boolean stateChange = state.onTaskExecutorStatusChange(statusChange);
             if (stateChange) {
                 if (state.isAvailable()) {
-                    this.executorStateManager.markAvailable(taskExecutorID);
+                    this.executorStateManager.tryMarkAvailable(taskExecutorID);
                 } else {
-                    this.executorStateManager.markUnavailable(taskExecutorID);
+                    this.executorStateManager.tryMarkUnavailable(taskExecutorID);
                 }
             }
 
@@ -552,7 +552,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             {
                 boolean stateChange = state.onUnassignment();
                 if (stateChange) {
-                    this.executorStateManager.markAvailable(request.getTaskExecutorID());
+                    this.executorStateManager.tryMarkAvailable(request.getTaskExecutorID());
                 }
             } catch (IllegalStateException e) {
                 if (state.isRegistered()) {
@@ -661,7 +661,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
 
     private void setupTaskExecutorStateIfNecessary(TaskExecutorID taskExecutorID) {
         this.executorStateManager
-            .putIfAbsent(taskExecutorID, TaskExecutorState.of(clock, rpcService, jobMessageRouter));
+            .onTaskExecutorStateAssigned(taskExecutorID, TaskExecutorState.of(clock, rpcService, jobMessageRouter));
     }
 
     private void updateHeartbeatTimeout(TaskExecutorID taskExecutorID) {

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
@@ -18,11 +18,14 @@ package io.mantisrx.master.resourcecluster;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
+import io.mantisrx.common.WorkerConstants;
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.common.util.DelegateClock;
+import io.mantisrx.master.resourcecluster.ExecutorStateManagerImpl.TaskExecutorHolder;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssignmentRequest;
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.server.core.TestingRpcService;
@@ -41,6 +44,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.tuple.Pair;
@@ -78,37 +82,41 @@ public class ExecutorStateManagerTests {
         new MachineDefinition(4.0, 2.0, 3.0, 4.0, 5);
     private static final Map<String, String> ATTRIBUTES =
         ImmutableMap.of("attr1", "attr2");
+
+    private static final String SCALE_GROUP_1 = "io-mantisrx-v001";
+    private static final String SCALE_GROUP_2 = "io-mantisrx-v002";
+
+    private static final Map<String, String> ATTRIBUTES_WITH_SCALE_GROUP_1 =
+        ImmutableMap.of(WorkerConstants.AUTO_SCALE_GROUP_KEY, SCALE_GROUP_1);
+
+    private static final Map<String, String> ATTRIBUTES_WITH_SCALE_GROUP_2 =
+        ImmutableMap.of(WorkerConstants.AUTO_SCALE_GROUP_KEY, SCALE_GROUP_2);
+
     private static final WorkerId WORKER_ID = WorkerId.fromIdUnsafe("late-sine-function-tutorial-1-worker-0-1");
 
-    private final TaskExecutorRegistration registration1 = TaskExecutorRegistration.builder()
-        .taskExecutorID(TASK_EXECUTOR_ID_1)
-                .clusterID(CLUSTER_ID)
-                .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
-                .hostname(HOST_NAME)
-                .workerPorts(WORKER_PORTS)
-                .machineDefinition(MACHINE_DEFINITION_1)
-                .taskExecutorAttributes(ATTRIBUTES)
-                .build();
+    private final TaskExecutorRegistration registration1 =
+        getRegistrationBuilder(TASK_EXECUTOR_ID_1, MACHINE_DEFINITION_1, ATTRIBUTES).build();
 
-    private final TaskExecutorRegistration registration2 = TaskExecutorRegistration.builder()
-        .taskExecutorID(TASK_EXECUTOR_ID_2)
-        .clusterID(CLUSTER_ID)
-        .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
-        .hostname(HOST_NAME)
-        .workerPorts(WORKER_PORTS)
-        .machineDefinition(MACHINE_DEFINITION_2)
-        .taskExecutorAttributes(ATTRIBUTES)
-        .build();
+    private final TaskExecutorRegistration registration2 =
+        getRegistrationBuilder(TASK_EXECUTOR_ID_2, MACHINE_DEFINITION_2, ATTRIBUTES).build();
 
-    private final TaskExecutorRegistration registration3 = TaskExecutorRegistration.builder()
-        .taskExecutorID(TASK_EXECUTOR_ID_3)
-        .clusterID(CLUSTER_ID)
-        .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
-        .hostname(HOST_NAME)
-        .workerPorts(WORKER_PORTS)
-        .machineDefinition(MACHINE_DEFINITION_2)
-        .taskExecutorAttributes(ATTRIBUTES)
-        .build();
+    private final TaskExecutorRegistration registration3 =
+        getRegistrationBuilder(TASK_EXECUTOR_ID_3, MACHINE_DEFINITION_2, ATTRIBUTES).build();
+
+    private static TaskExecutorRegistration.TaskExecutorRegistrationBuilder getRegistrationBuilder(
+        TaskExecutorID id,
+        MachineDefinition mDef,
+        Map<String,
+        String> attributes) {
+        return TaskExecutorRegistration.builder()
+            .taskExecutorID(id)
+            .clusterID(CLUSTER_ID)
+            .taskExecutorAddress(TASK_EXECUTOR_ADDRESS)
+            .hostname(HOST_NAME)
+            .workerPorts(WORKER_PORTS)
+            .machineDefinition(mDef)
+            .taskExecutorAttributes(attributes);
+    }
 
     private final ExecutorStateManager stateManager = new ExecutorStateManagerImpl();
 
@@ -126,21 +134,20 @@ public class ExecutorStateManagerTests {
 
         assertFalse(bestFitO.isPresent());
 
-        stateManager.putIfAbsent(TASK_EXECUTOR_ID_1, state1);
+        stateManager.onTaskExecutorStateAssigned(TASK_EXECUTOR_ID_1, state1);
         state1.onRegistration(registration1);
         state1.onTaskExecutorStatusChange(new TaskExecutorStatusChange(TASK_EXECUTOR_ID_1, CLUSTER_ID,
             TaskExecutorReport.available()));
-        stateManager.markAvailable(TASK_EXECUTOR_ID_1);
+        stateManager.tryMarkAvailable(TASK_EXECUTOR_ID_1);
 
-        stateManager.putIfAbsent(TASK_EXECUTOR_ID_2, state2);
+        stateManager.onTaskExecutorStateAssigned(TASK_EXECUTOR_ID_2, state2);
         state2.onRegistration(registration2);
         state2.onTaskExecutorStatusChange(new TaskExecutorStatusChange(TASK_EXECUTOR_ID_2, CLUSTER_ID,
             TaskExecutorReport.available()));
-        stateManager.markAvailable(TASK_EXECUTOR_ID_2);
+        stateManager.tryMarkAvailable(TASK_EXECUTOR_ID_2);
 
-        stateManager.putIfAbsent(TASK_EXECUTOR_ID_3, state3);
+        stateManager.onTaskExecutorStateAssigned(TASK_EXECUTOR_ID_3, state3);
         state3.onRegistration(registration3);
-        stateManager.markAvailable(TASK_EXECUTOR_ID_3);
 
         // test machine def 1
         bestFitO =
@@ -169,6 +176,7 @@ public class ExecutorStateManagerTests {
         // enable e3 and disable e2
         state3.onTaskExecutorStatusChange(new TaskExecutorStatusChange(TASK_EXECUTOR_ID_3, CLUSTER_ID,
             TaskExecutorReport.available()));
+        stateManager.tryMarkAvailable(TASK_EXECUTOR_ID_3);
         state2.onTaskExecutorStatusChange(new TaskExecutorStatusChange(TASK_EXECUTOR_ID_2, CLUSTER_ID,
             TaskExecutorReport.occupied(WORKER_ID)));
 
@@ -181,11 +189,162 @@ public class ExecutorStateManagerTests {
         assertEquals(state3, bestFitO.get().getRight());
 
         // test mark as unavailable
-        stateManager.markUnavailable(TASK_EXECUTOR_ID_3);
+        stateManager.tryMarkUnavailable(TASK_EXECUTOR_ID_3);
         bestFitO =
             stateManager.findBestFit(new TaskExecutorAssignmentRequest(
                 TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2), CLUSTER_ID));
 
         assertFalse(bestFitO.isPresent());
+    }
+
+    @Test
+    public void testTaskExecutorHolderCreation() {
+        TaskExecutorHolder taskExecutorHolder = TaskExecutorHolder.of(
+            TASK_EXECUTOR_ID_1,
+            getRegistrationBuilder(TASK_EXECUTOR_ID_1, MACHINE_DEFINITION_1, ATTRIBUTES).build());
+        assertEquals("empty-generation", taskExecutorHolder.getGeneration());
+        assertEquals(TASK_EXECUTOR_ID_1, taskExecutorHolder.getId());
+
+        taskExecutorHolder = TaskExecutorHolder.of(
+            TASK_EXECUTOR_ID_2,
+            getRegistrationBuilder(TASK_EXECUTOR_ID_2, MACHINE_DEFINITION_1, ATTRIBUTES_WITH_SCALE_GROUP_1).build());
+        assertEquals(SCALE_GROUP_1, taskExecutorHolder.getGeneration());
+        assertEquals(TASK_EXECUTOR_ID_2, taskExecutorHolder.getId());
+
+        taskExecutorHolder = TaskExecutorHolder.of(
+            TASK_EXECUTOR_ID_2,
+            getRegistrationBuilder(TASK_EXECUTOR_ID_2, MACHINE_DEFINITION_2, ATTRIBUTES_WITH_SCALE_GROUP_2).build());
+        assertEquals(SCALE_GROUP_2, taskExecutorHolder.getGeneration());
+        assertEquals(TASK_EXECUTOR_ID_2, taskExecutorHolder.getId());
+
+        ImmutableMap<String, String> attributeWithGeneration = ImmutableMap.of(
+            WorkerConstants.AUTO_SCALE_GROUP_KEY, SCALE_GROUP_1,
+            WorkerConstants.MANTIS_WORKER_CONTAINER_GENERATION, SCALE_GROUP_2);
+
+        taskExecutorHolder = TaskExecutorHolder.of(
+            TASK_EXECUTOR_ID_2,
+            getRegistrationBuilder(TASK_EXECUTOR_ID_2, MACHINE_DEFINITION_2, attributeWithGeneration).build());
+        assertEquals(SCALE_GROUP_2, taskExecutorHolder.getGeneration());
+        assertEquals(TASK_EXECUTOR_ID_2, taskExecutorHolder.getId());
+    }
+
+    @Test
+    public void testGetBestFit_WithGenerationFromScaleGroup() {
+        Optional<Pair<TaskExecutorID, TaskExecutorState>> bestFitO =
+            stateManager.findBestFit(
+                new TaskExecutorAssignmentRequest(
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2),
+                    CLUSTER_ID));
+        assertFalse(bestFitO.isPresent());
+
+        /*
+        Setup 3 TE where te1 is in group 2 while te2/3 in group 1. The best fit should be te1.
+         */
+
+        // add te0 to another mDef, should not be chosen.
+        TaskExecutorState teState0 = registerNewTaskExecutor(TaskExecutorID.of("te0"),
+            MACHINE_DEFINITION_2,
+            ATTRIBUTES_WITH_SCALE_GROUP_2,
+            stateManager);
+
+        TaskExecutorState teState1 = registerNewTaskExecutor(TASK_EXECUTOR_ID_1,
+            MACHINE_DEFINITION_1,
+            ATTRIBUTES_WITH_SCALE_GROUP_2,
+            stateManager);
+
+        TaskExecutorState teState2 = registerNewTaskExecutor(TASK_EXECUTOR_ID_2,
+            MACHINE_DEFINITION_1,
+            ATTRIBUTES_WITH_SCALE_GROUP_1,
+            stateManager);
+
+        TaskExecutorState teState3 = registerNewTaskExecutor(TASK_EXECUTOR_ID_3,
+            MACHINE_DEFINITION_1,
+            ATTRIBUTES_WITH_SCALE_GROUP_1,
+            stateManager);
+
+        // should get te1 with group2
+        bestFitO =
+            stateManager.findBestFit(
+                new TaskExecutorAssignmentRequest(
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1),
+                    CLUSTER_ID));
+
+        assertTrue(bestFitO.isPresent());
+        assertEquals(TASK_EXECUTOR_ID_1, bestFitO.get().getLeft());
+        assertEquals(teState1, bestFitO.get().getRight());
+
+        // add new TE in group1 doesn't affect result.
+        TaskExecutorState teState4 = registerNewTaskExecutor(TaskExecutorID.of("te4"),
+            MACHINE_DEFINITION_1,
+            ATTRIBUTES_WITH_SCALE_GROUP_1,
+            stateManager);
+
+        bestFitO =
+            stateManager.findBestFit(
+                new TaskExecutorAssignmentRequest(
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1),
+                    CLUSTER_ID));
+
+        assertTrue(bestFitO.isPresent());
+        assertEquals(TASK_EXECUTOR_ID_1, bestFitO.get().getLeft());
+        assertEquals(teState1, bestFitO.get().getRight());
+
+        // remove te1 and add new te in both groups
+        teState1.onTaskExecutorStatusChange(
+            new TaskExecutorStatusChange(TASK_EXECUTOR_ID_1, CLUSTER_ID, TaskExecutorReport.occupied(WORKER_ID)));
+
+        TaskExecutorID te5Id = TaskExecutorID.of("te5");
+        TaskExecutorState teState5 = registerNewTaskExecutor(te5Id,
+            MACHINE_DEFINITION_1,
+            ATTRIBUTES_WITH_SCALE_GROUP_2,
+            stateManager);
+
+        TaskExecutorState teState6 = registerNewTaskExecutor(TaskExecutorID.of("te6"),
+            MACHINE_DEFINITION_1,
+            ATTRIBUTES_WITH_SCALE_GROUP_1,
+            stateManager);
+
+        bestFitO =
+            stateManager.findBestFit(
+                new TaskExecutorAssignmentRequest(
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1),
+                    CLUSTER_ID));
+
+        assertTrue(bestFitO.isPresent());
+        assertEquals(te5Id, bestFitO.get().getLeft());
+        assertEquals(teState5, bestFitO.get().getRight());
+
+        // disable all group2 TEs and allow bestFit from group1
+        teState5.onTaskExecutorStatusChange(
+            new TaskExecutorStatusChange(te5Id, CLUSTER_ID, TaskExecutorReport.occupied(WORKER_ID)));
+        bestFitO =
+            stateManager.findBestFit(
+                new TaskExecutorAssignmentRequest(
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1),
+                    CLUSTER_ID));
+
+        assertTrue(bestFitO.isPresent());
+        assertNotEquals(te5Id, bestFitO.get().getLeft());
+        assertNotEquals(TASK_EXECUTOR_ID_1, bestFitO.get().getLeft());
+        assertEquals(SCALE_GROUP_1,
+            Objects.requireNonNull(bestFitO.get().getRight().getRegistration())
+                .getAttributeByKey(WorkerConstants.AUTO_SCALE_GROUP_KEY).orElse("invalid"));
+    }
+
+    private TaskExecutorState registerNewTaskExecutor(TaskExecutorID id, MachineDefinition mdef,
+        Map<String, String> attributes,
+        ExecutorStateManager stateManager) {
+        TaskExecutorState state = TaskExecutorState.of(clock, rpc, router);
+        TaskExecutorRegistration reg = getRegistrationBuilder(id, mdef, attributes).build();
+        stateManager.onTaskExecutorStateAssigned(id, state);
+        state.onRegistration(reg);
+        state.onTaskExecutorStatusChange(
+            new TaskExecutorStatusChange(
+                id,
+                CLUSTER_ID,
+                TaskExecutorReport.available()));
+        stateManager.tryMarkAvailable(id);
+
+        return state;
     }
 }


### PR DESCRIPTION
### Context

Introduce new metadata "generation" in the task executor state so that the scheduler will always try to use a TE on newer generation during scheduling. Thus during any TE upgrade/migration, the newly deployed TEs will get the migrated-out assignments and avoid repeated migration if these migrated-out workers were assigned to other older generation TEs that would get upgraded shortly after.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
