### PR TITLE
Improving Job Artifact Caching: Immediate Downloads, Configurable Clusters, and Efficient Cleanup Mechanism

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/domain/JobMetadata.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/domain/JobMetadata.java
@@ -54,4 +54,9 @@ public class JobMetadata {
         this.heartbeatIntervalSecs = heartbeatIntervalSecs;
         this.minRuntimeSecs = minRuntimeSecs;
     }
+
+    public ArtifactID getJobArtifact() {
+        final String urlString = jobJarUrl.toString();
+        return  ArtifactID.of(urlString.substring(urlString.lastIndexOf('/') + 1));
+    }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorAllocationRequest.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorAllocationRequest.java
@@ -17,6 +17,7 @@
 package io.mantisrx.server.master.resourcecluster;
 
 import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.server.core.domain.JobMetadata;
 import io.mantisrx.server.core.domain.WorkerId;
 import lombok.AllArgsConstructor;
 import lombok.Value;
@@ -26,4 +27,6 @@ import lombok.Value;
 public class TaskExecutorAllocationRequest {
     WorkerId workerId;
     MachineDefinition machineDefinition;
+    JobMetadata jobMetadata;
+    int stageNum;
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/core/domain/JobMetadataTest.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/core/domain/JobMetadataTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.core.domain;
+
+import static org.junit.Assert.assertEquals;
+
+import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.descriptor.SchedulingInfo;
+import io.mantisrx.shaded.com.google.common.collect.Lists;
+import java.net.URL;
+import org.junit.Test;
+
+public class JobMetadataTest {
+    @Test
+    public void testGetJobArtifact() throws Exception {
+        MachineDefinition machineDefinition = new MachineDefinition(1.0, 1.0, 1.0, 1.0, 3);
+        SchedulingInfo schedulingInfo = new SchedulingInfo.Builder()
+                .numberOfStages(1)
+                .singleWorkerStageWithConstraints(machineDefinition,
+                        Lists.newArrayList(),
+                        Lists.newArrayList()).build();
+        JobMetadata jobMetadata = new JobMetadata(
+                "testId", new URL("http://artifact.zip"),1,"testUser",schedulingInfo, Lists.newArrayList(),0,10, 0);
+        assertEquals(jobMetadata.getJobArtifact(), ArtifactID.of("artifact.zip"));
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -170,7 +170,9 @@ class ResourceClustersManagerActor extends AbstractActor {
                     clock,
                     rpcService,
                     mantisJobStore,
-                    jobMessageRouter),
+                    jobMessageRouter,
+                    masterConfiguration.getMaxJobArtifactsToCache(),
+                    masterConfiguration.getJobClustersWithArtifactCachingEnabled()),
                 "ResourceClusterActor-" + clusterID.getResourceID());
         log.info("Created resource cluster actor for {}", clusterID);
         return clusterActor;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/metrics/ResourceClusterActorMetrics.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/metrics/ResourceClusterActorMetrics.java
@@ -38,6 +38,7 @@ public class ResourceClusterActorMetrics {
 
     public static final String TE_CONNECTION_FAILURE = "taskExecutorConnectionFailure";
     public static final String TE_RECONNECTION_FAILURE = "taskExecutorReconnectionFailure";
+    public static final String MAX_JOB_ARTIFACTS_TO_CACHE_REACHED = "maxJobArtifactsToCacheReached";
 
     private final Registry registry;
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -370,6 +370,15 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("io.mantisrx.master.jobcluster.job.NoopCostsCalculator")
     CostsCalculator getJobCostsCalculator();
 
+    @Config("mantis.job.worker.max.artifacts.to.cache")
+    @Default("5")
+    int getMaxJobArtifactsToCache();
+
+    @Config("mantis.artifactCaching.jobClusters")
+    @Default("")
+    String getJobClustersWithArtifactCachingEnabled();
+
+
     default Duration getHeartbeatInterval() {
         return Duration.ofMillis(getHeartbeatIntervalInMs());
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
@@ -125,7 +125,7 @@ class ResourceClusterAwareSchedulerActor extends AbstractActorWithTimers {
             resourceCluster
                 .getTaskExecutorFor(
                     TaskExecutorAllocationRequest.of(
-                        event.getRequest().getWorkerId(), event.getRequest().getMachineDefinition()))
+                        event.getRequest().getWorkerId(), event.getRequest().getMachineDefinition(), event.getRequest().getJobMetadata(), event.getRequest().getStageNum()))
                 .<Object>thenApply(event::onAssignment)
                 .exceptionally(event::onFailure);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
@@ -131,7 +131,7 @@ public class ExecutorStateManagerTests {
     public void testGetBestFit() {
         Optional<Pair<TaskExecutorID, TaskExecutorState>> bestFitO =
             stateManager.findBestFit(new TaskExecutorAssignmentRequest(
-                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2),
+                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0),
                 CLUSTER_ID));
 
         assertFalse(bestFitO.isPresent());
@@ -154,14 +154,14 @@ public class ExecutorStateManagerTests {
         // test machine def 1
         bestFitO =
             stateManager.findBestFit(new TaskExecutorAssignmentRequest(
-                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1), CLUSTER_ID));
+                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0), CLUSTER_ID));
         assertTrue(bestFitO.isPresent());
         assertEquals(TASK_EXECUTOR_ID_1, bestFitO.get().getLeft());
         assertEquals(state1, bestFitO.get().getRight());
 
         bestFitO =
             stateManager.findBestFit(new TaskExecutorAssignmentRequest(
-                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2), CLUSTER_ID));
+                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0), CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
         assertEquals(TASK_EXECUTOR_ID_2, bestFitO.get().getLeft());
