### PR TITLE
Add error handling to gateway future

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
@@ -175,7 +175,11 @@ class ResourceClusterAwareSchedulerActor extends AbstractActorWithTimers {
                                     }
                                 })
 
-                        );
+                        )
+                        .exceptionally(
+                            throwable -> new FailedToSubmitScheduleRequestEvent(
+                                event.getScheduleRequestEvent(),
+                                event.getTaskExecutorID(), throwable));
                 pipe(ackFuture, getContext().getDispatcher()).to(self());
             }
         } catch (Exception e) {


### PR DESCRIPTION
### Context

Add explicit error handling to the future of getting TE gateway in case the error happened before the compose logic.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
