### PR TITLE
Remove liuml07 from default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @codyrioux @nickmahilani @jeffchao @piygoyal @calvin681 @sundargates @Andyz26 @hmitnflx @markcho @liuml07 @fdc-ntflx
+* @codyrioux @nickmahilani @jeffchao @piygoyal @calvin681 @sundargates @Andyz26 @hmitnflx @markcho @fdc-ntflx


### PR DESCRIPTION
Got a lot of emails and push notifications about changes and comments on pull requests. As I do not actively work on Mantis right now, it's better to remove me from the default reviewers.