### PR TITLE
Handle TE gateway connection error cases

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -118,6 +118,8 @@ public interface ResourceCluster extends ResourceClusterGateway {
      */
     CompletableFuture<TaskExecutorGateway> getTaskExecutorGateway(TaskExecutorID taskExecutorID);
 
+    CompletableFuture<TaskExecutorGateway> reconnectTaskExecutorGateway(TaskExecutorID taskExecutorID);
+
     CompletableFuture<TaskExecutorRegistration> getTaskExecutorInfo(String hostName);
 
     /**

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -350,14 +350,14 @@ class ResourceClusterActor extends AbstractActorWithTimers {
     private void onTaskExecutorGatewayRequest(TaskExecutorGatewayRequest request) {
         TaskExecutorState state = this.executorStateManager.get(request.getTaskExecutorID());
         if (state == null) {
-            sender().tell(new Exception("Null TaskExecutorState for: " + request.getTaskExecutorID()), self());
+            sender().tell(new NullPointerException("Null TaskExecutorState for: " + request.getTaskExecutorID()), self());
         } else {
             try {
                 if (state.isRegistered()) {
                     sender().tell(state.getGateway(), self());
                 } else {
                     sender().tell(
-                        new Status.Failure(new Exception("Unregistered TaskExecutor: " + request.getTaskExecutorID())),
+                        new Status.Failure(new IllegalStateException("Unregistered TaskExecutor: " + request.getTaskExecutorID())),
                         self());
                 }
             } catch (Exception e) {
@@ -390,7 +390,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         TaskExecutorState state = this.executorStateManager.get(request.getTaskExecutorID());
         if (state == null) {
             sender().tell(
-                new Status.Failure(new Exception("Null TaskExecutor state: " + request.getTaskExecutorID())),
+                new Status.Failure(new NullPointerException("Null TaskExecutor state: " + request.getTaskExecutorID())),
                 self());
         } else {
             try {
@@ -398,7 +398,8 @@ class ResourceClusterActor extends AbstractActorWithTimers {
                     sender().tell(state.reconnect().join(), self());
                 } else {
                     sender().tell(
-                        new Status.Failure(new Exception("Unregistered TaskExecutor: " + request.getTaskExecutorID())),
+                        new Status.Failure(
+                            new IllegalStateException("Unregistered TaskExecutor: " + request.getTaskExecutorID())),
                         self());
                 }
             } catch (Exception e) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -34,6 +34,7 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.InitializeTaskExe
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.RemoveJobArtifactsToCacheRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.ResourceOverviewRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssignmentRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayReconnectRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorInfoRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorsList;
@@ -198,6 +199,17 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
         return
             Patterns
                 .ask(resourceClusterManagerActor, new TaskExecutorGatewayRequest(taskExecutorID, clusterID), askTimeout)
+                .thenApply(TaskExecutorGateway.class::cast)
+                .toCompletableFuture();
+    }
+
+    @Override
+    public CompletableFuture<TaskExecutorGateway> reconnectTaskExecutorGateway(
+        TaskExecutorID taskExecutorID) {
+        return
+            Patterns
+                .ask(resourceClusterManagerActor, new TaskExecutorGatewayReconnectRequest(taskExecutorID, clusterID),
+                    askTimeout)
                 .thenApply(TaskExecutorGateway.class::cast)
                 .toCompletableFuture();
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -34,6 +34,7 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetUnregisteredTa
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.RemoveJobArtifactsToCacheRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.ResourceOverviewRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssignmentRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayReconnectRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorInfoRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterScalerActor.TriggerClusterRuleRefreshRequest;
@@ -142,6 +143,8 @@ class ResourceClustersManagerActor extends AbstractActor {
                 .match(TaskExecutorInfoRequest.class, req ->
                     getRCActor(req.getClusterID()).forward(req, context()))
                 .match(TaskExecutorGatewayRequest.class, req ->
+                    getRCActor(req.getClusterID()).forward(req, context()))
+                .match(TaskExecutorGatewayReconnectRequest.class, req ->
                     getRCActor(req.getClusterID()).forward(req, context()))
                 .match(DisableTaskExecutorsRequest.class, req ->
                     getRCActor(req.getClusterID()).forward(req, context()))


### PR DESCRIPTION
### Context
Fixing a few issues from prod.
* TE get info call exception escaped and caused actor failure. 
* TE RPC gateway connection saw a dead-letter error to the RPC worker. Such an error is not handled right now so the dead letter error will persist in the TE gateway. Added explicit reconnection call on failure to ensure the dead-letter worker gets refreshed.


### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
