### PR TITLE
SinkConnectionsStatus to also provide running workers count

### DIFF
--- a/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
@@ -45,6 +45,8 @@ public class MantisClient {
 
     private static final String ENABLE_PINGS_KEY = "mantis.sse.disablePingFiltering";
     private final boolean disablePingFiltering;
+    // TODO: make this configurable + default false
+    private final boolean useRunningWorkers = true;
 
     private final MasterClientWrapper clientWrapper;
     private final JobSinkLocator jobSinkLocator = new JobSinkLocator() {
@@ -225,7 +227,12 @@ public class MantisClient {
         return new SinkClientImpl<T>(jobId, sinkConnectionFunc, getSinkLocator(),
                 numSinkWrkrsSubject
                         .filter((jobSinkNumWorkers) -> jobId.equals(jobSinkNumWorkers.getJobId()))
-                        .map((jobSinkNumWorkers) -> jobSinkNumWorkers.getNumSinkWorkers()),
+                        .map((jobSinkNumWorkers -> {
+                            if (useRunningWorkers) {
+                                return jobSinkNumWorkers.getNumSinkRunningWorkers();
+                            }
+                            return jobSinkNumWorkers.getNumSinkWorkers();
+                        })),
                 sinkConnectionsStatusObserver, dataRecvTimeoutSecs, this.disablePingFiltering);
     }
 

--- a/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
@@ -45,8 +45,6 @@ public class MantisClient {
 
     private static final String ENABLE_PINGS_KEY = "mantis.sse.disablePingFiltering";
     private final boolean disablePingFiltering;
-    // TODO: make this configurable + default false
-    private final boolean useRunningWorkers = true;
 
     private final MasterClientWrapper clientWrapper;
     private final JobSinkLocator jobSinkLocator = new JobSinkLocator() {
@@ -226,13 +224,7 @@ public class MantisClient {
         clientWrapper.addNumSinkWorkersObserver(numSinkWrkrsSubject);
         return new SinkClientImpl<T>(jobId, sinkConnectionFunc, getSinkLocator(),
                 numSinkWrkrsSubject
-                        .filter((jobSinkNumWorkers) -> jobId.equals(jobSinkNumWorkers.getJobId()))
-                        .map((jobSinkNumWorkers -> {
-                            if (useRunningWorkers) {
-                                return jobSinkNumWorkers.getNumSinkRunningWorkers();
-                            }
-                            return jobSinkNumWorkers.getNumSinkWorkers();
-                        })),
+                        .filter((jobSinkNumWorkers) -> jobId.equals(jobSinkNumWorkers.getJobId())),
                 sinkConnectionsStatusObserver, dataRecvTimeoutSecs, this.disablePingFiltering);
     }
 

--- a/mantis-client/src/main/java/io/mantisrx/client/SinkConnectionsStatus.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/SinkConnectionsStatus.java
@@ -21,11 +21,13 @@ public class SinkConnectionsStatus {
     private final long numConnected;
     private final long total;
     private final long recevingDataFrom;
+    private final long runningCount;
 
-    public SinkConnectionsStatus(long recevingDataFrom, long numConnected, long total) {
+    public SinkConnectionsStatus(long recevingDataFrom, long numConnected, long total, long runningCount) {
         this.recevingDataFrom = recevingDataFrom;
         this.numConnected = numConnected;
         this.total = total;
+        this.runningCount = runningCount;
     }
 
     public long getRecevingDataFrom() {
@@ -39,4 +41,6 @@ public class SinkConnectionsStatus {
     public long getTotal() {
         return total;
     }
+
+    public long getRunningCount() { return runningCount; }
 }

--- a/mantis-common/src/main/java/io/mantisrx/runtime/MantisJobState.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/MantisJobState.java
@@ -109,4 +109,7 @@ public enum MantisJobState {
         }
     }
 
+    public static boolean isOnStartedState(MantisJobState state) {
+        return state == MantisJobState.Started;
+    }
 }

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MasterClientWrapper.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MasterClientWrapper.java
@@ -242,7 +242,7 @@ public class MasterClientWrapper {
                                                     .getHosts()
                                                     .values()
                                                     .stream()
-                                                    .filter(e -> MantisJobState.isRunningState(e.getState()))
+                                                    .filter(e -> MantisJobState.isOnStartedState(e.getState()))
                                                     .count();
                                                 numSinkWorkersSubject.onNext(new JobSinkNumWorkers(jobId, totalFromPartitions, runningWorkers));
                                                 if (usePartition(workerIndex, totalFromPartitions, forPartition, totalPartitions)) {

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MasterClientWrapper.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MasterClientWrapper.java
@@ -238,7 +238,13 @@ public class MasterClientWrapper {
                                             for (WorkerHost host : workerAssignments.getHosts().values()) {
                                                 final int workerIndex = host.getWorkerIndex();
                                                 final int totalFromPartitions = workerAssignments.getNumWorkers();
-                                                numSinkWorkersSubject.onNext(new JobSinkNumWorkers(jobId, totalFromPartitions));
+                                                final int runningWorkers = (int) workerAssignments
+                                                    .getHosts()
+                                                    .values()
+                                                    .stream()
+                                                    .filter(e -> MantisJobState.isRunningState(e.getState()))
+                                                    .count();
+                                                numSinkWorkersSubject.onNext(new JobSinkNumWorkers(jobId, totalFromPartitions, runningWorkers));
                                                 if (usePartition(workerIndex, totalFromPartitions, forPartition, totalPartitions)) {
                                                     //logger.info("Using partition " + workerIndex);
                                                     if (host.getState() == MantisJobState.Started) {
@@ -311,11 +317,13 @@ public class MasterClientWrapper {
     public static class JobSinkNumWorkers {
 
         protected final int numSinkWorkers;
+        protected final int numSinkRunningWorkers;
         private final String jobId;
 
-        public JobSinkNumWorkers(String jobId, int numSinkWorkers) {
+        public JobSinkNumWorkers(String jobId, int numSinkWorkers, int numSinkRunningWorkers) {
             this.jobId = jobId;
             this.numSinkWorkers = numSinkWorkers;
+            this.numSinkRunningWorkers = numSinkRunningWorkers;
         }
 
         public String getJobId() {
@@ -324,6 +332,10 @@ public class MasterClientWrapper {
 
         public int getNumSinkWorkers() {
             return numSinkWorkers;
+        }
+
+        public int getNumSinkRunningWorkers() {
+            return numSinkRunningWorkers;
         }
     }
 


### PR DESCRIPTION
### Context

The current issues with unreliable periods identified on go/realtimesps largely arise from scale-up operations on the PlayAPI source job. Whenever a scale-up occurs, additional workers are introduced. However, the SPS tracker perceives this as a lack of connection with all up-stream workers and consequently flags the signal as unreliable. This is largely due to the current operational logic. Specifically, each SPS worker assesses the total number of workers in the source against the number it’s connected to. Since the SPS worker cannot connect to workers in the ‘launched’ state, this results in a discrepancy exceeding 5% (since the source is always scaled up by 40 units, surpassing 5% of the total). The discussion yesterday highlighted two potential solutions: 1) the total connections should perhaps be compared with source workers that are in a connectable/running state, and 2) there might be a need to delay the process of flagging the signal as unreliable, rather than doing so immediately upon the first detection of a mismatch, which currently occurs soon after the workers are assigned post the scale-up operation.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
