### PR TITLE
TE connection improvement

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -118,8 +118,6 @@ public interface ResourceCluster extends ResourceClusterGateway {
      */
     CompletableFuture<TaskExecutorGateway> getTaskExecutorGateway(TaskExecutorID taskExecutorID);
 
-    CompletableFuture<Ack> reconnectGateway(TaskExecutorID taskExecutorID);
-
     CompletableFuture<TaskExecutorRegistration> getTaskExecutorInfo(String hostName);
 
     /**

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -34,7 +34,6 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.InitializeTaskExe
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.RemoveJobArtifactsToCacheRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.ResourceOverviewRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssignmentRequest;
-import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayReconnectRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorInfoRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorsList;
@@ -210,17 +209,6 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
                             return exceptionFuture;
                         }
                     });
-    }
-
-    @Override
-    public CompletableFuture<Ack> reconnectGateway(
-        TaskExecutorID taskExecutorID) {
-        return
-            Patterns
-                .ask(resourceClusterManagerActor, new TaskExecutorGatewayReconnectRequest(taskExecutorID, clusterID),
-                    askTimeout)
-                .thenApply(Ack.class::cast)
-                .toCompletableFuture();
     }
 
     @Override

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -34,7 +34,6 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetUnregisteredTa
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.RemoveJobArtifactsToCacheRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.ResourceOverviewRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorAssignmentRequest;
-import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayReconnectRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorGatewayRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorInfoRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterScalerActor.TriggerClusterRuleRefreshRequest;
@@ -143,8 +142,6 @@ class ResourceClustersManagerActor extends AbstractActor {
                 .match(TaskExecutorInfoRequest.class, req ->
                     getRCActor(req.getClusterID()).forward(req, context()))
                 .match(TaskExecutorGatewayRequest.class, req ->
-                    getRCActor(req.getClusterID()).forward(req, context()))
-                .match(TaskExecutorGatewayReconnectRequest.class, req ->
                     getRCActor(req.getClusterID()).forward(req, context()))
                 .match(DisableTaskExecutorsRequest.class, req ->
                     getRCActor(req.getClusterID()).forward(req, context()))


### PR DESCRIPTION
### Context
Problem:
TEs can get into connection problems where the TE gateway keeps failing causing frequent worker restarts and exhausting the idle pool.

* Refactor and clean up reconnection logic (handle the reconnection inside the TE gateway directly).
* Support scheduling rate limiter (this is supported via Fenzo on mesos but not supported on Titus).

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
