### PR TITLE
Make default: inherit worker count from previous job if exists

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobDefinition.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobDefinition.java
@@ -133,12 +133,13 @@ public class JobDefinition {
     }
 
     public boolean requireInheritInstanceCheck() {
-        return this.schedulingInfo != null && this.deploymentStrategy != null && this.getDeploymentStrategy().requireInheritInstanceCheck();
+        return this.schedulingInfo != null &&
+            (this.deploymentStrategy == null || this.getDeploymentStrategy().requireInheritInstanceCheck());
     }
 
     public boolean requireInheritInstanceCheck(int stageNum) {
         return this.schedulingInfo != null && this.getSchedulingInfo().getStages().containsKey(stageNum) &&
-                this.deploymentStrategy != null && this.getDeploymentStrategy().requireInheritInstanceCheck(stageNum);
+            (this.deploymentStrategy == null || this.getDeploymentStrategy().requireInheritInstanceCheck(stageNum));
     }
 
     private void validateSla() throws InvalidJobException {


### PR DESCRIPTION
### Context

When launching a new job, default to worker count from previous job if one exists.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
