### PR TITLE
[PR/623 - pt 2] Use scheduling constraints to find best fit TEs

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
@@ -16,10 +16,13 @@
 
 package io.mantisrx.common;
 
+import java.util.regex.Pattern;
+
 public class WorkerConstants {
     public static final String WORKER_CONTAINER_DEFINITION_ID = "MANTIS_WORKER_CONTAINER_DEFINITION_ID";
     public static final String WORKER_TASK_ATTRIBUTE_ENV_KEY = "MANTIS_WORKER_CONTAINER_ATTRIBUTE";
     // TODO(fdichiara): make this configurable.
     public static final String AUTO_SCALE_GROUP_KEY = "NETFLIX_AUTO_SCALE_GROUP";
     public static final String MANTIS_WORKER_CONTAINER_GENERATION = "MANTIS_WORKER_CONTAINER_GENERATION";
+    public static final Pattern SCHEDULING_CONSTRAINT_PATTERN = Pattern.compile("^SCHEDULING_CONSTRAINT_(.*)$");
 }

--- a/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
+++ b/mantis-common/src/main/java/io/mantisrx/common/WorkerConstants.java
@@ -24,5 +24,5 @@ public class WorkerConstants {
     // TODO(fdichiara): make this configurable.
     public static final String AUTO_SCALE_GROUP_KEY = "NETFLIX_AUTO_SCALE_GROUP";
     public static final String MANTIS_WORKER_CONTAINER_GENERATION = "MANTIS_WORKER_CONTAINER_GENERATION";
-    public static final Pattern SCHEDULING_CONSTRAINT_PATTERN = Pattern.compile("^SCHEDULING_CONSTRAINT_(.*)$");
+    public static final Pattern MANTIS_SCHEDULING_ATTRIBUTE_PATTERN = Pattern.compile("^MANTIS_SCHEDULING_ATTRIBUTE_(.*)$");
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/scheduler/SchedulingConstraints.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/scheduler/SchedulingConstraints.java
@@ -24,7 +24,7 @@ import lombok.AllArgsConstructor;
 import lombok.Value;
 
 /**
- * A class that represents scheduling constraints. These constraints include the resource constraints, and a map of assignment attributes (e.g. jdkVersion:17).
+ * A class that represents scheduling constraints. These constraints include the resource constraints, and a map of scheduling attributes (e.g. jdkVersion:17).
  */
 @AllArgsConstructor(staticName = "of")
 @Value
@@ -32,8 +32,8 @@ public class SchedulingConstraints {
     // Defines the resource constraints for scheduling
     MachineDefinition machineDefinition;
 
-    // Additional attributes for assignment (ie. jdkVersion:17)
-    Map<String, String> assignmentAttributes;
+    // Additional attributes for scheduling (ie. jdkVersion:17)
+    Map<String, String> schedulingAttributes;
 
     @VisibleForTesting
     public static SchedulingConstraints of(MachineDefinition machineDefinition) {

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistration.java
@@ -29,11 +29,13 @@ import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
+import lombok.Value;
 import lombok.experimental.FieldDefaults;
 
 /**
@@ -147,15 +149,27 @@ public class TaskExecutorRegistration {
     }
 
     @JsonIgnore
-    public Map<String, String> getAllocationAttributes() {
+    public Map<String, String> getSchedulingAttributes() {
         return taskExecutorAttributes.entrySet().stream()
             .flatMap(entry -> {
-                Matcher matcher = WorkerConstants.SCHEDULING_CONSTRAINT_PATTERN.matcher(entry.getKey());
+                Matcher matcher = WorkerConstants.MANTIS_SCHEDULING_ATTRIBUTE_PATTERN.matcher(entry.getKey());
                 return matcher.matches() ? Stream.of(new AbstractMap.SimpleEntry<>(matcher.group(1).toLowerCase(), entry.getValue())) : Stream.empty();
             })
             .collect(Collectors.toMap(
                 Map.Entry::getKey,
                 entry -> getAttributeByKey(entry.getKey()).orElse(entry.getValue())
             ));
+    }
+
+    @JsonIgnore
+    public TaskExecutorGroupKey getTaskExecutorGroupKey() {
+        return new TaskExecutorGroupKey(machineDefinition, getSchedulingAttributes());
+    }
+
+    @Value
+    @AllArgsConstructor
+    public static class TaskExecutorGroupKey {
+        MachineDefinition machineDefinition;
+        Map<String, String> schedulingAttributes;
     }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistrationTest.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistrationTest.java
@@ -69,7 +69,7 @@ public class TaskExecutorRegistrationTest {
         final TaskExecutorRegistration registration =
                 serializer.fromJSON(str, TaskExecutorRegistration.class);
         assertEquals(ImmutableMap.of(), registration.getTaskExecutorAttributes());
-        assertEquals(ImmutableMap.of(), registration.getAllocationAttributes());
+        assertEquals(ImmutableMap.of(), registration.getSchedulingAttributes());
         final TaskExecutorRegistration deserialized =
                 serializer.fromJSON(serializer.toJson(registration), TaskExecutorRegistration.class);
         assertEquals(registration, deserialized);
@@ -125,7 +125,7 @@ public class TaskExecutorRegistrationTest {
             serializer.fromJSON(str, TaskExecutorRegistration.class);
         assertEquals(ImmutableMap.of("attribute1", "attributeValue1", "attribute2", "AttributeValue2", "attribute3",
             "attributeValue3"), registration.getTaskExecutorAttributes());
-        assertEquals(ImmutableMap.of(), registration.getAllocationAttributes());
+        assertEquals(ImmutableMap.of(), registration.getSchedulingAttributes());
         final TaskExecutorRegistration deserialized =
             serializer.fromJSON(serializer.toJson(registration), TaskExecutorRegistration.class);
         assertEquals(registration, deserialized);
@@ -176,7 +176,7 @@ public class TaskExecutorRegistrationTest {
     }
 
     @Test
-    public void testAllocationAttributes() throws Exception {
+    public void testSchedulingAttributes() throws Exception {
         String str = "{\n" +
             "    \"taskExecutorID\":\n" +
             "    {\n" +
@@ -216,12 +216,12 @@ public class TaskExecutorRegistrationTest {
             "    },\n" +
             "    \"taskExecutorAttributes\": {\n" +
             "    \t\"attribute1\": \"attributeValue1\",\n" +
-            "    \t\"SCHEDULING_CONSTRAINT_JDK\": \"17\",\n" +
-            "    \t\"SCHEDULING_CONSTRAINT_another\": \"whatever\"\n" +
+            "    \t\"MANTIS_SCHEDULING_ATTRIBUTE_JDK\": \"17\",\n" +
+            "    \t\"MANTIS_SCHEDULING_ATTRIBUTE_another\": \"whatever\"\n" +
             "    }\n" +
             "}";
         final TaskExecutorRegistration registration =
             serializer.fromJSON(str, TaskExecutorRegistration.class);
-        assertEquals(ImmutableMap.of("jdk", "17", "another", "whatever"), registration.getAllocationAttributes());
+        assertEquals(ImmutableMap.of("jdk", "17", "another", "whatever"), registration.getSchedulingAttributes());
     }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistrationTest.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/test/java/io/mantisrx/server/master/resourcecluster/TaskExecutorRegistrationTest.java
@@ -69,6 +69,7 @@ public class TaskExecutorRegistrationTest {
         final TaskExecutorRegistration registration =
                 serializer.fromJSON(str, TaskExecutorRegistration.class);
         assertEquals(ImmutableMap.of(), registration.getTaskExecutorAttributes());
+        assertEquals(ImmutableMap.of(), registration.getAllocationAttributes());
         final TaskExecutorRegistration deserialized =
                 serializer.fromJSON(serializer.toJson(registration), TaskExecutorRegistration.class);
         assertEquals(registration, deserialized);
@@ -124,6 +125,7 @@ public class TaskExecutorRegistrationTest {
             serializer.fromJSON(str, TaskExecutorRegistration.class);
         assertEquals(ImmutableMap.of("attribute1", "attributeValue1", "attribute2", "AttributeValue2", "attribute3",
             "attributeValue3"), registration.getTaskExecutorAttributes());
+        assertEquals(ImmutableMap.of(), registration.getAllocationAttributes());
         final TaskExecutorRegistration deserialized =
             serializer.fromJSON(serializer.toJson(registration), TaskExecutorRegistration.class);
         assertEquals(registration, deserialized);
@@ -171,5 +173,55 @@ public class TaskExecutorRegistrationTest {
         final TaskExecutorRegistration registration =
             serializer.fromJSON(expected, TaskExecutorRegistration.class);
         assertEquals(expected.replaceAll("[\\n\\s]+", ""), serializer.toJson(registration));
+    }
+
+    @Test
+    public void testAllocationAttributes() throws Exception {
+        String str = "{\n" +
+            "    \"taskExecutorID\":\n" +
+            "    {\n" +
+            "        \"resourceId\": \"25400d92-96ed-40b9-9843-a6e7e248db52\"\n" +
+            "    },\n" +
+            "    \"clusterID\":\n" +
+            "    {\n" +
+            "        \"resourceID\": \"mantistaskexecutor\"\n" +
+            "    },\n" +
+            "    \"taskExecutorAddress\": \"akka.tcp://flink@100.118.114.30:5050/user/rpc/worker_0\",\n" +
+            "    \"hostname\": \"localhost\",\n" +
+            "    \"workerPorts\":\n" +
+            "    {\n" +
+            "        \"metricsPort\": 5051,\n" +
+            "        \"debugPort\": 5052,\n" +
+            "        \"consolePort\": 5053,\n" +
+            "        \"customPort\": 5054,\n" +
+            "        \"ports\":\n" +
+            "        [\n" +
+            "            5055,\n" +
+            "            5051,\n" +
+            "            5052,\n" +
+            "            5053,\n" +
+            "            5054\n" +
+            "        ],\n" +
+            "        \"sinkPort\": 5055,\n" +
+            "        \"numberOfPorts\": 5,\n" +
+            "        \"valid\": true\n" +
+            "    },\n" +
+            "    \"machineDefinition\":\n" +
+            "    {\n" +
+            "        \"cpuCores\": 4.0,\n" +
+            "        \"memoryMB\": 17179869184,\n" +
+            "        \"networkMbps\": 128.0,\n" +
+            "        \"diskMB\": 88969576448,\n" +
+            "        \"numPorts\": 5\n" +
+            "    },\n" +
+            "    \"taskExecutorAttributes\": {\n" +
+            "    \t\"attribute1\": \"attributeValue1\",\n" +
+            "    \t\"SCHEDULING_CONSTRAINT_JDK\": \"17\",\n" +
+            "    \t\"SCHEDULING_CONSTRAINT_another\": \"whatever\"\n" +
+            "    }\n" +
+            "}";
+        final TaskExecutorRegistration registration =
+            serializer.fromJSON(str, TaskExecutorRegistration.class);
+        assertEquals(ImmutableMap.of("jdk", "17", "another", "whatever"), registration.getAllocationAttributes());
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -1612,7 +1612,7 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
          * keys from the artifact's tags.
          *
          * @param artifactID the artifact used by the job whose attributes are to be fetched
-         * @return A merged map of assignment attributes. The precedence of keys follows: job definition > artifact's tags.
+         * @return A merged map of scheduling attributes. The precedence of keys follows: job definition > artifact's tags.
          */
         private Map<String, String> mergeJobDefAndArtifactAssigmentAttributes(ArtifactID artifactID) {
             try {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -116,8 +116,8 @@ class ResourceClusterActor extends AbstractActorWithTimers {
 
     private final boolean isJobArtifactCachingEnabled;
 
-    static Props props(final ClusterID clusterID, final Duration heartbeatTimeout, Duration assignmentTimeout, Duration disabledTaskExecutorsCheckInterval, Clock clock, RpcService rpcService, MantisJobStore mantisJobStore, JobMessageRouter jobMessageRouter, int maxJobArtifactsToCache, String jobClustersWithArtifactCachingEnabled, boolean isJobArtifactCachingEnabled, String assignmentAttributesAndDefaults) {
-        return Props.create(ResourceClusterActor.class, clusterID, heartbeatTimeout, assignmentTimeout, disabledTaskExecutorsCheckInterval, clock, rpcService, mantisJobStore, jobMessageRouter, maxJobArtifactsToCache, jobClustersWithArtifactCachingEnabled, isJobArtifactCachingEnabled, assignmentAttributesAndDefaults)
+    static Props props(final ClusterID clusterID, final Duration heartbeatTimeout, Duration assignmentTimeout, Duration disabledTaskExecutorsCheckInterval, Clock clock, RpcService rpcService, MantisJobStore mantisJobStore, JobMessageRouter jobMessageRouter, int maxJobArtifactsToCache, String jobClustersWithArtifactCachingEnabled, boolean isJobArtifactCachingEnabled, Map<String, String> schedulingAttributes) {
+        return Props.create(ResourceClusterActor.class, clusterID, heartbeatTimeout, assignmentTimeout, disabledTaskExecutorsCheckInterval, clock, rpcService, mantisJobStore, jobMessageRouter, maxJobArtifactsToCache, jobClustersWithArtifactCachingEnabled, isJobArtifactCachingEnabled, schedulingAttributes)
                 .withMailbox("akka.actor.metered-mailbox");
     }
 
@@ -133,7 +133,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         int maxJobArtifactsToCache,
         String jobClustersWithArtifactCachingEnabled,
         boolean isJobArtifactCachingEnabled,
-        String assignmentAttributesAndDefaults) {
+        Map<String, String> schedulingAttributes) {
         this.clusterID = clusterID;
         this.heartbeatTimeout = heartbeatTimeout;
         this.assignmentTimeout = assignmentTimeout;
@@ -149,7 +149,7 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         this.maxJobArtifactsToCache = maxJobArtifactsToCache;
         this.jobClustersWithArtifactCachingEnabled = jobClustersWithArtifactCachingEnabled;
 
-        this.executorStateManager = new ExecutorStateManagerImpl(assignmentAttributesAndDefaults);
+        this.executorStateManager = new ExecutorStateManagerImpl(schedulingAttributes);
 
         this.metrics = new ResourceClusterActorMetrics();
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -173,7 +173,8 @@ class ResourceClustersManagerActor extends AbstractActor {
                     jobMessageRouter,
                     masterConfiguration.getMaxJobArtifactsToCache(),
                     masterConfiguration.getJobClustersWithArtifactCachingEnabled(),
-                    masterConfiguration.isJobArtifactCachingEnabled()),
+                    masterConfiguration.isJobArtifactCachingEnabled(),
+                    masterConfiguration.getAssignmentAttributesAndDefaults()),
                 "ResourceClusterActor-" + clusterID.getResourceID());
         log.info("Created resource cluster actor for {}", clusterID);
         return clusterActor;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -174,7 +174,7 @@ class ResourceClustersManagerActor extends AbstractActor {
                     masterConfiguration.getMaxJobArtifactsToCache(),
                     masterConfiguration.getJobClustersWithArtifactCachingEnabled(),
                     masterConfiguration.isJobArtifactCachingEnabled(),
-                    masterConfiguration.getAssignmentAttributesAndDefaults()),
+                    masterConfiguration.getSchedulingConstraints()),
                 "ResourceClusterActor-" + clusterID.getResourceID());
         log.info("Created resource cluster actor for {}", clusterID);
         return clusterActor;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/scheduler/CpuWeightedFitnessCalculator.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/scheduler/CpuWeightedFitnessCalculator.java
@@ -19,7 +19,11 @@ package io.mantisrx.master.scheduler;
 import io.mantisrx.runtime.MachineDefinition;
 
 /**
- * Implementation of FitnessCalculator. Uses cpu cores with higher weight than memory.
+ * `CpuWeightedFitnessCalculator` is designed to optimize machine selection in Netflix's cloud container platform
+ * by focusing on the CPU to memory cost ratio. Given the CPU cost is approximated to be 18 times that of 1GB memory,
+ * this calculator leverages this ratio for optimal task-machine match.
+ *
+ * Note: configurability of weights to adjust to evolving cost dynamics is planned for future improvement.
  */
 public class CpuWeightedFitnessCalculator implements FitnessCalculator {
     @Override
@@ -31,8 +35,7 @@ public class CpuWeightedFitnessCalculator implements FitnessCalculator {
         double cpuScore = 1 - (available.getCpuCores() - requested.getCpuCores()) / available.getCpuCores();
         double memoryScore = 1 - (available.getMemoryMB() - requested.getMemoryMB()) / available.getMemoryMB();
 
-        // The weight for cpuScore is 18 and for memoryScore is 1. Hence, the total weight is 19.
-        // TODO: make these weights configurable.
+        // The weight for cpuScore is 18 and for memoryScore is 1, reflecting the CPU to memory cost ratio in Netflix's container platform
         return ((18 * cpuScore) + memoryScore) / 19;
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/scheduler/CpuWeightedFitnessCalculator.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/scheduler/CpuWeightedFitnessCalculator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.scheduler;
+
+import io.mantisrx.runtime.MachineDefinition;
+
+/**
+ * Implementation of FitnessCalculator. Uses cpu cores with higher weight than memory.
+ */
+public class CpuWeightedFitnessCalculator implements FitnessCalculator {
+    @Override
+    public double calculate(MachineDefinition requested, MachineDefinition available) {
+        if (!available.canFit(requested)) {
+            return 0.0;
+        }
+
+        double cpuScore = 1 - (available.getCpuCores() - requested.getCpuCores()) / available.getCpuCores();
+        double memoryScore = 1 - (available.getMemoryMB() - requested.getMemoryMB()) / available.getMemoryMB();
+
+        // The weight for cpuScore is 18 and for memoryScore is 1. Hence, the total weight is 19.
+        // TODO: make these weights configurable.
+        return ((18 * cpuScore) + memoryScore) / 19;
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/scheduler/FitnessCalculator.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/scheduler/FitnessCalculator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.scheduler;
+
+import io.mantisrx.runtime.MachineDefinition;
+
+/**
+ * Interface definition for computing the fitness score between machine definitions.
+ */
+public interface FitnessCalculator {
+    double calculate(MachineDefinition requested, MachineDefinition available);
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -351,6 +351,11 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("false")
     boolean isBatchSchedulingEnabled();
 
+    // Example: "jdk:17"
+    @Config("mantis.scheduler.assignmentAttributesAndDefaults")
+    @Default("")
+    String getAssignmentAttributesAndDefaults();
+
     default Duration getHeartbeatInterval() {
         return Duration.ofMillis(getHeartbeatIntervalInMs());
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -19,7 +19,10 @@ package io.mantisrx.server.master.config;
 import io.mantisrx.master.jobcluster.job.CostsCalculator;
 import io.mantisrx.server.core.CoreConfiguration;
 import io.mantisrx.server.master.store.KeyValueStore;
+import io.mantisrx.shaded.com.google.common.base.Splitter;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
 import java.time.Duration;
+import java.util.Map;
 import org.skife.config.Config;
 import org.skife.config.Default;
 import org.skife.config.DefaultNull;
@@ -352,9 +355,9 @@ public interface MasterConfiguration extends CoreConfiguration {
     boolean isBatchSchedulingEnabled();
 
     // Example: "jdk:17"
-    @Config("mantis.scheduler.assignmentAttributesAndDefaults")
+    @Config("mantis.scheduler.schedulingConstraints")
     @Default("")
-    String getAssignmentAttributesAndDefaults();
+    String getSchedulingConstraintsString();
 
     default Duration getHeartbeatInterval() {
         return Duration.ofMillis(getHeartbeatIntervalInMs());
@@ -363,4 +366,6 @@ public interface MasterConfiguration extends CoreConfiguration {
     default Duration getMaxAssignmentThreshold() {
         return Duration.ofMillis(getAssignmentIntervalInMs());
     }
+
+    default Map<String, String> getSchedulingConstraints() { return getSchedulingConstraintsString().isEmpty() ? ImmutableMap.of() : Splitter.on(",").withKeyValueSeparator(':').split(getSchedulingConstraintsString());}
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobDefinition.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobDefinition.java
@@ -67,13 +67,13 @@ public class JobDefinition {
     private Map<String, Label> labels; // Map label->name to label instance.
     /**
      * A map of scheduling constraints deduced from labels.
-     * The constraints are extracted from labels matching the "SCHEDULING_CONSTRAINT_LABEL_REGEX" pattern.
+     * The constraints are extracted from labels matching the "MANTIS_SCHEDULING_ATTRIBUTE_LABEL_REGEX" pattern.
      * Only the contents of the capturing group (i.e., the key that comes after "_mantis.schedulingConstraint.")
      * are saved. These values are then used as constraints during worker scheduling.
      */
     private final Map<String, String> schedulingConstraints;
 
-    private final static Pattern SCHEDULING_CONSTRAINT_LABEL_REGEX =
+    private final static Pattern MANTIS_SCHEDULING_ATTRIBUTE_LABEL_REGEX =
         Pattern.compile("_mantis\\.schedulingConstraint\\.(.+)");
 
     @JsonCreator
@@ -116,7 +116,7 @@ public class JobDefinition {
         this.withNumberOfStages = withNumberOfStages;
         this.schedulingConstraints = this.labels.entrySet().stream()
             .map(label -> {
-                Matcher matcher = SCHEDULING_CONSTRAINT_LABEL_REGEX.matcher(label.getKey());
+                Matcher matcher = MANTIS_SCHEDULING_ATTRIBUTE_LABEL_REGEX.matcher(label.getKey());
                 return matcher.find() ? Pair.of(matcher.group(1), label.getValue().getValue()) : null;
             })
             .filter(Objects::nonNull)

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerTests.java
@@ -129,7 +129,7 @@ public class ExecutorStateManagerTests {
             .taskExecutorAttributes(attributes);
     }
 
-    private ExecutorStateManager stateManager = new ExecutorStateManagerImpl("");
+    private ExecutorStateManager stateManager = new ExecutorStateManagerImpl(ImmutableMap.of());
 
     @Before
     public void setup() {
@@ -398,8 +398,8 @@ public class ExecutorStateManagerTests {
     }
 
     @Test
-    public void testGetBestFit_WithAllocationAttributes() {
-        stateManager = new ExecutorStateManagerImpl("jdk:8,constraint0:whatever");
+    public void testGetBestFit_WithSchedulingAttributes() {
+        stateManager = new ExecutorStateManagerImpl(ImmutableMap.of("jdk", "8", "constraint0", "whatever"));
 
         // register TE with jdk:8
         TaskExecutorRegistration jdk8Te =
@@ -419,7 +419,7 @@ public class ExecutorStateManagerTests {
 
         // register TE with jdk:17
         TaskExecutorRegistration jdk17Te =
-            getRegistrationBuilder(TaskExecutorID.of("jdk17"), MACHINE_DEFINITION_1, ImmutableMap.of("SCHEDULING_CONSTRAINT_JDK", "17")).build();
+            getRegistrationBuilder(TaskExecutorID.of("jdk17"), MACHINE_DEFINITION_1, ImmutableMap.of("MANTIS_SCHEDULING_ATTRIBUTE_JDK", "17")).build();
 
         stateManager.trackIfAbsent(TaskExecutorID.of("jdk17"), state2);
         state2.onRegistration(jdk17Te);
@@ -436,12 +436,12 @@ public class ExecutorStateManagerTests {
     }
 
     @Test
-    public void testGetBestFit_WithAllocationAttributesDefaults() {
-        stateManager = new ExecutorStateManagerImpl("jdk:8,constraint0:whatever");
+    public void testGetBestFit_WithSchedulingAttributesDefaults() {
+        stateManager = new ExecutorStateManagerImpl(ImmutableMap.of("jdk", "8", "constraint0", "whatever"));
 
         // register TE with jdk:17
         TaskExecutorRegistration jdk17Te =
-            getRegistrationBuilder(TaskExecutorID.of("jdk17"), MACHINE_DEFINITION_1, ImmutableMap.of("SCHEDULING_CONSTRAINT_JDK", "17")).build();
+            getRegistrationBuilder(TaskExecutorID.of("jdk17"), MACHINE_DEFINITION_1, ImmutableMap.of("MANTIS_SCHEDULING_ATTRIBUTE_JDK", "17")).build();
 
         stateManager.trackIfAbsent(TaskExecutorID.of("jdk17"), state1);
         state1.onRegistration(jdk17Te);
@@ -474,12 +474,12 @@ public class ExecutorStateManagerTests {
     }
 
     @Test
-    public void testGetBestFit_WithMultipleAllocationAttributes() {
-        stateManager = new ExecutorStateManagerImpl("jdk:17,constraint0:whatever");
+    public void testGetBestFit_WithMultipleSchedulingAttributes() {
+        stateManager = new ExecutorStateManagerImpl(ImmutableMap.of("jdk", "17", "constraint0", "whatever"));
 
         // register TE with jdk:8
         TaskExecutorRegistration jdk8Te =
-            getRegistrationBuilder(TaskExecutorID.of("jdk8"), MACHINE_DEFINITION_1, ImmutableMap.of("SCHEDULING_CONSTRAINT_JDK", "8")).build();
+            getRegistrationBuilder(TaskExecutorID.of("jdk8"), MACHINE_DEFINITION_1, ImmutableMap.of("MANTIS_SCHEDULING_ATTRIBUTE_JDK", "8")).build();
 
         stateManager.trackIfAbsent(TaskExecutorID.of("jdk8"), state1);
         state1.onRegistration(jdk8Te);
@@ -489,7 +489,7 @@ public class ExecutorStateManagerTests {
 
         // register TE with constraint0:another
         TaskExecutorRegistration jdk8Constraint0Te =
-            getRegistrationBuilder(TaskExecutorID.of("constraint0"), MACHINE_DEFINITION_1, ImmutableMap.of("SCHEDULING_CONSTRAINT_CONSTRAINT0", "another")).build();
+            getRegistrationBuilder(TaskExecutorID.of("constraint0"), MACHINE_DEFINITION_1, ImmutableMap.of("MANTIS_SCHEDULING_ATTRIBUTE_CONSTRAINT0", "another")).build();
 
         stateManager.trackIfAbsent(TaskExecutorID.of("constraint0"), state2);
         state2.onRegistration(jdk8Constraint0Te);
@@ -499,7 +499,7 @@ public class ExecutorStateManagerTests {
 
         // register TE with jdk:17/constraint0:different
         TaskExecutorRegistration jdk17Te =
-            getRegistrationBuilder(TaskExecutorID.of("jdk17"), MACHINE_DEFINITION_1, ImmutableMap.of("SCHEDULING_CONSTRAINT_JDK", "17")).build();
+            getRegistrationBuilder(TaskExecutorID.of("jdk17"), MACHINE_DEFINITION_1, ImmutableMap.of("MANTIS_SCHEDULING_ATTRIBUTE_JDK", "17")).build();
 
         stateManager.trackIfAbsent(TaskExecutorID.of("jdk17"), state3);
         state3.onRegistration(jdk17Te);
@@ -515,7 +515,7 @@ public class ExecutorStateManagerTests {
 
         // register TE with jdk:17/constraint0:whatever
         TaskExecutorRegistration jdk17Constraint0Te =
-            getRegistrationBuilder(TaskExecutorID.of("jdk17Constraint0"), MACHINE_DEFINITION_1, ImmutableMap.of("SCHEDULING_CONSTRAINT_JDK", "17", "SCHEDULING_CONSTRAINT_CONSTRAINT0", "whatever")).build();
+            getRegistrationBuilder(TaskExecutorID.of("jdk17Constraint0"), MACHINE_DEFINITION_1, ImmutableMap.of("MANTIS_SCHEDULING_ATTRIBUTE_JDK", "17", "MANTIS_SCHEDULING_ATTRIBUTE_CONSTRAINT0", "whatever")).build();
 
         TaskExecutorState state4 = TaskExecutorState.of(clock, rpc, router);
         stateManager.trackIfAbsent(TaskExecutorID.of("jdk17Constraint0"), state4);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -200,7 +200,7 @@ public class ResourceClusterActorTest {
                 jobMessageRouter,
                 0,
                 "",
-                false);
+                false, "");
 
         resourceClusterActor = actorSystem.actorOf(props);
         resourceCluster =

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -200,7 +200,8 @@ public class ResourceClusterActorTest {
                 jobMessageRouter,
                 0,
                 "",
-                false, "");
+                false,
+                ImmutableMap.of());
 
         resourceClusterActor = actorSystem.actorOf(props);
         resourceCluster =

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/scheduler/CpuWeightedFitnessCalculatorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/scheduler/CpuWeightedFitnessCalculatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.scheduler;
+
+import static org.junit.Assert.assertEquals;
+
+import io.mantisrx.runtime.MachineDefinition;
+import org.junit.Before;
+import org.junit.Test;
+
+public class CpuWeightedFitnessCalculatorTest {
+
+    private CpuWeightedFitnessCalculator calculator;
+
+    @Before
+    public void setUp() {
+        calculator = new CpuWeightedFitnessCalculator();
+    }
+
+    @Test
+    public void testCalculate_whenCpuCannotFit() {
+        MachineDefinition requested = new MachineDefinition(16, 10000, 2048, 1);
+        MachineDefinition available = new MachineDefinition(8, 16000, 2048, 1);  // Less cpu than requested
+        assertEquals(0.0, calculator.calculate(requested, available), 0.01);
+    }
+
+    @Test
+    public void testCalculate_whenMemoryCannotFit() {
+        MachineDefinition requested = new MachineDefinition(6, 32000, 2048, 1);
+        MachineDefinition available = new MachineDefinition(8, 16000, 2048, 1); // Less memory than requested
+        assertEquals(0.0, calculator.calculate(requested, available), 0.01);
+    }
+
+    @Test
+    public void testCalculate_whenDiskCannotFit() {
+        MachineDefinition requested = new MachineDefinition(8, 10000, 2048, 1);
+        MachineDefinition available = new MachineDefinition(8, 16000, 1024, 1); // Less disk than requested
+        assertEquals(0.0, calculator.calculate(requested, available), 0.01);
+    }
+
+    @Test
+    public void testCalculate_whenFitPerfectly() {
+        MachineDefinition requested = new MachineDefinition(8, 16000, 1024, 1); // Equal to available - disk, net and ports are excluded
+        MachineDefinition available = new MachineDefinition(8, 16000, 2048, 3);
+        assertEquals(1.0, calculator.calculate(requested, available), 0.01);
+    }
+
+    @Test
+    public void testCalculate_whenCpuFitExactlyButMemoryIsHigher() {
+        MachineDefinition requested = new MachineDefinition(8, 16000, 2048, 1); // cpuCores fit exactly, memory is less than available
+        MachineDefinition available = new MachineDefinition(8, 32000, 2048, 1);
+        double expected = (18 + 0.5) / 19;
+        assertEquals(expected, calculator.calculate(requested, available), 0.01);
+    }
+
+    @Test
+    public void testCalculate_whenMemoryFitExactlyButCpuIsHigher() {
+        MachineDefinition requested = new MachineDefinition(4, 32000, 2048, 1);  // memory fit exactly, cpuCores is less than available
+        MachineDefinition available = new MachineDefinition(8, 32000, 2048, 1);
+        double expected = ((18*0.5) + 1) / 19;
+        assertEquals(expected, calculator.calculate(requested, available), 0.01);
+    }
+}


### PR DESCRIPTION
### Context
This PR is the second one of an effort to split a [larger PR](https://github.com/Netflix/mantis/pull/623) into manageable parts.

In the [preceding PR](https://github.com/Netflix/mantis/pull/629), we introduced "scheduling constraints," composed of machine and assignment attributes, to guide scheduling decisions.

The focus of this PR is to employ these constraints optimally to identify the best Task Executors.

Task Executors will continue to register in the system, carrying essential metadata for facilitating on-demand scheduling. However, they now also carry "allocation attributes" to support the newly introduced scheduling logic. While initially the registered TEs were indexed solely by core count, we now allow multiple "versions" of TEs for each core count. For instance:

- 2 cores, 16GB | jdk:8
- 2 cores, 32GB | jdk:8
- 2 cores, 16GB | jdk:17

With this system, there might be multiple SKUs available for a given core count. Efficient and safe scheduling requires us to search for a single SKU that fits a request the best. To achieve this, we will change our indexing strategy for Task Executors: instead of purely using cores count, we will use a group key that encapsulates both machine definition and allocation attributes.

The scheduling search process now involves two steps. First, we need to ensure that the allocation attributes specified in the request can be satisfied by the TEs. Second, the selected TEs should be the "best fit" for the request in terms of CPU and memory. The first step is achieved by passing the required allocation attributes (and potential default values) along with the request (via config) to the RC actor. The second step is accomplished through a new interface introduced to calculate the fitness score of two machine definitions -- the one from the request and the one from the registered TE. An implementation of this interface is provided, which computes the fitness score based on a CPU/memory ratio of 18/1.
### Important note
To maintain focus on scheduling, this PR intentionally neglects the pending scheduling cache logic, which is currently flawed as it groups by cores, while it should use all scheduling constraints. This will be resolved in a future PR, the third in this series.

Unresolved items, marked with TODO in the PR, have been left deliberately to reduce complexity. An example would be the passage of the fitness function through the config; this and other items will be taken care of in subsequent PRs.

### Tests

* Added more unit tests
* verified mantis-helm works

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
