### PR TITLE
Fix losing job on control plane restart

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
@@ -402,7 +402,7 @@ public class KeyValueBasedPersistenceProvider implements IMantisPersistenceProvi
                     // If there are duplicate workers on the same stage index, only attach the one with latest
                     // worker number. The stale workers will not present in the stage metadata thus gets terminated
                     // when it sends heartbeats to its JobActor.
-                    boolean addedWorker = jobMeta.addWorkerMedata(workerMeta.getStageNum(), workerMeta);
+                    boolean addedWorker = jobMeta.tryAddOrReplaceWorker(workerMeta.getStageNum(), workerMeta);
                     if (!addedWorker) {
                         staleWorkersFoundCounter.increment();
                     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
@@ -49,7 +49,6 @@ import io.mantisrx.shaded.com.fasterxml.jackson.databind.DeserializationFeature;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import io.mantisrx.shaded.com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import io.mantisrx.shaded.com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.mantisrx.shaded.com.google.common.base.Preconditions;
 import io.mantisrx.shaded.com.google.common.collect.ImmutableList;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
 import java.io.IOException;
@@ -129,7 +128,9 @@ public class KeyValueBasedPersistenceProvider implements IMantisPersistenceProvi
     private final KeyValueStore kvStore;
     private final LifecycleEventPublisher eventPublisher;
     private final Counter noWorkersFoundCounter;
+    private final Counter staleWorkersFoundCounter;
     private final Counter workersFoundCounter;
+    private final Counter failedToLoadJobCounter;
 
     public KeyValueBasedPersistenceProvider(KeyValueStore kvStore, LifecycleEventPublisher eventPublisher) {
         this.kvStore = kvStore;
@@ -137,12 +138,16 @@ public class KeyValueBasedPersistenceProvider implements IMantisPersistenceProvi
         Metrics m = new Metrics.Builder()
             .id("storage")
             .addCounter("noWorkersFound")
+            .addCounter("staleWorkerFound")
             .addCounter("workersFound")
+            .addCounter("failedToLoadJobCount")
             .build();
 
         m = MetricsRegistry.getInstance().registerAndGet(m);
         this.noWorkersFoundCounter = m.getCounter("noWorkersFound");
+        this.staleWorkersFoundCounter = m.getCounter("staleWorkerFound");
         this.workersFoundCounter = m.getCounter("workersFound");
+        this.failedToLoadJobCounter = m.getCounter("failedToLoadJobCount");
     }
 
     protected String getJobMetadataFieldName() {
@@ -394,18 +399,18 @@ public class KeyValueBasedPersistenceProvider implements IMantisPersistenceProvi
 
                 workersFoundCounter.increment();
                 for (MantisWorkerMetadataWritable workerMeta : workersByJobId.get(jobId)) {
-                    Preconditions.checkState(
-                        jobMeta.addWorkerMedata(workerMeta.getStageNum(), workerMeta, null),
-                        "JobID=%s stage=%d workerIdx=%d has existing worker, existing=%s, new=%s",
-                        workerMeta.getJobId(),
-                        workerMeta.getStageNum(),
-                        workerMeta.getWorkerIndex(),
-                        jobMeta.getWorkerByIndex(workerMeta.getStageNum(), workerMeta.getWorkerIndex()).getWorkerId(),
-                        workerMeta.getWorkerId());
+                    // If there are duplicate workers on the same stage index, only attach the one with latest
+                    // worker number. The stale workers will not present in the stage metadata thus gets terminated
+                    // when it sends heartbeats to its JobActor.
+                    boolean addedWorker = jobMeta.addWorkerMedata(workerMeta.getStageNum(), workerMeta);
+                    if (!addedWorker) {
+                        staleWorkersFoundCounter.increment();
+                    }
                 }
                 jobMetas.add(DataFormatAdapter.convertMantisJobWriteableToMantisJobMetadata(jobMeta, eventPublisher));
             } catch (Exception e) {
-                logger.warn("Exception loading job {}", jobId, e);
+                logger.error("Exception loading job {}", jobId, e);
+                this.failedToLoadJobCounter.increment();
             }
         }
         // need to load all workers for the jobMeta and then ensure they are added to jobMetas!

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
@@ -41,6 +41,7 @@ import io.mantisrx.server.master.store.KeyValueStore;
 import io.mantisrx.server.master.store.MantisJobMetadataWritable;
 import io.mantisrx.server.master.store.MantisStageMetadata;
 import io.mantisrx.server.master.store.MantisStageMetadataWritable;
