### PR TITLE
Fix unexpected sink side unsubscribe behavior 

### DIFF
--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/SubscriptionStateHandlerImpl.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/SubscriptionStateHandlerImpl.java
@@ -53,9 +53,7 @@ class SubscriptionStateHandlerImpl extends AbstractScheduledService implements S
 
     @Override
     public void startUp() {
-        if (currentState.get() == null) {
-            currentState.compareAndSet(null, SubscriptionState.of(clock));
-        }
+        currentState.compareAndSet(null, SubscriptionState.of(clock));
         log.info("SubscriptionStateHandlerImpl service started.");
     }
 

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/SubscriptionStateHandlerImpl.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/SubscriptionStateHandlerImpl.java
@@ -56,6 +56,7 @@ class SubscriptionStateHandlerImpl extends AbstractScheduledService implements S
         if (currentState.get() == null) {
             currentState.compareAndSet(null, SubscriptionState.of(clock));
         }
+        log.info("SubscriptionStateHandlerImpl service started.");
     }
 
     @Override
@@ -92,11 +93,7 @@ class SubscriptionStateHandlerImpl extends AbstractScheduledService implements S
 
     @Override
     public void onSinkSubscribed() {
-        // sink subscription can happen before the startup of this service.
-        if (currentState.get() == null) {
-            currentState.compareAndSet(null, SubscriptionState.of(clock));
-        }
-
+        Preconditions.checkNotNull(currentState.get(), "currentState is not intialized onSinkSubscribed.");
         currentState.updateAndGet(SubscriptionState::onSinkSubscribed);
     }
 

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
@@ -26,7 +26,6 @@ import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.runtime.MantisJobState;
 import io.mantisrx.runtime.loader.ClassLoaderHandle;
 import io.mantisrx.runtime.loader.RuntimeTask;
-import io.mantisrx.runtime.loader.SinkSubscriptionStateHandler;
 import io.mantisrx.runtime.loader.TaskFactory;
 import io.mantisrx.runtime.loader.config.WorkerConfiguration;
 import io.mantisrx.runtime.loader.config.WorkerConfigurationUtils;
@@ -94,7 +93,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     private final WorkerConfiguration workerConfiguration;
     private final HighAvailabilityServices highAvailabilityServices;
     private final ClassLoaderHandle classLoaderHandle;
-    private final SinkSubscriptionStateHandler.Factory subscriptionStateHandlerFactory;
     private final TaskExecutorRegistration taskExecutorRegistration;
     private final CompletableFuture<Void> startFuture = new CompletableFuture<>();
     private final ExecutorService ioExecutor;
@@ -122,10 +120,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         RpcService rpcService,
         WorkerConfiguration workerConfiguration,
         HighAvailabilityServices highAvailabilityServices,
-        ClassLoaderHandle classLoaderHandle,
-        SinkSubscriptionStateHandler.Factory subscriptionStateHandlerFactory) {
-        this(rpcService, workerConfiguration, highAvailabilityServices, classLoaderHandle,
-            subscriptionStateHandlerFactory, null);
+        ClassLoaderHandle classLoaderHandle) {
+        this(rpcService, workerConfiguration, highAvailabilityServices, classLoaderHandle, null);
     }
 
     public TaskExecutor(
@@ -133,7 +129,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         WorkerConfiguration workerConfiguration,
         HighAvailabilityServices highAvailabilityServices,
         ClassLoaderHandle classLoaderHandle,
-        SinkSubscriptionStateHandler.Factory subscriptionStateHandlerFactory,
         @Nullable TaskFactory taskFactory) {
         super(rpcService, RpcServiceUtils.createRandomName("worker"));
 
@@ -146,7 +141,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         this.workerConfiguration = workerConfiguration;
         this.highAvailabilityServices = highAvailabilityServices;
         this.classLoaderHandle = classLoaderHandle;
-        this.subscriptionStateHandlerFactory = subscriptionStateHandlerFactory;
         WorkerPorts workerPorts = new WorkerPorts(workerConfiguration.getMetricsPort(),
             workerConfiguration.getDebugPort(), workerConfiguration.getConsolePort(),
             workerConfiguration.getCustomPort(),

--- a/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/RuntimeTaskImplExecutorTest.java
+++ b/mantis-server/mantis-server-agent/src/test/java/io/mantisrx/server/agent/RuntimeTaskImplExecutorTest.java
@@ -458,8 +458,7 @@ public class RuntimeTaskImplExecutorTest {
                                    ClassLoaderHandle classLoaderHandle,
                                    SinkSubscriptionStateHandler.Factory subscriptionStateHandlerFactory,
                                    Consumer<Status> consumer) {
-            super(rpcService, workerConfiguration, highAvailabilityServices, classLoaderHandle,
-                subscriptionStateHandlerFactory);
+            super(rpcService, workerConfiguration, highAvailabilityServices, classLoaderHandle);
         }
 
     }


### PR DESCRIPTION
### Context

There is a race condition on the subscription handler where the current state can be empty if the subscription is established before the handler service is started, which causes non-perpetual jobs to silently fail at startup.

- Added handling + logs to this case.
- Added extra test in integration test.
- Removed sinkSubscriptionHandlerFactory on TaskExecutor level (not used anymore).

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
