### PR TITLE
Fix duplicate TE allocation to multiple workers with different resource spec matching the same SKU 

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
@@ -259,14 +259,14 @@ class ExecutorStateManagerImpl implements ExecutorStateManager {
         }
 
         boolean noResourcesAvailable = false;
-        final Map<TaskExecutorAllocationRequest, Pair<TaskExecutorID, TaskExecutorState>> bestFit = new HashMap<>();
+        final BestFit bestFit = new BestFit();
         final boolean isJobIdAlreadyPending = pendingJobRequests.getIfPresent(request.getJobId()) != null;
 
         for (Entry<MachineDefinition, List<TaskExecutorAllocationRequest>> entry : request.getGroupedByMachineDef().entrySet()) {
             final MachineDefinition machineDefinition = entry.getKey();
             final List<TaskExecutorAllocationRequest> allocationRequests = entry.getValue();
 
-            Optional<Map<TaskExecutorID, TaskExecutorState>> taskExecutors = findTaskExecutorsFor(request, machineDefinition, allocationRequests, isJobIdAlreadyPending);
+            Optional<Map<TaskExecutorID, TaskExecutorState>> taskExecutors = findTaskExecutorsFor(request, machineDefinition, allocationRequests, isJobIdAlreadyPending, bestFit);
 
             // Mark noResourcesAvailable if we can't find enough TEs for a given machine def
             if (!taskExecutors.isPresent()) {
@@ -277,7 +277,7 @@ class ExecutorStateManagerImpl implements ExecutorStateManager {
             // Map each TE to a given allocation request
             int index = 0;
             for (Entry<TaskExecutorID, TaskExecutorState> taskToStateEntry : taskExecutors.get().entrySet()) {
-                bestFit.put(allocationRequests.get(index), Pair.of(taskToStateEntry.getKey(), taskToStateEntry.getValue()));
+                bestFit.add(allocationRequests.get(index), Pair.of(taskToStateEntry.getKey(), taskToStateEntry.getValue()));
                 index++;
             }
         }
@@ -287,12 +287,12 @@ class ExecutorStateManagerImpl implements ExecutorStateManager {
             return Optional.empty();
         } else {
             // Return best fit only if there are enough available TEs for all machine def
-            return Optional.of(new BestFit(bestFit));
+            return Optional.of(bestFit);
         }
 
     }
 
-    private Optional<Map<TaskExecutorID, TaskExecutorState>> findBestFitFor(TaskExecutorBatchAssignmentRequest request, MachineDefinition machineDefinition, Integer numWorkers) {
+    private Optional<Map<TaskExecutorID, TaskExecutorState>> findBestFitFor(TaskExecutorBatchAssignmentRequest request, MachineDefinition machineDefinition, Integer numWorkers, BestFit currentBestFit) {
         // only allow allocation in the lowest CPU cores matching group.
         SortedMap<Double, NavigableSet<TaskExecutorHolder>> targetMap =
             this.executorByCores.tailMap(machineDefinition.getCpuCores());
@@ -323,6 +323,10 @@ class ExecutorStateManagerImpl implements ExecutorStateManager {
                 .stream()
                 .filter(teHolder -> {
                     if (!this.taskExecutorStateMap.containsKey(teHolder.getId())) {
+                        return false;
+                    }
+
+                    if (currentBestFit.contains(teHolder.getId())) {
                         return false;
                     }
 
@@ -433,10 +437,10 @@ class ExecutorStateManagerImpl implements ExecutorStateManager {
             .orElse(0);
     }
 
-    private Optional<Map<TaskExecutorID, TaskExecutorState>> findTaskExecutorsFor(TaskExecutorBatchAssignmentRequest request, MachineDefinition machineDefinition, List<TaskExecutorAllocationRequest> allocationRequests, boolean isJobIdAlreadyPending) {
+    private Optional<Map<TaskExecutorID, TaskExecutorState>> findTaskExecutorsFor(TaskExecutorBatchAssignmentRequest request, MachineDefinition machineDefinition, List<TaskExecutorAllocationRequest> allocationRequests, boolean isJobIdAlreadyPending, BestFit currentBestFit) {
         // Finds best fit for N workers of the same machine def
         final Optional<Map<TaskExecutorID, TaskExecutorState>> taskExecutors = findBestFitFor(
-            request, machineDefinition, allocationRequests.size());
+            request, machineDefinition, allocationRequests.size(), currentBestFit);
 
         // Verify that the number of task executors returned matches the asked
         if (taskExecutors.isPresent() && taskExecutors.get().size() == allocationRequests.size()) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -1042,9 +1042,23 @@ class ResourceClusterActor extends AbstractActorWithTimers {
 
 
     @Value
-    @Builder
     static class BestFit {
         Map<TaskExecutorAllocationRequest, Pair<TaskExecutorID, TaskExecutorState>> bestFit;
+        Set<TaskExecutorID> taskExecutorIDSet;
+
+        public BestFit() {
+            this.bestFit = new HashMap<>();
+            this.taskExecutorIDSet = new HashSet<>();
+        }
+
+        public void add(TaskExecutorAllocationRequest request, Pair<TaskExecutorID, TaskExecutorState> taskExecutorStatePair) {
+            bestFit.put(request, taskExecutorStatePair);
+            taskExecutorIDSet.add(taskExecutorStatePair.getLeft());
+        }
+
+        public boolean contains(TaskExecutorID taskExecutorID) {
+            return taskExecutorIDSet.contains(taskExecutorID);
+        }
 
         public Map<TaskExecutorAllocationRequest, TaskExecutorID> getRequestToTaskExecutorMap() {
             return bestFit


### PR DESCRIPTION
### Context

This PR addresses a problem encountered with TE allocation in scenarios where jobs have TEs with different resource specs that match the same SKU. For instance, if a job contains a TE with 1 core and another with 2 cores, and the smallest SKU available is a 2 core, both TEs will match the smallest SKU. This situation can lead to the same TE being incorrectly allocated to different workers, as currently the logic assumes that resource spec always matches the SKU size (which in a few cases it's not the case).

In order to address this issue, we now pass the list of already assigned TEs over to the matching logic, ensuring we aren't reusing them for other worker requests.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
