### PR TITLE
Fix getTaskExecutorStatus failure on invalid TE ID

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -228,14 +228,11 @@ public interface ResourceCluster extends ResourceClusterGateway {
         @Nullable
         WorkerId workerId;
         long lastHeartbeatInMs;
+    }
 
-        public static TaskExecutorStatus NotFound = new TaskExecutorStatus(
-            null,
-            false,
-            false,
-            false,
-            false,
-            null,
-            -1);
+    class NotFoundException extends Exception {
+        public NotFoundException(String message) {
+            super(message);
+        }
     }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -230,8 +230,8 @@ public interface ResourceCluster extends ResourceClusterGateway {
         long lastHeartbeatInMs;
     }
 
-    class NotFoundException extends Exception {
-        public NotFoundException(String message) {
+    class ResourceNotFoundException extends Exception {
+        public ResourceNotFoundException(String message) {
             super(message);
         }
     }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -229,10 +229,4 @@ public interface ResourceCluster extends ResourceClusterGateway {
         WorkerId workerId;
         long lastHeartbeatInMs;
     }
-
-    class ResourceNotFoundException extends Exception {
-        public ResourceNotFoundException(String message) {
-            super(message);
-        }
-    }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -228,5 +228,14 @@ public interface ResourceCluster extends ResourceClusterGateway {
         @Nullable
         WorkerId workerId;
         long lastHeartbeatInMs;
+
+        public static TaskExecutorStatus NotFound = new TaskExecutorStatus(
+            null,
+            false,
+            false,
+            false,
+            false,
+            null,
+            -1);
     }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorNotFoundException.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorNotFoundException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.master.resourcecluster;
+
+/**
+ * Exception when asked {@link TaskExecutorID} cannot be found in control plane.
+ */
+public class TaskExecutorNotFoundException extends Exception {
+    public TaskExecutorNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
@@ -42,7 +42,7 @@ import com.netflix.spectator.api.BasicTag;
 import io.mantisrx.master.api.akka.route.Jackson;
 import io.mantisrx.master.api.akka.route.MasterApiMetrics;
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
-import io.mantisrx.server.master.resourcecluster.ResourceCluster.NotFoundException;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceNotFoundException;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.node.ObjectNode;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ser.FilterProvider;
@@ -324,7 +324,7 @@ abstract class BaseRoute extends AllDirectives {
         return onComplete(tFuture,
             t -> t.fold(
                 throwable -> {
-                    if (throwable instanceof NotFoundException) {
+                    if (throwable instanceof ResourceNotFoundException) {
                         return complete(StatusCodes.NOT_FOUND);
                     }
                     return complete(StatusCodes.INTERNAL_SERVER_ERROR, throwable, Jackson.marshaller());

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
@@ -42,6 +42,7 @@ import com.netflix.spectator.api.BasicTag;
 import io.mantisrx.master.api.akka.route.Jackson;
 import io.mantisrx.master.api.akka.route.MasterApiMetrics;
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster.NotFoundException;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.node.ObjectNode;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ser.FilterProvider;
@@ -322,7 +323,12 @@ abstract class BaseRoute extends AllDirectives {
     protected  <T> Route withFuture(CompletableFuture<T> tFuture) {
         return onComplete(tFuture,
             t -> t.fold(
-                throwable -> complete(StatusCodes.INTERNAL_SERVER_ERROR, throwable, Jackson.marshaller()),
+                throwable -> {
+                    if (throwable instanceof NotFoundException) {
+                        return complete(StatusCodes.NOT_FOUND);
+                    }
+                    return complete(StatusCodes.INTERNAL_SERVER_ERROR, throwable, Jackson.marshaller());
+                },
                 r -> complete(StatusCodes.OK, r, Jackson.marshaller())));
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
@@ -42,7 +42,7 @@ import com.netflix.spectator.api.BasicTag;
 import io.mantisrx.master.api.akka.route.Jackson;
 import io.mantisrx.master.api.akka.route.MasterApiMetrics;
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
-import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceNotFoundException;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorNotFoundException;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.node.ObjectNode;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ser.FilterProvider;
@@ -324,7 +324,7 @@ abstract class BaseRoute extends AllDirectives {
         return onComplete(tFuture,
             t -> t.fold(
                 throwable -> {
-                    if (throwable instanceof ResourceNotFoundException) {
+                    if (throwable instanceof TaskExecutorNotFoundException) {
                         return complete(StatusCodes.NOT_FOUND);
                     }
                     return complete(StatusCodes.INTERNAL_SERVER_ERROR, throwable, Jackson.marshaller());

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -37,6 +37,7 @@ import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.PagedActiveJobOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ConnectionFailedException;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.NoResourceAvailableException;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster.NotFoundException;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.TaskExecutorStatus;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorAllocationRequest;
@@ -638,11 +639,12 @@ class ResourceClusterActor extends AbstractActorWithTimers {
     }
 
     @Nonnull
-    private TaskExecutorStatus getTaskExecutorStatus(TaskExecutorID taskExecutorID) {
+    private Object getTaskExecutorStatus(TaskExecutorID taskExecutorID) throws NotFoundException {
         final TaskExecutorState state = this.executorStateManager.get(taskExecutorID);
         if (state == null) {
             log.info("Unknown executorID: {}", taskExecutorID);
-            return TaskExecutorStatus.NotFound;
+            return new Status.Failure(new NotFoundException(String.format("%s not found",
+                taskExecutorID.getResourceId())));
         }
 
         return new TaskExecutorStatus(

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -37,7 +37,7 @@ import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.PagedActiveJobOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ConnectionFailedException;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.NoResourceAvailableException;
-import io.mantisrx.server.master.resourcecluster.ResourceCluster.NotFoundException;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceNotFoundException;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.TaskExecutorStatus;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorAllocationRequest;
@@ -639,11 +639,11 @@ class ResourceClusterActor extends AbstractActorWithTimers {
     }
 
     @Nonnull
-    private Object getTaskExecutorStatus(TaskExecutorID taskExecutorID) throws NotFoundException {
+    private Object getTaskExecutorStatus(TaskExecutorID taskExecutorID) throws ResourceNotFoundException {
         final TaskExecutorState state = this.executorStateManager.get(taskExecutorID);
         if (state == null) {
             log.info("Unknown executorID: {}", taskExecutorID);
-            return new Status.Failure(new NotFoundException(String.format("%s not found",
+            return new Status.Failure(new ResourceNotFoundException(String.format("%s not found",
                 taskExecutorID.getResourceId())));
         }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
@@ -19,6 +19,8 @@ package io.mantisrx.master.resourcecluster;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -329,6 +331,9 @@ public class ExecutorStateManagerTests {
         assertEquals(SCALE_GROUP_1,
             Objects.requireNonNull(bestFitO.get().getRight().getRegistration())
                 .getAttributeByKey(WorkerConstants.AUTO_SCALE_GROUP_KEY).orElse("invalid"));
+
+        assertNotNull(stateManager.get(TASK_EXECUTOR_ID_1));
+        assertNull(stateManager.get(TaskExecutorID.of("invalid")));
     }
 
     private TaskExecutorState registerNewTaskExecutor(TaskExecutorID id, MachineDefinition mdef,

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -45,7 +45,7 @@ import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.server.master.resourcecluster.PagedActiveJobOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster;
-import io.mantisrx.server.master.resourcecluster.ResourceCluster.NotFoundException;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceNotFoundException;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.TaskExecutorStatus;
 import io.mantisrx.server.master.resourcecluster.ResourceClusterTaskExecutorMapper;
@@ -292,7 +292,7 @@ public class ResourceClusterActorTest {
         resourceClusterActor.tell(new GetTaskExecutorStatusRequest(TaskExecutorID.of("invalid"), CLUSTER_ID),
             probe.getRef());
         Failure teNotFoundStatusRes = probe.expectMsgClass(Failure.class);
-        assertTrue(teNotFoundStatusRes.cause() instanceof NotFoundException);
+        assertTrue(teNotFoundStatusRes.cause() instanceof ResourceNotFoundException);
 
         assertEquals(1, usageRes.getUsages().stream()
             .filter(usage -> Objects.equals(usage.getUsageGroupKey(), CONTAINER_DEF_ID_2.getResourceID())).count());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -45,13 +45,13 @@ import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.server.master.resourcecluster.PagedActiveJobOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster;
-import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceNotFoundException;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.TaskExecutorStatus;
 import io.mantisrx.server.master.resourcecluster.ResourceClusterTaskExecutorMapper;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorAllocationRequest;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorHeartbeat;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorNotFoundException;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorRegistration;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorReport;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorStatusChange;
@@ -292,7 +292,7 @@ public class ResourceClusterActorTest {
         resourceClusterActor.tell(new GetTaskExecutorStatusRequest(TaskExecutorID.of("invalid"), CLUSTER_ID),
             probe.getRef());
         Failure teNotFoundStatusRes = probe.expectMsgClass(Failure.class);
-        assertTrue(teNotFoundStatusRes.cause() instanceof ResourceNotFoundException);
+        assertTrue(teNotFoundStatusRes.cause() instanceof TaskExecutorNotFoundException);
 
         assertEquals(1, usageRes.getUsages().stream()
             .filter(usage -> Objects.equals(usage.getUsageGroupKey(), CONTAINER_DEF_ID_2.getResourceID())).count());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
+import akka.actor.Status.Failure;
 import akka.testkit.javadsl.TestKit;
 import io.mantisrx.common.Ack;
 import io.mantisrx.common.WorkerConstants;
@@ -44,6 +45,7 @@ import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
 import io.mantisrx.server.master.resourcecluster.PagedActiveJobOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster.NotFoundException;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.ResourceOverview;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.TaskExecutorStatus;
 import io.mantisrx.server.master.resourcecluster.ResourceClusterTaskExecutorMapper;
@@ -289,8 +291,8 @@ public class ResourceClusterActorTest {
         // test get invalid TE status
         resourceClusterActor.tell(new GetTaskExecutorStatusRequest(TaskExecutorID.of("invalid"), CLUSTER_ID),
             probe.getRef());
-        teStatusRes = probe.expectMsgClass(TaskExecutorStatus.class);
-        assertEquals(TaskExecutorStatus.NotFound, teStatusRes);
+        Failure teNotFoundStatusRes = probe.expectMsgClass(Failure.class);
+        assertTrue(teNotFoundStatusRes.cause() instanceof NotFoundException);
 
         assertEquals(1, usageRes.getUsages().stream()
             .filter(usage -> Objects.equals(usage.getUsageGroupKey(), CONTAINER_DEF_ID_2.getResourceID())).count());


### PR DESCRIPTION
### Context
Calling GetTaskExecutorStatus gets 500 internal error + actor crash error.
Fix:
* Separate the calls and return the proper type for the actor ask.
* Add UTs.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
