### PR TITLE
[PR/623 - pt 1] Introduce scheduling constraints

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/scheduler/SchedulingConstraints.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/scheduler/SchedulingConstraints.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.core.scheduler;
+
+import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.shaded.com.google.common.annotations.VisibleForTesting;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+/**
+ * A class that represents scheduling constraints. These constraints include the resource constraints, and a map of assignment attributes (e.g. jdkVersion:17 or springBootVersion:3).
+ */
+@RequiredArgsConstructor
+@Getter
+@EqualsAndHashCode
+@AllArgsConstructor(staticName = "of")
+@ToString
+public class SchedulingConstraints {
+    // Defines the resource constraints for scheduling
+    MachineDefinition machineDefinition;
+
+    // Additional attributes for assignment (ie. jdkVersion:17 or springBootVersion:3)
+    Map<String, String> assignmentAttributes;
+
+    @VisibleForTesting
+    public static SchedulingConstraints of(MachineDefinition machineDefinition) {
+        return SchedulingConstraints.of(machineDefinition, ImmutableMap.of());
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/scheduler/SchedulingConstraints.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/scheduler/SchedulingConstraints.java
@@ -21,24 +21,18 @@ import io.mantisrx.shaded.com.google.common.annotations.VisibleForTesting;
 import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
+import lombok.Value;
 
 /**
- * A class that represents scheduling constraints. These constraints include the resource constraints, and a map of assignment attributes (e.g. jdkVersion:17 or springBootVersion:3).
+ * A class that represents scheduling constraints. These constraints include the resource constraints, and a map of assignment attributes (e.g. jdkVersion:17).
  */
-@RequiredArgsConstructor
-@Getter
-@EqualsAndHashCode
 @AllArgsConstructor(staticName = "of")
-@ToString
+@Value
 public class SchedulingConstraints {
     // Defines the resource constraints for scheduling
     MachineDefinition machineDefinition;
 
-    // Additional attributes for assignment (ie. jdkVersion:17 or springBootVersion:3)
+    // Additional attributes for assignment (ie. jdkVersion:17)
     Map<String, String> assignmentAttributes;
 
     @VisibleForTesting

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorAllocationRequest.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorAllocationRequest.java
@@ -16,9 +16,9 @@
 
 package io.mantisrx.server.master.resourcecluster;
 
-import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.server.core.domain.JobMetadata;
 import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.core.scheduler.SchedulingConstraints;
 import lombok.AllArgsConstructor;
 import lombok.Value;
 
@@ -26,7 +26,7 @@ import lombok.Value;
 @AllArgsConstructor(staticName = "of")
 public class TaskExecutorAllocationRequest {
     WorkerId workerId;
-    MachineDefinition machineDefinition;
+    SchedulingConstraints constraints;
     JobMetadata jobMetadata;
     int stageNum;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -1590,6 +1590,7 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                         workerRequest.getNumberOfPorts(),
                         jobMetadata,
                         mantisJobMetaData.getSla().orElse(new JobSla.Builder().build()).getDurationType(),
+                        // TODO(fdichiara): make this a property of JobStageMetadata. https://github.com/Netflix/mantis/pull/629/files#r1487043262
                         SchedulingConstraints.of(
                             stageMetadata.getMachineDefinition(),
                             mergeJobDefAndArtifactAssigmentAttributes(jobMetadata.getJobArtifact())),
@@ -1617,12 +1618,12 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
             try {
                 JobArtifact artifact = jobStore.getJobArtifact(artifactID);
                 Map<String, String> mergedMap = new HashMap<>(artifact.getTags());
-                mergedMap.putAll(mantisJobMetaData.getJobDefinition().getAssignmentAttributes());
+                mergedMap.putAll(mantisJobMetaData.getJobDefinition().getSchedulingConstraints());
                 return mergedMap;
             } catch (Exception e) {
                 LOGGER.warn("Couldn't find job artifact by id: {}", artifactID, e);
             }
-            return mantisJobMetaData.getJobDefinition().getAssignmentAttributes();
+            return mantisJobMetaData.getJobDefinition().getSchedulingConstraints();
         }
 
         private List<IMantisWorkerMetadata> getInitialWorkers(JobDefinition jobDetails, long submittedAt)

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -634,7 +634,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
                     "jobCluster",
                     req.getWorkerId().getJobCluster(),
                     "cpuCores",
-                    String.valueOf(req.getMachineDefinition().getCpuCores())))));
+                    String.valueOf(req.getConstraints().getMachineDefinition().getCpuCores())))));
             sender().tell(new Status.Failure(new NoResourceAvailableException(
                 String.format("No resource available for request %s: resource overview: %s", request,
                     getResourceOverview()))), self());
