### PR TITLE
Fix index obs

### DIFF
--- a/mantis-examples/mantis-examples-sine-function/src/main/java/io/mantisrx/mantis/examples/sinefunction/SineFunctionJob.java
+++ b/mantis-examples/mantis-examples-sine-function/src/main/java/io/mantisrx/mantis/examples/sinefunction/SineFunctionJob.java
@@ -202,6 +202,7 @@ public class SineFunctionJob extends MantisJobProvider<Point> {
             return Observable.just(
                     Observable.interval(0, period, TimeUnit.SECONDS)
                             .map(time -> {
+                                System.out.println("total worker num: " + index.getTotalNumWorkers());
                                 if (useRandom) {
                                     return randomNumGenerator.nextInt((max - min) + 1) + min;
                                 } else {

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/Index.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/Index.java
@@ -16,14 +16,15 @@
 
 package io.mantisrx.runtime.source;
 
+import lombok.extern.slf4j.Slf4j;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-
+@Slf4j
 public class Index {
 
     private final int workerIndex;
-    private final Observable<Integer> totalNumWorkersObservable;
+    private final BehaviorSubject<Integer> totalNumWorkersObservable;
 
 
     public Index(int offset, int total) {
@@ -34,7 +35,8 @@ public class Index {
 
     public Index(int offset, final Observable<Integer> totalWorkerAtStageObservable) {
         this.workerIndex = offset;
-        this.totalNumWorkersObservable = totalWorkerAtStageObservable;
+        this.totalNumWorkersObservable = BehaviorSubject.create();
+        totalWorkerAtStageObservable.subscribe(this.totalNumWorkersObservable);
     }
 
     public int getWorkerIndex() {
@@ -42,6 +44,12 @@ public class Index {
     }
 
     public int getTotalNumWorkers() {
+        Integer workerNum = this.totalNumWorkersObservable.getValue();
+        if (workerNum != null) {
+            return workerNum;
+        }
+
+        log.info("totalNumWorkersObservable is not ready yet, waiting.");
         return totalNumWorkersObservable.take(1).toBlocking().first();
     }
 


### PR DESCRIPTION
### Context

Observable received on index needs to be wrapped within cached behavior subject. The upstream observable received on index ctor is altered thus no longer a valid behaviorSubject and job sources use index's calls with blocking take(1) to get total worker number will cause the node to stuck.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
