### PR TITLE
Fixing a bug around identify cgroup v1 correctly

### DIFF
--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/metrics/cgroups/CgroupImpl.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/metrics/cgroups/CgroupImpl.java
@@ -24,9 +24,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -120,12 +122,16 @@ public class CgroupImpl implements Cgroup {
         }
     }
 
+    private static final Set<String> knownSubsystems =
+        new HashSet<>(Arrays.asList("cpu", "cpuacct", "cpuset", "memory"));
+
     private List<String> getSubsystems() {
         return
             Arrays.asList(Objects.requireNonNull(Paths.get(path).toFile().listFiles()))
                 .stream()
                 .filter(s -> s.isDirectory())
                 .map(s -> s.getName())
+                .filter(s -> knownSubsystems.contains(s))
                 .collect(Collectors.toList());
     }
 }

--- a/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/metrics/cgroups/TestCgroup.java
+++ b/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/metrics/cgroups/TestCgroup.java
@@ -17,6 +17,7 @@
 package io.mantisrx.server.agent.metrics.cgroups;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import io.mantisrx.shaded.com.google.common.io.Resources;
@@ -33,6 +34,7 @@ public class TestCgroup {
         assertEquals(
             ImmutableMap.of("user", 49692738L, "system", 4700825L),
             cgroup.getStats("cpuacct", "cpuacct.stat"));
+        assertTrue(cgroup.isV1());
     }
 
     @Test

--- a/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/metrics/cgroups/TestCpuAcctsSubsystemProcess.java
+++ b/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/metrics/cgroups/TestCpuAcctsSubsystemProcess.java
@@ -17,6 +17,7 @@
 package io.mantisrx.server.agent.metrics.cgroups;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -55,6 +56,7 @@ public class TestCpuAcctsSubsystemProcess {
     public void testCgroupsV2() throws IOException {
         final Cgroup cgroupv2 =
             new CgroupImpl(Resources.getResource("example2").getPath());
+        assertFalse(cgroupv2.isV1());
 
         final CpuAcctsSubsystemProcess process = new CpuAcctsSubsystemProcess(cgroupv2);
         final Usage.UsageBuilder usageBuilder = Usage.builder();


### PR DESCRIPTION
### Context

Explain context and other details for this pull request.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
