### PR TITLE
Bump docker-compose ZooKeeper version to 3.5.5 to fix compatability bug.

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -10,7 +10,7 @@ version: '3'
 services:
 
   zookeeper:
-    image: jplock/zookeeper:3.4.6
+    image: jplock/zookeeper:3.5.5
     ports:
       - "2181:2181"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ version: '3'
 services:
 
   zookeeper:
-    image: jplock/zookeeper:3.4.6
+    image: jplock/zookeeper:3.5.5
     ports:
       - "2181:2181"
     networks:


### PR DESCRIPTION


### Context

https://github.com/Netflix/mantis/issues/605 describes a fatal issue with the existing docker-compose file that I resolved with the contents of this PR. Based on conversations in https://github.com/yahoo/CMAK/issues/748, it sounds like Curator is no longer compatible with ZooKeeper 3.4.

### How to reproduce and test

The following commands will reproduce the issue, which can then be resolved by using this commit instead:

```
$ mkdir mantis
$ cd mantis
$ wget https://raw.githubusercontent.com/Netflix/mantis/master/docker-compose.yml
$ docker-compose -f docker-compose.yml up
```

You'll likely need to prune your volumes when switching between versions to allow for the ZooKeeper upgrade.

### Checklist

- [ ] `./gradlew build` compiles code correctly
    - I'm unable to build Mantis as described in https://github.com/Netflix/mantis/issues/604.
- [x] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
    - I'm unable to build Mantis as described in https://github.com/Netflix/mantis/issues/604.
- [x] Extended README or added javadocs where applicable
