### PR TITLE
Fix example job spectator

### DIFF
--- a/mantis-examples/mantis-examples-groupby-sample/build.gradle
+++ b/mantis-examples/mantis-examples-groupby-sample/build.gradle
@@ -15,7 +15,7 @@ task execute(type: JavaExec) {
 
 dependencies {
     implementation project(':mantis-runtime')
-    implementation "com.netflix.spectator:spectator-api:1.3.+"
+    implementation libraries.spectatorApi
 
     implementation libraries.mockneat
     implementation libraries.slf4jApi

--- a/mantis-examples/mantis-examples-jobconnector-sample/build.gradle
+++ b/mantis-examples/mantis-examples-jobconnector-sample/build.gradle
@@ -25,4 +25,5 @@ dependencies {
 
     implementation libraries.slf4jApi
     implementation libraries.slf4jLog4j12
+    implementation libraries.spectatorApi
 }

--- a/mantis-examples/mantis-examples-sine-function/build.gradle
+++ b/mantis-examples/mantis-examples-sine-function/build.gradle
@@ -30,5 +30,5 @@ task execute(type:JavaExec) {
 }
 dependencies {
     implementation project(':mantis-server:mantis-server-worker')
-    implementation "com.netflix.spectator:spectator-api:1.3.+"
+    implementation libraries.spectatorApi
 }

--- a/mantis-examples/mantis-examples-synthetic-sourcejob/build.gradle
+++ b/mantis-examples/mantis-examples-synthetic-sourcejob/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation project(':mantis-runtime')
 
     implementation "io.mantisrx:mql-jvm:$mqlVersion"
+    implementation libraries.spectatorApi
 
     implementation libraries.mockneat
     implementation libraries.slf4jApi

--- a/mantis-examples/mantis-examples-twitter-sample/build.gradle
+++ b/mantis-examples/mantis-examples-twitter-sample/build.gradle
@@ -15,7 +15,7 @@ task execute(type: JavaExec) {
 
 dependencies {
     implementation project(':mantis-runtime')
-    implementation "com.netflix.spectator:spectator-api:1.3.+"
+    implementation libraries.spectatorApi
     implementation 'com.twitter:hbc-core:2.2.0'
 
     implementation libraries.slf4jApi

--- a/mantis-examples/mantis-examples-wordcount/build.gradle
+++ b/mantis-examples/mantis-examples-wordcount/build.gradle
@@ -16,7 +16,7 @@ task execute(type: JavaExec) {
 dependencies {
     implementation project(':mantis-runtime')
     implementation project(':mantis-examples:mantis-examples-core')
-    implementation "com.netflix.spectator:spectator-api:1.3.+"
+    implementation libraries.spectatorApi
     implementation 'com.twitter:hbc-core:2.2.0'
 
     implementation libraries.slf4jApi


### PR DESCRIPTION
### Context

Since mantis-runtime now treats spectator API jars as compileOnly, the example jobs need to declare this directly.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