@@ -172,7 +172,7 @@ public class ExecutorStateManagerTests {
             TaskExecutorReport.occupied(WORKER_ID)));
         bestFitO =
             stateManager.findBestFit(new TaskExecutorAssignmentRequest(
-                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1), CLUSTER_ID));
+                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0), CLUSTER_ID));
         assertFalse(bestFitO.isPresent());
 
         // enable e3 and disable e2
@@ -184,7 +184,7 @@ public class ExecutorStateManagerTests {
 
         bestFitO =
             stateManager.findBestFit(new TaskExecutorAssignmentRequest(
-                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2), CLUSTER_ID));
+                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0), CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
         assertEquals(TASK_EXECUTOR_ID_3, bestFitO.get().getLeft());
@@ -194,7 +194,7 @@ public class ExecutorStateManagerTests {
         stateManager.tryMarkUnavailable(TASK_EXECUTOR_ID_3);
         bestFitO =
             stateManager.findBestFit(new TaskExecutorAssignmentRequest(
-                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2), CLUSTER_ID));
+                TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0), CLUSTER_ID));
 
         assertFalse(bestFitO.isPresent());
     }
@@ -235,7 +235,7 @@ public class ExecutorStateManagerTests {
         Optional<Pair<TaskExecutorID, TaskExecutorState>> bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorAssignmentRequest(
-                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2),
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0),
                     CLUSTER_ID));
         assertFalse(bestFitO.isPresent());
 
@@ -268,7 +268,7 @@ public class ExecutorStateManagerTests {
         bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorAssignmentRequest(
-                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1),
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0),
                     CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
@@ -284,7 +284,7 @@ public class ExecutorStateManagerTests {
         bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorAssignmentRequest(
-                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1),
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0),
                     CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
@@ -309,7 +309,7 @@ public class ExecutorStateManagerTests {
         bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorAssignmentRequest(
-                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1),
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0),
                     CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
@@ -322,7 +322,7 @@ public class ExecutorStateManagerTests {
         bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorAssignmentRequest(
-                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1),
+                    TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0),
                     CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -232,7 +232,7 @@ public class ResourceClusterActorTest {
                         TaskExecutorReport.available())).get());
         assertEquals(
             TASK_EXECUTOR_ID,
-            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION)).get());
+            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0)).get());
         assertEquals(
             TASK_EXECUTOR_ID,
             resourceCluster.getTaskExecutorAssignedFor(WORKER_ID).get());
