### PR TITLE
Fix disable path

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -557,6 +557,12 @@ class ResourceClusterActor extends AbstractActorWithTimers {
                 if (registration != null) {
                     log.debug("Found registration {} for task executor {}", registration, heartbeat.getTaskExecutorID());
                     Preconditions.checkState(state.onRegistration(registration));
+
+                    // check if the task executor has been marked as 'Disabled'
+                    if (isTaskExecutorDisabled(registration)) {
+                        log.info("Reconnected task executor {} was already marked for disabling.", registration.getTaskExecutorID());
+                        state.onNodeDisabled();
+                    }
                 } else {
 //                  TODO(sundaram): add a metric
                     log.warn("Received heartbeat from unknown task executor {}", heartbeat.getTaskExecutorID());


### PR DESCRIPTION
### Context

After https://github.com/Netflix/mantis/pull/579 TEs won't send registration requests after restarting, so it's important to mark TEs as disabled on heartbeats. This check will only be performed the very first heartbeat TEs send after restart (when registration is null and fetched from the DB).  

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
