### PR TITLE
Revert metricsServer measurement group id

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/metrics/MetricsServer.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/metrics/MetricsServer.java
@@ -82,7 +82,7 @@ public class MetricsServer {
                                     for (Entry<MetricId, Gauge> gaugeEntry : metrics.gauges().entrySet()) {
                                         gauges.add(new GaugeMeasurement(gaugeEntry.getKey().metricName(), gaugeEntry.getValue().doubleValue()));
                                     }
-                                    measurements.add(new Measurements(metrics.getMetricGroupId().name(),
+                                    measurements.add(new Measurements(metrics.getMetricGroupId().id(),
                                             timestamp, counters, gauges, tags));
                                 }
                                 return Observable.from(measurements);


### PR DESCRIPTION
### Context

Revert to use id of the metricsGroupId in MetricsServer to fix the custom tagging.
(The original reason to switch to name to drop common tags is no longer required).

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
