### PR TITLE
add add-opens for java17

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -95,6 +95,7 @@ docker {
         baseImage = 'azul/zulu-openjdk:17-latest'
         maintainer = 'Mantis Developers "mantis-oss-dev@netflix.com"'
         mainClassName = 'io.mantisrx.server.master.MasterMain'
+        applicationDefaultJvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED', '--add-opens', 'java.base/sun.net.util=ALL-UNNAMED']
         images = ["$imageRepository/mantiscontrolplaneserver:latest"]
         ports = [8100]
     }

--- a/mantis-server/mantis-server-agent/build.gradle
+++ b/mantis-server/mantis-server-agent/build.gradle
@@ -69,6 +69,7 @@ docker {
         baseImage = 'azul/zulu-openjdk:17-latest'
         maintainer = 'Mantis Developers "mantis-oss-dev@netflix.com"'
         mainClassName = 'io.mantisrx.server.agent.AgentV2Main'
+        applicationDefaultJvmArgs = ['--add-opens', 'java.base/java.lang=ALL-UNNAMED', '--add-opens', 'java.base/sun.net.util=ALL-UNNAMED']
         images = ["$imageRepository/mantisagent:latest"]
         ports = [5050]
     }


### PR DESCRIPTION
### Context

Add support for calling java modules for java17. Tested via local mantis-helm chart deployment

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