@@ -861,13 +861,13 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         public Map<MachineDefinition, List<TaskExecutorAllocationRequest>> getGroupedByMachineDef() {
             return allocationRequests
                 .stream()
-                .collect(Collectors.groupingBy(TaskExecutorAllocationRequest::getMachineDefinition));
+                .collect(Collectors.groupingBy(a -> a.getConstraints().getMachineDefinition()));
         }
 
         public Map<Double, Integer> getGroupedByCoresCount() {
             return allocationRequests
                 .stream()
-                .collect(Collectors.groupingBy(TaskExecutorAllocationRequest::getMachineDefinition))
+                .collect(Collectors.groupingBy(a -> a.getConstraints().getMachineDefinition()))
                 .entrySet()
                 .stream()
                 .collect(Collectors.toMap(

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobDefinition.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobDefinition.java
@@ -44,8 +44,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.ToString;
+import org.apache.commons.lang3.tuple.Pair;
 
 @ToString
 public class JobDefinition {
@@ -62,6 +65,9 @@ public class JobDefinition {
     private final DeploymentStrategy deploymentStrategy;
     private final int withNumberOfStages;
     private Map<String, Label> labels; // Map label->name to label instance.
+
+    private final static Pattern SCHEDULING_CONSTRAINT_LABEL_REGEX =
+        Pattern.compile("_mantis\\.schedulingConstraint\\.(.+)");
 
     @JsonCreator
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -244,6 +250,26 @@ public class JobDefinition {
             .filter(label -> label.getName().equals(MANTIS_RESOURCE_CLUSTER_NAME_LABEL.label))
             .findFirst()
             .map(l -> ClusterID.of(l.getValue()));
+    }
+
+    /**
+     * Returns the map of assignment attributes deduced from labels. The attributes are extracted
+     * from labels matching the "SCHEDULING_CONSTRAINT_LABEL_REGEX" pattern, and only the capturing
+     * group content (i.e., the key that comes after "_mantis.schedulingConstraint.") is saved.
+     *
+     * The return value would be used as constraint during worker scheduling.
+     */
+    public Map<String, String> getAssignmentAttributes() {
+        return labels.entrySet().stream()
+            .map(label -> {
+                final Matcher matcher = SCHEDULING_CONSTRAINT_LABEL_REGEX.matcher(label.getKey());
+                return matcher.find() ? Pair.of(matcher.group(1), label.getValue().getValue()) : null;
+            })
+            .filter(Objects::nonNull)
+            .collect(Collectors.toMap(
+                Pair::getLeft,
+                Pair::getRight
+            ));
     }
 
     @JsonIgnore

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/MantisJobStore.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/MantisJobStore.java
@@ -24,6 +24,7 @@ import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
 import io.mantisrx.master.jobcluster.job.worker.JobWorker;
 import io.mantisrx.master.resourcecluster.DisableTaskExecutorsRequest;
 import io.mantisrx.server.core.domain.ArtifactID;
+import io.mantisrx.server.core.domain.JobArtifact;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.domain.JobClusterDefinitionImpl.CompletedJob;
 import io.mantisrx.server.master.domain.JobId;
@@ -275,6 +276,10 @@ public class MantisJobStore {
 
     public List<String> getJobArtifactsToCache(ClusterID clusterID) throws IOException {
         return storageProvider.listJobArtifactsToCache(clusterID);
+    }
+
+    public JobArtifact getJobArtifact(ArtifactID artifactID) throws IOException {
+        return storageProvider.getArtifactById(artifactID.getResourceID());
     }
 
     private static class TerminatedJob implements Comparable<TerminatedJob> {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
@@ -197,7 +197,7 @@ class ResourceClusterAwareSchedulerActor extends AbstractActorWithTimers {
             resourceCluster
                 .getTaskExecutorsFor(
                     Collections.singleton(TaskExecutorAllocationRequest.of(
-                        event.getRequest().getWorkerId(), event.getRequest().getMachineDefinition(), event.getRequest().getJobMetadata(), event.getRequest().getStageNum())))
+                        event.getRequest().getWorkerId(), event.getRequest().getSchedulingConstraints(), event.getRequest().getJobMetadata(), event.getRequest().getStageNum())))
                 .<Object>thenApply(allocation -> event.onAssignment(allocation.values().stream().findFirst().get()))
                 .exceptionally(event::onFailure);
 
@@ -402,7 +402,7 @@ class ResourceClusterAwareSchedulerActor extends AbstractActorWithTimers {
             this.allocationRequestScheduleRequestMap = request
                 .getScheduleRequests()
                 .stream()
-                .map(req -> Pair.of(req, TaskExecutorAllocationRequest.of(req.getWorkerId(), req.getMachineDefinition(), req.getJobMetadata(), req.getStageNum())))
+                .map(req -> Pair.of(req, TaskExecutorAllocationRequest.of(req.getWorkerId(), req.getSchedulingConstraints(), req.getJobMetadata(), req.getStageNum())))
                 .collect(Collectors.toMap(Pair::getRight, Pair::getLeft));
         }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ScheduleRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ScheduleRequest.java
@@ -24,6 +24,7 @@ import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.runtime.MantisJobDurationType;
 import io.mantisrx.server.core.domain.JobMetadata;
 import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.core.scheduler.SchedulingConstraints;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -50,7 +51,7 @@ public class ScheduleRequest implements QueuableTask {
     private final int numPortsRequested;
     private final JobMetadata jobMetadata;
     private final MantisJobDurationType durationType;
-    private final MachineDefinition machineDefinition;
+    private final SchedulingConstraints schedulingConstraints;
     private final List<ConstraintEvaluator> hardConstraints;
     private final List<VMTaskFitnessCalculator> softConstraints;
     private final Optional<String> preferredCluster;
@@ -61,7 +62,7 @@ public class ScheduleRequest implements QueuableTask {
                            final int numPortsRequested,
                            final JobMetadata jobMetadata,
                            final MantisJobDurationType durationType,
-                           final MachineDefinition machineDefinition,
+                           final SchedulingConstraints schedulingConstraints,
                            final List<ConstraintEvaluator> hardConstraints,
                            final List<VMTaskFitnessCalculator> softConstraints,
                            final long readyAt,
@@ -71,7 +72,8 @@ public class ScheduleRequest implements QueuableTask {
         this.numPortsRequested = numPortsRequested;
         this.jobMetadata = jobMetadata;
         this.durationType = durationType;
-        this.machineDefinition = machineDefinition;
+        this.schedulingConstraints = schedulingConstraints;
+
         this.hardConstraints = hardConstraints;
         this.softConstraints = softConstraints;
         this.readyAt = readyAt;
@@ -109,22 +111,22 @@ public class ScheduleRequest implements QueuableTask {
 
     @Override
     public double getCPUs() {
-        return machineDefinition.getCpuCores();
+        return schedulingConstraints.getMachineDefinition().getCpuCores();
     }
 
     @Override
     public double getMemory() {
-        return machineDefinition.getMemoryMB();
+        return schedulingConstraints.getMachineDefinition().getMemoryMB();
     }
 
     @Override
     public double getNetworkMbps() {
-        return machineDefinition.getNetworkMbps();
+        return schedulingConstraints.getMachineDefinition().getNetworkMbps();
     }
 
     @Override
     public double getDisk() {
-        return machineDefinition.getDiskMB();
+        return schedulingConstraints.getMachineDefinition().getDiskMB();
     }
 
     @Override
@@ -137,7 +139,11 @@ public class ScheduleRequest implements QueuableTask {
     }
 
     public MachineDefinition getMachineDefinition() {
-        return machineDefinition;
+        return schedulingConstraints.getMachineDefinition();
+    }
+
+    public SchedulingConstraints getSchedulingConstraints() {
+        return schedulingConstraints;
     }
 
     @Override

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/com/netflix/mantis/master/scheduler/TestHelpers.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/com/netflix/mantis/master/scheduler/TestHelpers.java
@@ -25,6 +25,7 @@ import io.mantisrx.runtime.descriptor.SchedulingInfo;
 import io.mantisrx.runtime.descriptor.StageSchedulingInfo;
 import io.mantisrx.server.core.domain.JobMetadata;
 import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.core.scheduler.SchedulingConstraints;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.config.StaticPropertiesConfigurationFactory;
 import io.mantisrx.server.master.domain.JobDefinition;
@@ -72,7 +73,7 @@ public class TestHelpers {
                             mantisJobMetadata.getMinRuntimeSecs()
                     ),
                     mantisJobMetadata.getSla().get().getDurationType(),
-                    machineDefinition,
+                    SchedulingConstraints.of(machineDefinition),
                     Collections.emptyList(),
                     Collections.emptyList(),
                     0,Optional.empty()

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
@@ -52,6 +52,7 @@ import io.mantisrx.runtime.descriptor.StageSchedulingInfo;
 import io.mantisrx.server.core.JobCompletedReason;
 import io.mantisrx.server.core.domain.JobMetadata;
 import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.core.scheduler.SchedulingConstraints;
 import io.mantisrx.server.master.domain.IJobClusterDefinition;
 import io.mantisrx.server.master.domain.JobDefinition;
 import io.mantisrx.server.master.domain.JobId;
@@ -303,7 +304,7 @@ public class JobTestLifecycle {
             JobMetadata jobMetadata = new JobMetadata(jobId, new URL("http://myart" +
                     ""),1,"njoshi",schedInfo,Lists.newArrayList(),0,10, 0);
             ScheduleRequest scheduleRequest = new ScheduleRequest(workerId,
-                    1,4, jobMetadata,MantisJobDurationType.Perpetual,machineDefinition,Lists.newArrayList(),Lists.newArrayList(),0,empty());
+                    1,4, jobMetadata,MantisJobDurationType.Perpetual, SchedulingConstraints.of(machineDefinition),Lists.newArrayList(),Lists.newArrayList(),0,empty());
             BatchScheduleRequest expectedRequest = new BatchScheduleRequest(Collections.singletonList(scheduleRequest));
             verify(schedulerMock).scheduleWorkers(expectedRequest);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
@@ -33,6 +33,7 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.TaskExecutorBatch
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.server.core.TestingRpcService;
 import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.core.scheduler.SchedulingConstraints;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorAllocationRequest;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
@@ -138,7 +139,7 @@ public class ExecutorStateManagerTests {
     public void testGetBestFit() {
         Optional<BestFit> bestFitO =
             stateManager.findBestFit(new TaskExecutorBatchAssignmentRequest(
-                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0)),
+                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_2), null, 0)),
                 CLUSTER_ID));
 
         assertFalse(bestFitO.isPresent());
@@ -161,14 +162,14 @@ public class ExecutorStateManagerTests {
         // test machine def 1
         bestFitO =
             stateManager.findBestFit(new TaskExecutorBatchAssignmentRequest(
-                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0)), CLUSTER_ID));
+                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_1), null, 0)), CLUSTER_ID));
         assertTrue(bestFitO.isPresent());
         assertEquals(TASK_EXECUTOR_ID_1, bestFitO.get().getBestFit().values().stream().findFirst().get().getLeft());
         assertEquals(state1, bestFitO.get().getBestFit().values().stream().findFirst().get().getRight());
 
         bestFitO =
             stateManager.findBestFit(new TaskExecutorBatchAssignmentRequest(
-                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0)), CLUSTER_ID));
+                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_2), null, 0)), CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
         assertEquals(TASK_EXECUTOR_ID_2, bestFitO.get().getBestFit().values().stream().findFirst().get().getLeft());
