### PR TITLE
Handle TE gateway timeout

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -345,7 +345,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         } else {
             try {
                 if (state.isRegistered()) {
-                    sender().tell(state.getGateway().join(), self());
+                    sender().tell(state.getGateway(), self());
                 } else {
                     sender().tell(new Status.Failure(new Exception("")), self());
                 }
@@ -764,23 +764,18 @@ class ResourceClusterActor extends AbstractActorWithTimers {
     private void onCacheJobArtifactsOnTaskExecutorRequest(CacheJobArtifactsOnTaskExecutorRequest request) {
         TaskExecutorState state = this.executorStateManager.get(request.getTaskExecutorID());
         if (state != null && state.isRegistered()) {
-            if (state.getGateway() != null) {
-                TaskExecutorGateway gateway = state.getGateway().join();
-                if (gateway != null) {
-                    // TODO(fdichiara): store URI directly to avoid remapping for each TE
-                    List<URI> artifacts = jobArtifactsToCache.stream().map(artifactID -> URI.create(artifactID.getResourceID())).collect(Collectors.toList());
-                    try {
-                        log.debug("Caching artifacts {} in task executor {}", artifacts, request.getTaskExecutorID());
-                        gateway.cacheJobArtifacts(new CacheJobArtifactsRequest(artifacts));
-                    } catch(Exception e) {
-                        log.warn("Failed to cache job artifacts in task executor {}", request.getTaskExecutorID());
-                    }
-                } else {
-                    log.warn("Failed to fetch gateway for task executor {}", request.getTaskExecutorID());
-                }
-            } else {
-                log.warn("Gateway for task executor {} is not set", request.getTaskExecutorID());
+            try {
+                TaskExecutorGateway gateway = state.getGateway();
+                // TODO(fdichiara): store URI directly to avoid remapping for each TE
+                List<URI> artifacts = jobArtifactsToCache.stream().map(artifactID -> URI.create(artifactID.getResourceID())).collect(Collectors.toList());
+
+                gateway.cacheJobArtifacts(new CacheJobArtifactsRequest(artifacts));
+            } catch (Exception ex) {
+                log.warn("Failed to cache job artifacts in task executor {}", request.getTaskExecutorID(), ex);
             }
+        }
+        else {
+            log.warn("no valid TE state for CacheJobArtifactsOnTaskExecutorRequest: {}", request);
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
@@ -34,6 +34,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -251,8 +252,11 @@ class TaskExecutorState {
         return this.registration;
     }
 
-    protected CompletableFuture<TaskExecutorGateway> getGateway() {
-        return this.gateway;
+    protected TaskExecutorGateway getGateway() throws ExecutionException, InterruptedException {
+        if (this.gateway == null) {
+            throw new IllegalStateException("gateway is null");
+        }
+        return this.gateway.get();
     }
 
     protected CompletableFuture<TaskExecutorGateway> reconnect() {


### PR DESCRIPTION
### Context

Gateway registration runs as a detached future and the failure there is caused exception leak to the common thread pool and is not connected back to the state.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
