### PR TITLE
Disable TEs on scaleDown

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -247,6 +248,16 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                 .idleInstances(response.getInstanceIds())
                 .build(),
             self());
+
+        // also disable the scale down targets to avoid them being used during the scale down process.
+        response.getInstanceIds().forEach(id ->
+            this.resourceClusterActor.tell(new DisableTaskExecutorsRequest(
+                Collections.emptyMap(),
+                this.clusterId,
+                Instant.now().plus(Duration.ofHours(24)),
+                Optional.of(id)),
+                self()
+        ));
     }
 
     private void onTriggerClusterUsageRequest(TriggerClusterUsageRequest req) {


### PR DESCRIPTION
### Context

Add disable TE requests during scale-down operation on RC.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