@@ -179,7 +180,7 @@ public class ExecutorStateManagerTests {
             TaskExecutorReport.occupied(WORKER_ID)));
         bestFitO =
             stateManager.findBestFit(new TaskExecutorBatchAssignmentRequest(
-                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0)), CLUSTER_ID));
+                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_1), null, 0)), CLUSTER_ID));
         assertFalse(bestFitO.isPresent());
 
         // enable e3 and disable e2
@@ -191,7 +192,7 @@ public class ExecutorStateManagerTests {
 
         bestFitO =
             stateManager.findBestFit(new TaskExecutorBatchAssignmentRequest(
-                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0)), CLUSTER_ID));
+                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_2), null, 0)), CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
         assertEquals(TASK_EXECUTOR_ID_3, bestFitO.get().getBestFit().values().stream().findFirst().get().getLeft());
@@ -201,7 +202,7 @@ public class ExecutorStateManagerTests {
         stateManager.tryMarkUnavailable(TASK_EXECUTOR_ID_3);
         bestFitO =
             stateManager.findBestFit(new TaskExecutorBatchAssignmentRequest(
-                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0)), CLUSTER_ID));
+                Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_2), null, 0)), CLUSTER_ID));
 
         assertFalse(bestFitO.isPresent());
     }
@@ -242,7 +243,7 @@ public class ExecutorStateManagerTests {
         Optional<BestFit> bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorBatchAssignmentRequest(
-                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0)),
+                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_2), null, 0)),
                     CLUSTER_ID));
         assertFalse(bestFitO.isPresent());
 
