### PR TITLE
Replace guava rate limiter

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -380,7 +380,7 @@ public interface MasterConfiguration extends CoreConfiguration {
 
     // rate limit actions on resource cluster actor to control backlog.
     @Config("mantis.master.resource.cluster.actions.permitsPerSecond")
-    @Default("300")
+    @Default("2000")
     int getResourceClusterActionsPermitsPerSecond();
 
     default Duration getHeartbeatInterval() {


### PR DESCRIPTION
### Context

The guava rate limiter blocks during acquisition and causes degradation on API response for the akka routes. 

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