@@ -328,7 +328,7 @@ public class ResourceClusterActorTest {
 
         assertEquals(
             TASK_EXECUTOR_ID_3,
-            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2)).get());
+            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0)).get());
 
         probe = new TestKit(actorSystem);
         resourceClusterActor.tell(new GetClusterUsageRequest(
@@ -362,7 +362,7 @@ public class ResourceClusterActorTest {
 
         assertEquals(
             TASK_EXECUTOR_ID_2,
-            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION)).get());
+            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0)).get());
         probe = new TestKit(actorSystem);
         resourceClusterActor.tell(new GetClusterUsageRequest(
                 CLUSTER_ID, ResourceClusterScalerActor.groupKeyFromTaskExecutorDefinitionIdFunc),
@@ -417,13 +417,13 @@ public class ResourceClusterActorTest {
                         TaskExecutorReport.available())).get());
         assertEquals(
             TASK_EXECUTOR_ID,
-            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION)).get());
+            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0)).get());
         assertEquals(ImmutableList.of(), resourceCluster.getAvailableTaskExecutors().get());
         Thread.sleep(2000);
         assertEquals(ImmutableList.of(TASK_EXECUTOR_ID), resourceCluster.getAvailableTaskExecutors().get());
         assertEquals(
             TASK_EXECUTOR_ID,
-            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION)).get());
+            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0)).get());
     }
 
     @Test
@@ -464,7 +464,7 @@ public class ResourceClusterActorTest {
 
             assertEquals(
                 taskExecutorID,
-                resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(workerId, MACHINE_DEFINITION))
+                resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(workerId, MACHINE_DEFINITION, null, 0))
                     .get());
         }
 
@@ -577,7 +577,7 @@ public class ResourceClusterActorTest {
         resourceCluster.disableTaskExecutorsFor(ATTRIBUTES, Instant.now().plus(Duration.ofDays(1)), Optional.empty()).get();
         assertEquals(
             TASK_EXECUTOR_ID_2,
-            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION)).get());
+            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0)).get());
     }
 
     @Test
@@ -610,7 +610,7 @@ public class ResourceClusterActorTest {
 
         assertEquals(
             TASK_EXECUTOR_ID,
-            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION)).join());
+            resourceCluster.getTaskExecutorFor(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0)).join());
         assertEquals(TASK_EXECUTOR_ID, resourceCluster.getTaskExecutorAssignedFor(WORKER_ID).join());
         assertEquals(Ack.getInstance(), resourceCluster.notifyTaskExecutorStatusChange(
             new TaskExecutorStatusChange(TASK_EXECUTOR_ID, CLUSTER_ID, TaskExecutorReport.occupied(WORKER_ID))).join());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -190,7 +190,9 @@ public class ResourceClusterActorTest {
                 Clock.systemDefaultZone(),
                 rpcService,
                 mantisJobStore,
-                jobMessageRouter);
+                jobMessageRouter,
+                0,
+                "");
 
         resourceClusterActor = actorSystem.actorOf(props);
         resourceCluster =


### PR DESCRIPTION
### Context

This PR is intended to improve the job artifact caching in these areas:

- Immediate downloads of newly registered job artifacts are ensured by _available_ Task Executors, eliminating the need for the first Task Executor restart. This approach is likely to speed up job initializations following the registration of a new job artifact.
- By attaching their clusters to a fast property (for now - we can have an API in the future), users have the option to adapt their job clusters for artifact caching. Master will ensure that the most recent artifact is always cached for the clusters configured in this way. This process occurs during each job launch. If any job's artifact has not been previously encountered, it will be included in the caching process after being added to the artifacts-to-cache list.
- To prevent the Task Executor from issues such as disk overuse, slowed startup times, and others that might arise from overloading with too many artifacts, a limit has been placed on the number of simultaneous artifact downloads. Hence, Task Executors won't download more than X artifacts concurrently.

#### Cleanup unused job artifacts : 

- A purging procedure must be established to continually maintain a suitably compact list of job artifacts used for caching. This implies that unused artifacts should not be cached. I haven't decided yet on how to implement this. An external cleaning mechanism, which aligns required cache artifacts based on active jobs and configured job clusters, is likely to be a quicker and less fault-prone solution than probably implementing it within master. Since we can already delete artifacts via api this cleanup mechanism is not super urgent. 

### Tests

Tested successfully in staging.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