@@ -275,7 +276,7 @@ public class ExecutorStateManagerTests {
         bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorBatchAssignmentRequest(
-                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0)),
+                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_1), null, 0)),
                     CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
@@ -291,7 +292,7 @@ public class ExecutorStateManagerTests {
         bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorBatchAssignmentRequest(
-                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0)),
+                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_1), null, 0)),
                     CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
@@ -316,7 +317,7 @@ public class ExecutorStateManagerTests {
         bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorBatchAssignmentRequest(
-                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0)),
+                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_1), null, 0)),
                     CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
@@ -329,7 +330,7 @@ public class ExecutorStateManagerTests {
         bestFitO =
             stateManager.findBestFit(
                 new TaskExecutorBatchAssignmentRequest(
-                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 0)),
+                    Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_1), null, 0)),
                     CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());
@@ -372,8 +373,8 @@ public class ExecutorStateManagerTests {
             stateManager.findBestFit(
                 new TaskExecutorBatchAssignmentRequest(
                     new HashSet<>(Arrays.asList(
-                        TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0),
-                        TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 1))),
+                        TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_2), null, 0),
+                        TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_1), null, 1))),
                     CLUSTER_ID));
 
         assertFalse(bestFitO.isPresent());
@@ -387,8 +388,8 @@ public class ExecutorStateManagerTests {
             stateManager.findBestFit(
                 new TaskExecutorBatchAssignmentRequest(
                     new HashSet<>(Arrays.asList(
-                        TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0),
-                        TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_1, null, 1))),
+                        TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_2), null, 0),
+                        TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_1), null, 1))),
                     CLUSTER_ID));
 
         assertTrue(bestFitO.isPresent());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -43,6 +43,7 @@ import io.mantisrx.master.resourcecluster.proto.GetClusterUsageResponse.UsageByG
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.server.core.TestingRpcService;
 import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.core.scheduler.SchedulingConstraints;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.resourcecluster.ClusterID;
 import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