+import io.mantisrx.server.master.store.MantisWorkerMetadata;
 import io.mantisrx.server.master.store.MantisWorkerMetadataWritable;
 import io.mantisrx.server.master.store.NamedJob;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
@@ -402,8 +403,10 @@ public class KeyValueBasedPersistenceProvider implements IMantisPersistenceProvi
                     // If there are duplicate workers on the same stage index, only attach the one with latest
                     // worker number. The stale workers will not present in the stage metadata thus gets terminated
                     // when it sends heartbeats to its JobActor.
-                    boolean addedWorker = jobMeta.tryAddOrReplaceWorker(workerMeta.getStageNum(), workerMeta);
-                    if (!addedWorker) {
+                    MantisWorkerMetadata existedWorker =
+                        jobMeta.tryAddOrReplaceWorker(workerMeta.getStageNum(), workerMeta);
+                    if (existedWorker != null) {
+                        logger.error("Encountered duplicate worker {} when adding {}", existedWorker, workerMeta);
                         staleWorkersFoundCounter.increment();
                     }
                 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
@@ -177,11 +177,17 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
         return stageMetadataMap.putIfAbsent(msmd.getStageNum(), msmd) == null;
     }
 
-    public boolean addWorkerMedata(int stageNum, MantisWorkerMetadata workerMetadata, MantisWorkerMetadata replacedWorker)
-            throws InvalidJobException {
+    /**
+     * Add the given MantisWorkerMetadata instance to the corresponding stage.
+     * If the stage worker index already exists, replace it only when the given worker has higher worker number.
+     * @param stageNum target stage number.
+     * @param workerMetadata new worker metadata instance.
+     * @return true if the given worker metadata instance is added to this job.
+     */
+    public boolean addWorkerMedata(int stageNum, MantisWorkerMetadata workerMetadata) {
         final boolean result =
             stageMetadataMap.get(stageNum)
-                .replaceWorkerIndex(workerMetadata, replacedWorker);
+                .replaceWorkerIndex(workerMetadata);
 
         if (result) {
             Integer integer = workerNumberToStageMap.put(workerMetadata.getWorkerNumber(), stageNum);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
@@ -182,9 +182,10 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
      * If the stage worker index already exists, replace it only when the given worker has higher worker number.
      * @param stageNum target stage number.
      * @param workerMetadata new worker metadata instance.
-     * @return true if the given worker metadata instance is added to this job.
+     * @return null if the given worker metadata is added to this job. Otherwise, return the existing worker with
+     * newer number.
      */
-    public boolean tryAddOrReplaceWorker(int stageNum, MantisWorkerMetadata workerMetadata) {
+    public MantisWorkerMetadata tryAddOrReplaceWorker(int stageNum, MantisWorkerMetadata workerMetadata) {
         final boolean result =
             stageMetadataMap.get(stageNum)
                 .replaceWorkerIndex(workerMetadata);
@@ -195,8 +196,15 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
                 logger.error(String.format("Unexpected to put worker number mapping from %d to stage %d for job %s, prev mapping to stage %d",
                     workerMetadata.getWorkerNumber(), stageNum, workerMetadata.getJobId(), integer));
             }
+            return null;
+        } else {
+            try {
+                return stageMetadataMap.get(stageNum).getWorkerByIndex(workerMetadata.getWorkerIndex());
+            } catch (InvalidJobException e) {
+                logger.error("Failed to fetch existing worker when new worker got rejected: {}", workerMetadata, e);
+                throw new RuntimeException("Failed to fetch existing worker when new worker got rejected", e);
+            }
         }
-        return result;
     }
 
     @JsonIgnore

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/store/MantisJobMetadataWritable.java
@@ -184,7 +184,7 @@ public class MantisJobMetadataWritable implements MantisJobMetadata {
      * @param workerMetadata new worker metadata instance.
      * @return true if the given worker metadata instance is added to this job.
      */
-    public boolean addWorkerMedata(int stageNum, MantisWorkerMetadata workerMetadata) {
+    public boolean tryAddOrReplaceWorker(int stageNum, MantisWorkerMetadata workerMetadata) {
         final boolean result =
             stageMetadataMap.get(stageNum)
                 .replaceWorkerIndex(workerMetadata);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProviderTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProviderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.master.persistence;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import io.mantisrx.master.events.LifecycleEventPublisher;
+import io.mantisrx.master.jobcluster.job.IMantisJobMetadata;
+import io.mantisrx.server.master.persistence.exceptions.InvalidJobException;
+import io.mantisrx.server.master.store.KeyValueStore;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class KeyValueBasedPersistenceProviderTest {
+
+    @Test
+    public void testLoadJobWithDupeWorker() throws IOException, InvalidJobException {
+        KeyValueStore kvStore = Mockito.mock(KeyValueStore.class);
+        when(kvStore.getAllRows("MantisWorkers"))
+            .thenReturn(ImmutableMap.of(
+                "testjob-1-1000", ImmutableMap.of(
+                    "1-0-2",
+                    "{\"workerIndex\":0,\"workerNumber\":2,\"jobId\":\"testjob-1\",\"stageNum\":1,"
+                        + "\"numberOfPorts\":5,\"metricsPort\":1051,\"consolePort\":1053,\"debugPort\":1052,"
+                        + "\"customPort\":1054,\"ports\":[1055]}"),
+                "testjob-1-2000", ImmutableMap.of(
+                    "1-0-1",
+                    "{\"workerIndex\":0,\"workerNumber\":1,\"jobId\":\"testjob-1\",\"stageNum\":1,"
+                        + "\"numberOfPorts\":5,\"metricsPort\":1051,\"consolePort\":1053,\"debugPort\":1052,"
+                        + "\"customPort\":1054,\"ports\":[1055]}")
+            ));
+
+        when(kvStore.getAllRows("MantisJobStageData"))
+            .thenReturn(ImmutableMap.of(
+                "testjob-1",
+                ImmutableMap.of(
+                    "stageMetadata-1",
+                    "{\"jobId\":\"testjob-1\",\"stageNum\":1,\"numStages\":1,\"numWorkers\":1,"
+                        + "\"machineDefinition\":{\"cpuCores\":2.0,\"memoryMB\":5000.0,\"networkMbps\":1000.0,"
+                        + "\"diskMB\":8192.0,\"numPorts\":1}}",
+                    "jobMetadata",
+                    "{\"jobId\":\"testjob-1\",\"name\":\"testjob\",\"user\":\"mantisoss\","
+                        + "\"submittedAt\":1691103290000,\"startedAt\":1691103300002,\"jarUrl\":\"http://testjob1.zip\","
+                        + "\"numStages\":1,\"state\":\"Launched\",\"parameters\":[],\"nextWorkerNumberToUse\":3,"
+                        + "\"sla\":{\"runtimeLimitSecs\":0,\"minRuntimeSecs\":0,\"slaType\":\"Lossy\","
+                        + "\"durationType\":\"Perpetual\",\"userProvidedType\":\"\"}"
+                        + "}"
+                )));
+
+        LifecycleEventPublisher eventPublisher = Mockito.mock(LifecycleEventPublisher.class);
+
+        KeyValueBasedPersistenceProvider kvProvider =
+            new KeyValueBasedPersistenceProvider(kvStore, eventPublisher);
+
+        // loading two workers on same index should retain the one with newer worker number.
+        List<IMantisJobMetadata> iMantisJobMetadata = kvProvider.loadAllJobs();
+        assertNotNull(iMantisJobMetadata);
+        assertEquals(1, iMantisJobMetadata.size());
+        assertEquals("testjob-1", iMantisJobMetadata.get(0).getJobId().getId());
+        assertTrue(iMantisJobMetadata.get(0).getStageMetadata(1).isPresent());
+        assertEquals(2,
+            iMantisJobMetadata.get(0).getStageMetadata(1).get().getWorkerByIndex(0).getMetadata().getWorkerNumber());
+    }
+}


### PR DESCRIPTION
### Context

Currently, any failure during the loading job from the persistency layer step causes the job to be dropped without proper cleanup.
Here the logic is updated as follows:
* If two duplicate workers on the same stage index are found, load the one with the newer worker number to use as active.
* The dupe one with the older worker number then gets terminated in the job actor when it sends the heartbeat and doesn't match with the active worker number.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
