### PR TITLE
Fix runtime Index total worker observable + Revert control-plane change

### DIFF
--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
@@ -80,7 +80,7 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.functions.Func1;
 import rx.functions.Func2;
-
+import rx.subjects.BehaviorSubject;
 
 /**
  *
@@ -698,8 +698,11 @@ public class MantisMasterClientApi implements MantisMasterGateway {
      * @param jobId
      * @return
      */
+    @Override
     public Observable<JobSchedulingInfo> schedulingChanges(final String jobId) {
-        return masterMonitor.getMasterObservable()
+        BehaviorSubject<JobSchedulingInfo> behaviorSubject = BehaviorSubject.create();
+
+        masterMonitor.getMasterObservable()
                 .filter(masterDescription -> masterDescription != null)
                 .retryWhen(retryLogic)
                 .switchMap((Func1<MasterDescription,
@@ -728,7 +731,8 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                         }))
                 .repeatWhen(repeatLogic)
                 .retryWhen(retryLogic)
-                ;
+                .subscribe(behaviorSubject);
+        return behaviorSubject;
     }
 
     /**

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobDiscoveryRouteHandlerAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobDiscoveryRouteHandlerAkkaImpl.java
@@ -122,7 +122,7 @@ public class JobDiscoveryRouteHandlerAkkaImpl implements JobDiscoveryRouteHandle
                         Observable<JobSchedulingInfo> heartbeats =
                             Observable.interval(5, serverIdleConnectionTimeout.getSeconds() - 1, TimeUnit.SECONDS)
                                 .map(x -> {
-                                    if(isJobCompleted.get()) {
+                                    if(!isJobCompleted.get()) {
                                         return SCHED_INFO_HB_INSTANCE;
                                     } else {
                                         return completedJobSchedulingInfo;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobDiscoveryRouteHandlerAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/handlers/JobDiscoveryRouteHandlerAkkaImpl.java
@@ -46,7 +46,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -113,8 +112,7 @@ public class JobDiscoveryRouteHandlerAkkaImpl implements JobDiscoveryRouteHandle
         try {
             AtomicBoolean isJobCompleted = new AtomicBoolean(false);
             final String jobId = request.getJobId().getId();
-            AtomicReference<JobSchedulingInfo> jobSchedulingInfoAtomicRef =
-                new AtomicReference<>(new JobSchedulingInfo(jobId, new HashMap<>()));
+            final JobSchedulingInfo completedJobSchedulingInfo = new JobSchedulingInfo(jobId, new HashMap<>());
             CompletionStage<JobDiscoveryRouteProto.SchedInfoResponse> jobSchedInfoObsCS = response
                 .thenApply(getJobSchedInfoResp -> {
                     Optional<BehaviorSubject<JobSchedulingInfo>> jobStatusSubjectO = getJobSchedInfoResp.getJobSchedInfoSubject();
@@ -127,20 +125,15 @@ public class JobDiscoveryRouteHandlerAkkaImpl implements JobDiscoveryRouteHandle
                                     if(isJobCompleted.get()) {
                                         return SCHED_INFO_HB_INSTANCE;
                                     } else {
-                                        return jobSchedulingInfoAtomicRef.get();
+                                        return completedJobSchedulingInfo;
                                     }
 
                                 })
                                 .takeWhile(x -> sendHeartbeats == true);
 
-                        Observable<JobSchedulingInfo> jobSchedulingInfoObservable =
-                            jobSchedulingInfoObs
-                                .doOnCompleted(() -> isJobCompleted.set(true))
-                                .doOnNext(jobSchedulingInfoAtomicRef::set);
-
                         // Job SchedulingInfo obs completes on job shutdown. Use the do On completed as a signal to inform the user that there are no workers to connect to.
                         // TODO For future a more explicit key in the payload saying the job is completed.
-                        Observable<JobSchedulingInfo> jobSchedulingInfoWithHBObs = Observable.merge(jobSchedulingInfoObservable, heartbeats);
+                        Observable<JobSchedulingInfo> jobSchedulingInfoWithHBObs = Observable.merge(jobSchedulingInfoObs.doOnCompleted(() -> isJobCompleted.set(true)), heartbeats);
                         return new JobDiscoveryRouteProto.SchedInfoResponse(
                             getJobSchedInfoResp.requestId,
                             getJobSchedInfoResp.responseCode,


### PR DESCRIPTION
### Context
* Make the index total worker observable to cache the most recent result in case the subscription missed the very first scheduling info (and is stuck on the heartbeat message forever if no worker counts changes).
* Revert the control-plane side change so only the first SSE event contains the full info.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