@@ -238,7 +239,7 @@ public class ResourceClusterActorTest {
                         TASK_EXECUTOR_ID,
                         CLUSTER_ID,
                         TaskExecutorReport.available())).get());
-        final Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0));
+        final Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION), null, 0));
         assertEquals(
             TASK_EXECUTOR_ID,
             resourceCluster.getTaskExecutorsFor(requests).get().values().stream().findFirst().get());
@@ -335,7 +336,7 @@ public class ResourceClusterActorTest {
         assertEquals(ImmutableList.of(TASK_EXECUTOR_ID_3, TASK_EXECUTOR_ID_2), idleInstancesResponse.getInstanceIds());
         assertEquals(CONTAINER_DEF_ID_2, idleInstancesResponse.getSkuId());
 
-        Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION_2, null, 0));
+        Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION_2), null, 0));
         assertEquals(
             TASK_EXECUTOR_ID_3,
             resourceCluster.getTaskExecutorsFor(requests).get().values().stream().findFirst().get());
@@ -370,7 +371,7 @@ public class ResourceClusterActorTest {
         assertEquals(ImmutableList.of(TASK_EXECUTOR_ID), idleInstancesResponse.getInstanceIds());
         assertEquals(CONTAINER_DEF_ID_1, idleInstancesResponse.getSkuId());
 
-        requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0));
+        requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION), null, 0));
         assertEquals(
             TASK_EXECUTOR_ID_2,
             resourceCluster.getTaskExecutorsFor(requests).get().values().stream().findFirst().get());
