### PR TITLE
Put submitted vs launched behind a config/flag

### DIFF
--- a/mantis-control-plane/Dockerfile
+++ b/mantis-control-plane/Dockerfile
@@ -10,6 +10,9 @@ MAINTAINER Mantis Developers <mantis-oss-dev@netflix.com>
 #    apt-get install -y mesos=1.3.2-2.0.1 && \
 #    apt-get clean
 
+RUN mkdir -p /apps/mantis/mantis-control-plane-server/bin
+RUN mkdir -p /apps/mantis/mantis-control-plane-server/lib
+
 COPY ./mantis-control-plane-server/build/install/mantis-control-plane-server/bin/* /apps/mantis/mantis-control-plane-server/bin/
 COPY ./mantis-control-plane-server/build/install/mantis-control-plane-server/lib/* /apps/mantis/mantis-control-plane-server/lib/
 


### PR DESCRIPTION
### Context

This might be a more serious change and it'd be better to roll this out gradually separate from resource cluster upgrade. Putting the change behind a config (with default `false`).

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
