### PR TITLE
Reduce disable expiration on TE scale down

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -156,6 +156,12 @@ class ResourceClusterActor extends AbstractActorWithTimers {
     @Override
     public void preStart() throws Exception {
         super.preStart();
+        metrics.incrementCounter(
+            ResourceClusterActorMetrics.RC_ACTOR_RESTART,
+            TagList.create(ImmutableMap.of(
+                "resourceCluster",
+                clusterID.getResourceID())));
+
         fetchJobArtifactsToCache();
 
         List<DisableTaskExecutorsRequest> activeRequests =
@@ -445,7 +451,9 @@ class ResourceClusterActor extends AbstractActorWithTimers {
     }
 
     private void findAndMarkDisabledTaskExecutors(CheckDisabledTaskExecutors r) {
-        log.info("Checking disabled task executors for Cluster {} because of {}", clusterID.getResourceID(), r.getReason());
+        log.info(
+            "Checking disabled task executors for Cluster {} because of {}. Current disabled request size: {}",
+            clusterID.getResourceID(), r.getReason(), activeDisableTaskExecutorsByAttributesRequests.size());
         final Instant now = clock.instant();
         for (DisableTaskExecutorsRequest request : activeDisableTaskExecutorsByAttributesRequests) {
             if (request.isExpired(now)) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActorMetrics.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActorMetrics.java
@@ -55,6 +55,8 @@ class ResourceClusterActorMetrics {
     public static final String HEARTBEAT_TIMEOUT = "taskExecutorHeartbeatTimeout";
 
     public static final String TE_CONNECTION_FAILURE = "taskExecutorConnectionFailure";
+
+    public static final String RC_ACTOR_RESTART = "resourceClusterActorRestart";
     public static final String MAX_JOB_ARTIFACTS_TO_CACHE_REACHED = "maxJobArtifactsToCacheReached";
 
     private final Registry registry;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -254,7 +254,7 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
             this.resourceClusterActor.tell(new DisableTaskExecutorsRequest(
                 Collections.emptyMap(),
                 this.clusterId,
-                Instant.now().plus(Duration.ofHours(24)),
+                Instant.now().plus(Duration.ofMinutes(60)),
                 Optional.of(id)),
                 self()
         ));


### PR DESCRIPTION
### Context

Reduce the expiration time for disabled TE during scale-down.
Improve logging and metrics.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