@@ -426,14 +427,14 @@ public class ResourceClusterActorTest {
                         TASK_EXECUTOR_ID,
                         CLUSTER_ID,
                         TaskExecutorReport.available())).get());
-        Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0));
+        Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION), null, 0));
         assertEquals(
             TASK_EXECUTOR_ID,
             resourceCluster.getTaskExecutorsFor(requests).get().values().stream().findFirst().get());
         assertEquals(ImmutableList.of(), resourceCluster.getAvailableTaskExecutors().get());
         Thread.sleep(2000);
         assertEquals(ImmutableList.of(TASK_EXECUTOR_ID), resourceCluster.getAvailableTaskExecutors().get());
-        requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0));
+        requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION), null, 0));
         assertEquals(
             TASK_EXECUTOR_ID,
             resourceCluster.getTaskExecutorsFor(requests).get().values().stream().findFirst().get());
@@ -479,7 +480,7 @@ public class ResourceClusterActorTest {
             }
 
             expectedTaskExecutorIds.add(taskExecutorID);
-            requests.add(TaskExecutorAllocationRequest.of(workerId, MACHINE_DEFINITION, null, 0));
+            requests.add(TaskExecutorAllocationRequest.of(workerId, SchedulingConstraints.of(MACHINE_DEFINITION), null, 0));
         }
         assertEquals(
             expectedTaskExecutorIds,
@@ -592,7 +593,7 @@ public class ResourceClusterActorTest {
             resourceCluster.heartBeatFromTaskExecutor(
                 new TaskExecutorHeartbeat(TASK_EXECUTOR_ID_2, CLUSTER_ID, TaskExecutorReport.available())).get());
         resourceCluster.disableTaskExecutorsFor(ATTRIBUTES, Instant.now().plus(Duration.ofDays(1)), Optional.empty()).get();
-        Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0));
+        Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION), null, 0));
         assertEquals(
             TASK_EXECUTOR_ID_2,
             resourceCluster.getTaskExecutorsFor(requests).get().values().stream().findFirst().get());
@@ -627,7 +628,7 @@ public class ResourceClusterActorTest {
                 new TaskExecutorHeartbeat(TASK_EXECUTOR_ID, CLUSTER_ID, TaskExecutorReport.available())).join());
 
 
-        final Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, MACHINE_DEFINITION, null, 0));
+        final Set<TaskExecutorAllocationRequest> requests = Collections.singleton(TaskExecutorAllocationRequest.of(WORKER_ID, SchedulingConstraints.of(MACHINE_DEFINITION), null, 0));
         assertEquals(
             TASK_EXECUTOR_ID,
             resourceCluster.getTaskExecutorsFor(requests).get().values().stream().findFirst().get());


### PR DESCRIPTION
### Context

This PR is the initial effort in breaking down the [larger PR](https://github.com/Netflix/mantis/pull/623) into more digestible, manageable pieces.

The first concept we're introducing involves scheduling constraints, which is a combined set of machine specifications and assignment attributes, such as differentiating between jdk17 and jdk8. The scheduling constraints are now integrated into task executor allocation requests, however, aren't used yet, keeping this PR as simple and streamlined as possible.

The scheduling constraints are created by the job cluster actor and then inserted into schedule requests. These constraints, intended for each worker that requires scheduling, are compiled using the requested machine definition from the worker and extracting assignment attributes. The extraction of these attributes is achieved through merging the tags of job artifacts, that are now stored during the build process, and job definition attributes that are set either during job cluster creation or job submission.

As mentioned earlier, the main scheduling algorithm continues functioning at the core-level and does not consider assignment attributes at this moment to restrict the amount of alterations introduced in each PR. This core scheduling logic will incorporate these attributes in a future PR.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
