### PR TITLE
Fix unsubsribe on mantisMasterClient schedulingChanges

### DIFF
--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
@@ -80,7 +80,7 @@ import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.functions.Func1;
 import rx.functions.Func2;
-import rx.subjects.BehaviorSubject;
+
 
 /**
  *
@@ -698,11 +698,8 @@ public class MantisMasterClientApi implements MantisMasterGateway {
      * @param jobId
      * @return
      */
-    @Override
     public Observable<JobSchedulingInfo> schedulingChanges(final String jobId) {
-        BehaviorSubject<JobSchedulingInfo> behaviorSubject = BehaviorSubject.create();
-
-        masterMonitor.getMasterObservable()
+        return masterMonitor.getMasterObservable()
                 .filter(masterDescription -> masterDescription != null)
                 .retryWhen(retryLogic)
                 .switchMap((Func1<MasterDescription,
@@ -731,8 +728,7 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                         }))
                 .repeatWhen(repeatLogic)
                 .retryWhen(retryLogic)
-                .subscribe(behaviorSubject);
-        return behaviorSubject;
+                ;
     }
 
     /**

--- a/mantis-examples/mantis-examples-sine-function/src/main/java/io/mantisrx/mantis/examples/sinefunction/SineFunctionJob.java
+++ b/mantis-examples/mantis-examples-sine-function/src/main/java/io/mantisrx/mantis/examples/sinefunction/SineFunctionJob.java
@@ -202,7 +202,6 @@ public class SineFunctionJob extends MantisJobProvider<Point> {
             return Observable.just(
                     Observable.interval(0, period, TimeUnit.SECONDS)
                             .map(time -> {
-                                System.out.println("total worker num: " + index.getTotalNumWorkers());
                                 if (useRandom) {
                                     return randomNumGenerator.nextInt((max - min) + 1) + min;
                                 } else {

--- a/mantis-examples/mantis-examples-sine-function/src/main/java/io/mantisrx/mantis/examples/sinefunction/SineFunctionJob.java
+++ b/mantis-examples/mantis-examples-sine-function/src/main/java/io/mantisrx/mantis/examples/sinefunction/SineFunctionJob.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import rx.Observable;
+import rx.Subscription;
 import rx.functions.Func1;
 import rx.schedulers.Schedulers;
 
@@ -182,9 +183,10 @@ public class SineFunctionJob extends MantisJobProvider<Point> {
         public Observable<Observable<Integer>> call(Context context, Index index) {
             // If you want to be informed of scaleup/scale down of the source stage of this job you can subscribe
             // to getTotalNumWorkersObservable like the following.
-            index.getTotalNumWorkersObservable().subscribeOn(Schedulers.io()).subscribe((workerCount) -> {
-                System.out.println("Total worker count changed to -> " + workerCount);
-            });
+            Subscription subscription =
+                index.getTotalNumWorkersObservable().subscribeOn(Schedulers.io()).subscribe((workerCount) -> {
+                    System.out.println("Total worker count changed to -> " + workerCount);
+                });
             final int period = (int)
                     context.getParameters().get(INTERVAL_SEC);
             final int max = (int)
@@ -202,6 +204,7 @@ public class SineFunctionJob extends MantisJobProvider<Point> {
             return Observable.just(
                     Observable.interval(0, period, TimeUnit.SECONDS)
                             .map(time -> {
+                                System.out.println("total worker num: " + index.getTotalNumWorkers());
                                 if (useRandom) {
                                     return randomNumGenerator.nextInt((max - min) + 1) + min;
                                 } else {
@@ -212,6 +215,7 @@ public class SineFunctionJob extends MantisJobProvider<Point> {
                                 double value = randomRateVariable.nextDouble();
                                 return (value <= randomRate);
                             })
+                        .doOnUnsubscribe(subscription::unsubscribe)
             );
         }
 

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/source/Index.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/source/Index.java
@@ -16,15 +16,14 @@
 
 package io.mantisrx.runtime.source;
 
-import lombok.extern.slf4j.Slf4j;
 import rx.Observable;
 import rx.subjects.BehaviorSubject;
 
-@Slf4j
+
 public class Index {
 
     private final int workerIndex;
-    private final BehaviorSubject<Integer> totalNumWorkersObservable;
+    private final Observable<Integer> totalNumWorkersObservable;
 
 
     public Index(int offset, int total) {
@@ -35,8 +34,7 @@ public class Index {
 
     public Index(int offset, final Observable<Integer> totalWorkerAtStageObservable) {
         this.workerIndex = offset;
-        this.totalNumWorkersObservable = BehaviorSubject.create();
-        totalWorkerAtStageObservable.subscribe(this.totalNumWorkersObservable);
+        this.totalNumWorkersObservable = totalWorkerAtStageObservable;
     }
 
     public int getWorkerIndex() {
@@ -44,12 +42,6 @@ public class Index {
     }
 
     public int getTotalNumWorkers() {
-        Integer workerNum = this.totalNumWorkersObservable.getValue();
-        if (workerNum != null) {
-            return workerNum;
-        }
-
-        log.info("totalNumWorkersObservable is not ready yet, waiting.");
         return totalNumWorkersObservable.take(1).toBlocking().first();
     }
 


### PR DESCRIPTION
### Context

Using behavior subject breaks the subscription propagation back to the connection (mantis API layer) and can cause a connection leak on the API layer.
Revert the behavior subject change and apply "replay" instead of "share" on the client side observable stream to ensure last valid data item is still available while having the source connection stream unsub properly.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
