### PR TITLE
Add logs to check for dupe workers

### DIFF
--- a/mantis-testcontainers/dependencies.lock
+++ b/mantis-testcontainers/dependencies.lock
@@ -1,0 +1,583 @@
+{
+    "annotationProcessor": {
+        "org.projectlombok:lombok": {
+            "locked": "1.18.20"
+        }
+    },
+    "baseline-exact-dependencies-test": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.3.8"
+        },
+        "com.github.spullara.cli-parser:cli-parser": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "3.0.1"
+        },
+        "com.netflix:mantis-rxnetty": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "0.4.19.1"
+        },
+        "com.squareup.okhttp3:okhttp": {
+            "locked": "5.0.0-alpha.11"
+        },
+        "io.mantisrx:mantis-common": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-common-serde": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-control-plane-client": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-worker-client"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-control-plane-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-client",
+                "io.mantisrx:mantis-server-worker-client"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-remote-observable": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-client"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-server-worker-client": {
+            "project": true
+        },
+        "io.mantisrx:mantis-shaded": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-common-serde"
+            ],
+            "project": true
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "4.1.17.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "4.1.17.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "4.1.17.Final"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.3.8"
+        },
+        "joda-time:joda-time": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "2.12.5"
+        },
+        "org.apache.flink:flink-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.14.2"
+        },
+        "org.apache.flink:flink-rpc-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.14.2"
+        },
+        "org.apache.mesos:mesos": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.7.2"
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "2.1.12"
+        },
+        "org.jctools:jctools-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.json:json": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "20180813"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.9.1"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.9.1"
+        },
+        "org.skife.config:config-magic": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "0.11"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "2.0.7"
+        },
+        "org.slf4j:slf4j-log4j12": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.7.0"
+        },
+        "org.testcontainers:testcontainers": {
+            "locked": "1.18.3"
+        },
+        "org.xerial.snappy:snappy-java": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.1.10.3"
+        }
+    },
+    "compileClasspath": {
+        "io.mantisrx:mantis-shaded": {
+            "project": true
+        },
+        "org.projectlombok:lombok": {
+            "locked": "1.18.20"
+        }
+    },
+    "lombok": {
+        "org.projectlombok:lombok": {
+            "locked": "1.18.20"
+        }
+    },
+    "runtimeClasspath": {
+        "io.mantisrx:mantis-shaded": {
+            "project": true
+        },
+        "io.vavr:vavr": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-shaded"
+            ],
+            "locked": "0.9.2"
+        }
+    },
+    "testAnnotationProcessor": {
+        "org.projectlombok:lombok": {
+            "locked": "1.18.20"
+        }
+    },
+    "testCompileClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.3.8"
+        },
+        "com.github.spullara.cli-parser:cli-parser": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "3.0.1"
+        },
+        "com.netflix:mantis-rxnetty": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "0.4.19.1"
+        },
+        "com.squareup.okhttp3:okhttp": {
+            "locked": "5.0.0-alpha.11"
+        },
+        "io.mantisrx:mantis-common": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-common-serde": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-control-plane-client": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-worker-client"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-control-plane-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-client",
+                "io.mantisrx:mantis-server-worker-client"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-remote-observable": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-client"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-server-worker-client": {
+            "project": true
+        },
+        "io.mantisrx:mantis-shaded": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-common-serde"
+            ],
+            "project": true
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "4.1.17.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "4.1.17.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "4.1.17.Final"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.3.8"
+        },
+        "joda-time:joda-time": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "2.12.5"
+        },
+        "org.apache.flink:flink-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.14.2"
+        },
+        "org.apache.flink:flink-rpc-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.14.2"
+        },
+        "org.apache.mesos:mesos": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.7.2"
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "2.1.12"
+        },
+        "org.jctools:jctools-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.json:json": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "20180813"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.9.1"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.9.1"
+        },
+        "org.projectlombok:lombok": {
+            "locked": "1.18.20"
+        },
+        "org.skife.config:config-magic": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "0.11"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "2.0.7"
+        },
+        "org.slf4j:slf4j-log4j12": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.7.0"
+        },
+        "org.testcontainers:testcontainers": {
+            "locked": "1.18.3"
+        },
+        "org.xerial.snappy:snappy-java": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.1.10.3"
+        }
+    },
+    "testRuntimeClasspath": {
+        "ch.qos.logback:logback-classic": {
+            "locked": "1.3.8"
+        },
+        "com.github.spullara.cli-parser:cli-parser": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.1.1"
+        },
+        "com.google.code.findbugs:jsr305": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "3.0.1"
+        },
+        "com.netflix.rxjava:rxjava-math": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-remote-observable"
+            ],
+            "locked": "0.20.6"
+        },
+        "com.netflix:mantis-rxnetty": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "0.4.19.1"
+        },
+        "com.spotify:completable-futures": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-client"
+            ],
+            "locked": "0.3.1"
+        },
+        "com.squareup.okhttp3:okhttp": {
+            "locked": "5.0.0-alpha.11"
+        },
+        "commons-io:commons-io": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "2.11.0"
+        },
+        "io.mantisrx:mantis-common": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core",
+                "io.mantisrx:mantis-remote-observable"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-common-serde": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-control-plane-client": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-server-worker-client"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-control-plane-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-client",
+                "io.mantisrx:mantis-server-worker-client"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-remote-observable": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-client"
+            ],
+            "project": true
+        },
+        "io.mantisrx:mantis-server-worker-client": {
+            "project": true
+        },
+        "io.mantisrx:mantis-shaded": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-common-serde"
+            ],
+            "project": true
+        },
+        "io.netty:netty-buffer": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "4.1.60.Final"
+        },
+        "io.netty:netty-codec-http": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "4.1.60.Final"
+        },
+        "io.netty:netty-handler": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-remote-observable"
+            ],
+            "locked": "4.1.60.Final"
+        },
+        "io.netty:netty-transport-native-epoll": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "4.1.60.Final"
+        },
+        "io.reactivex:rxjava": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.3.8"
+        },
+        "io.vavr:vavr": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-shaded"
+            ],
+            "locked": "0.9.2"
+        },
+        "joda-time:joda-time": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "2.12.5"
+        },
+        "net.jcip:jcip-annotations": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.0"
+        },
+        "org.apache.flink:flink-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.14.2"
+        },
+        "org.apache.flink:flink-rpc-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.14.2"
+        },
+        "org.apache.mesos:mesos": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "1.7.2"
+        },
+        "org.asynchttpclient:async-http-client": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-client"
+            ],
+            "locked": "2.12.3"
+        },
+        "org.hdrhistogram:HdrHistogram": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "2.1.12"
+        },
+        "org.jctools:jctools-core": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.2.1"
+        },
+        "org.json:json": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "20180813"
+        },
+        "org.junit.jupiter:junit-jupiter": {
+            "locked": "5.9.1"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.9.1"
+        },
+        "org.skife.config:config-magic": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-control-plane-core"
+            ],
+            "locked": "0.11"
+        },
+        "org.slf4j:slf4j-api": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-remote-observable"
+            ],
+            "locked": "2.0.7"
+        },
+        "org.slf4j:slf4j-log4j12": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common",
+                "io.mantisrx:mantis-remote-observable"
+            ],
+            "locked": "1.7.0"
+        },
+        "org.testcontainers:testcontainers": {
+            "locked": "1.18.3"
+        },
+        "org.xerial.snappy:snappy-java": {
+            "firstLevelTransitive": [
+                "io.mantisrx:mantis-common"
+            ],
+            "locked": "1.1.10.3"
+        }
+    }
+}


### PR DESCRIPTION
### Context

Add logs to validate dupe workers on the same worker index.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
