### PR TITLE
Make calls on cacheArtifacts/reconnect non-blocking

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -118,7 +118,7 @@ public interface ResourceCluster extends ResourceClusterGateway {
      */
     CompletableFuture<TaskExecutorGateway> getTaskExecutorGateway(TaskExecutorID taskExecutorID);
 
-    CompletableFuture<Ack> reconnectTaskExecutorGateway(TaskExecutorID taskExecutorID);
+    CompletableFuture<Ack> reconnectGateway(TaskExecutorID taskExecutorID);
 
     CompletableFuture<TaskExecutorRegistration> getTaskExecutorInfo(String hostName);
 

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -118,7 +118,7 @@ public interface ResourceCluster extends ResourceClusterGateway {
      */
     CompletableFuture<TaskExecutorGateway> getTaskExecutorGateway(TaskExecutorID taskExecutorID);
 
-    CompletableFuture<TaskExecutorGateway> reconnectTaskExecutorGateway(TaskExecutorID taskExecutorID);
+    CompletableFuture<Ack> reconnectTaskExecutorGateway(TaskExecutorID taskExecutorID);
 
     CompletableFuture<TaskExecutorRegistration> getTaskExecutorInfo(String hostName);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -357,13 +357,14 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         } else {
             try {
                 if (state.isRegistered()) {
-                    sender().tell(state.getGateway(), self());
+                    sender().tell(state.getGatewayAsync(), self());
                 } else {
                     sender().tell(
                         new Status.Failure(new IllegalStateException("Unregistered TaskExecutor: " + request.getTaskExecutorID())),
                         self());
                 }
             } catch (Exception e) {
+                log.error("onTaskExecutorGatewayRequest error: {}", request, e);
                 metrics.incrementCounter(
                     ResourceClusterActorMetrics.TE_CONNECTION_FAILURE,
                     TagList.create(ImmutableMap.of(

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -197,10 +197,19 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
     public CompletableFuture<TaskExecutorGateway> getTaskExecutorGateway(
         TaskExecutorID taskExecutorID) {
         return
-            Patterns
-                .ask(resourceClusterManagerActor, new TaskExecutorGatewayRequest(taskExecutorID, clusterID), askTimeout)
-                .thenApply(TaskExecutorGateway.class::cast)
-                .toCompletableFuture();
+                (CompletableFuture<TaskExecutorGateway>) Patterns
+                    .ask(resourceClusterManagerActor, new TaskExecutorGatewayRequest(taskExecutorID, clusterID),
+                        askTimeout)
+                    .thenComposeAsync(result -> {
+                        if (result instanceof CompletableFuture) {
+                            return (CompletableFuture<TaskExecutorGateway>) result;
+                        } else {
+                            CompletableFuture<TaskExecutorGateway> exceptionFuture = new CompletableFuture<>();
+                            exceptionFuture.completeExceptionally(new RuntimeException(
+                                "Unexpected object type on getTaskExecutorGateway: " + result.getClass().getName()));
+                            return exceptionFuture;
+                        }
+                    });
     }
 
     @Override

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -213,7 +213,7 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
     }
 
     @Override
-    public CompletableFuture<Ack> reconnectTaskExecutorGateway(
+    public CompletableFuture<Ack> reconnectGateway(
         TaskExecutorID taskExecutorID) {
         return
             Patterns

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -204,13 +204,13 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
     }
 
     @Override
-    public CompletableFuture<TaskExecutorGateway> reconnectTaskExecutorGateway(
+    public CompletableFuture<Ack> reconnectTaskExecutorGateway(
         TaskExecutorID taskExecutorID) {
         return
             Patterns
                 .ask(resourceClusterManagerActor, new TaskExecutorGatewayReconnectRequest(taskExecutorID, clusterID),
                     askTimeout)
-                .thenApply(TaskExecutorGateway.class::cast)
+                .thenApply(Ack.class::cast)
                 .toCompletableFuture();
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
@@ -259,6 +259,13 @@ class TaskExecutorState {
         return this.gateway.get();
     }
 
+    protected CompletableFuture<TaskExecutorGateway> getGatewayAsync() {
+        if (this.gateway == null) {
+            throw new IllegalStateException("gateway is null");
+        }
+        return this.gateway;
+    }
+
     protected CompletableFuture<TaskExecutorGateway> reconnect() {
         this.gateway = rpcService.connect(registration.getTaskExecutorAddress(), TaskExecutorGateway.class)
             .whenComplete((gateway, throwable) -> {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
@@ -34,7 +34,6 @@ import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -250,13 +249,6 @@ class TaskExecutorState {
 
     TaskExecutorRegistration getRegistration() {
         return this.registration;
-    }
-
-    protected TaskExecutorGateway getGateway() throws ExecutionException, InterruptedException {
-        if (this.gateway == null) {
-            throw new IllegalStateException("gateway is null");
-        }
-        return this.gateway.get();
     }
 
     protected CompletableFuture<TaskExecutorGateway> getGatewayAsync() {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
@@ -238,7 +238,7 @@ class ResourceClusterAwareSchedulerActor extends AbstractActorWithTimers {
             Throwables.getStackTraceAsString(event.throwable)));
 
         try {
-            resourceCluster.reconnectTaskExecutorGateway(event.getTaskExecutorID())
+            resourceCluster.reconnectGateway(event.getTaskExecutorID())
                 .whenComplete((res, throwable) -> {
                     if (throwable != null) {
                         log.error("Failed to request reconnect to gateway for {}", event.getTaskExecutorID(), throwable);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
@@ -222,7 +222,15 @@ class ResourceClusterAwareSchedulerActor extends AbstractActorWithTimers {
             Throwables.getStackTraceAsString(event.throwable)));
 
         try {
-            resourceCluster.reconnectTaskExecutorGateway(event.getTaskExecutorID()).join();
+            resourceCluster.reconnectTaskExecutorGateway(event.getTaskExecutorID())
+                .whenComplete((res, throwable) -> {
+                    if (throwable != null) {
+                        log.error("Failed to request reconnect to gateway for {}", event.getTaskExecutorID(), throwable);
+                    }
+                    else {
+                        log.debug("Acked from reconnection request for {}", event.getTaskExecutorID());
+                    }
+                });
         } catch (Exception e) {
             log.warn(
                 "Failed to establish re-connection with the task executor {} on failed schedule request",


### PR DESCRIPTION
### Context

Convert the get resourceGateway calls (which perform RPC connection inside) to return future and perform the actions on the future's completion instead of blocking and waiting.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
