### PR TITLE
Fix job disoveryAPI with heartbeat parameter

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobDiscoveryRouteHandlerAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobDiscoveryRouteHandlerAkkaImpl.java
@@ -111,7 +111,7 @@ public class JobDiscoveryRouteHandlerAkkaImpl implements JobDiscoveryRouteHandle
                         Observable<JobSchedulingInfo> heartbeats =
                             Observable.interval(5, serverIdleConnectionTimeout.getSeconds() - 1, TimeUnit.SECONDS)
                                 .map(x -> {
-                                    if(!isJobCompleted.get()) {
+                                    if(isJobCompleted.get()) {
                                         return SCHED_INFO_HB_INSTANCE;
                                     } else {
                                         return completedJobSchedulingInfo;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisStageMetadataImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisStageMetadataImpl.java
@@ -566,7 +566,7 @@ public class MantisStageMetadataImpl implements IMantisStageMetadata {
             try {
                 worker.processEvent(event, jobStore);
             } catch (InvalidWorkerStateChangeException wex) {
-                LOGGER.warn("InvalidWorkerStateChangeException from {}: {}", wex);
+                LOGGER.warn("InvalidWorkerStateChangeException from: ", wex);
             }
 
             return of(worker);


### PR DESCRIPTION
### Context

Fix an old bug where job scheduleInfo discovery API with heartbeats will emit invalid info on running jobs.
E.g. `{"jobId":"HB_JobId","workerAssignments":null}` for `/assignmentresults/{JobId}?sendHB=true`
### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
