### PR TITLE
Update getting started local tutorial to clarify required JDK version.

### DIFF
--- a/docs/docs/getting-started/tutorials/local.md
+++ b/docs/docs/getting-started/tutorials/local.md
@@ -2,7 +2,10 @@
 
 ## Prerequisites
 
-JDK 8 or higher
+JDK 8 (newer versions may not be supported)
+
+!!! tip
+    Some users find https://sdkman.io/ helpful for managing multiple Java versions.
 
 ## Build and run the synthetic-sourcejob sample
 
@@ -43,7 +46,7 @@ Such an MQL query would like like this.
 ```bash
 select country from stream where status==500
 ```
-In another terminal window curl this port
+In another terminal window curl this port (note that your port will likely be different)
 ```bash
 $ curl "localhost:8436?subscriptionId=nj&criterion=select%20country%20from%20stream%20where%20status%3D%3D500&clientId=nj2"
 ```


### PR DESCRIPTION
### Context

See https://github.com/Netflix/mantis/issues/604 for context. The Mantis project does not presently compile will all JDK versions larger or equal to 8.

Note that I haven't tested for at which point the incompatibility begins, just that JDK17 doesn't work.

I added a tip box for the tip about JDK selection tooling that @calvin681 gave me in https://github.com/Netflix/mantis/issues/604.

I also ran through the rest of the guide and confirmed it's functional (with a slight adjustment to the wording around the port number selection incase that trips anyone up).

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
