### PR TITLE
[PR/623 - pt 4] Introduce sku size spec

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/MantisResourceClusterSpec.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/MantisResourceClusterSpec.java
@@ -23,6 +23,7 @@ import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
 import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Singular;
@@ -89,16 +90,25 @@ public class MantisResourceClusterSpec {
 
         String imageId;
 
+        @Deprecated
         int cpuCoreCount;
 
+        @Deprecated
         int memorySizeInMB;
 
+        @Deprecated
         int networkMbps;
 
+        @Deprecated
         int diskSizeInMB;
 
         @Singular
         Map<String, String> skuMetadataFields;
+
+        // TODO(fdichiara): Currently nullable for backward compatibility.
+        // Plan to remove nullable after upgrading all existing SKU specs.
+        @Nullable
+        SkuSizeSpec size;
 
         @JsonCreator
         public SkuTypeSpec(
@@ -109,7 +119,8 @@ public class MantisResourceClusterSpec {
                 @JsonProperty("memorySizeInBytes") final int memorySizeInMB,
                 @JsonProperty("networkMbps") final int networkMbps,
                 @JsonProperty("diskSizeInBytes") final int diskSizeInMB,
-                @JsonProperty("skuMetadataFields") final Map<String, String> skuMetadataFields) {
+                @JsonProperty("skuMetadataFields") final Map<String, String> skuMetadataFields,
+                @JsonProperty("size") final SkuSizeSpec size) {
             this.skuId = skuId;
             this.capacity = capacity;
             this.imageId = imageId;
@@ -118,6 +129,7 @@ public class MantisResourceClusterSpec {
             this.networkMbps = networkMbps;
             this.diskSizeInMB = diskSizeInMB;
             this.skuMetadataFields = skuMetadataFields;
+            this.size = size;
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/SkuSizeSpec.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/SkuSizeSpec.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.resourcecluster.proto;
+
+import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonCreator;
+import io.mantisrx.shaded.com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Value;
+import org.apache.commons.lang3.Validate;
+
+/**
+ * Encapsulates the specifications of a SKU size in terms of the machine's resources.
+ * Each SKU size has a name (similar to the label of t-shirt sizes), and a dedicated machine definition that
+ * consists of specifications for CPU, disk, memory, and network.
+ *
+ * The name is a convenient way to refer to a particular configuration of machine resources while the machine definition represents the actual values.
+ */
+@Builder
+@Value
+public class SkuSizeSpec {
+    // Includes the specifications of a machine: CPU cores, disk in MB, memory in MB, and network bandwidth in Mbps
+    MachineDefinition machineDefinition;
+
+
+    // The name for the SKU size. It is a short, descriptive term typically representing the size of the machine resource being specified (e.g., "small", "medium", "large")
+    String name;
+
+    @JsonCreator
+    public SkuSizeSpec(
+        @JsonProperty("machineDefinition") final MachineDefinition machineDefinition,
+        @JsonProperty("name") final String name) {
+
+        validateMachineDefinition(machineDefinition);
+        validateName(name);
+
+        this.name = name.trim();
+        this.machineDefinition = machineDefinition;
+    }
+
+    private void validateMachineDefinition(MachineDefinition machineDefinition) {
+        Validate.isTrue(machineDefinition.getCpuCores() >= 1, "CPU cores must be equal to or greater than 1");
+        Validate.isTrue(machineDefinition.getDiskMB() >= 1, "Disk size must be equal to or greater than 1MB");
+        Validate.isTrue(machineDefinition.getMemoryMB() >= 1, "Memory size must be equal to or greater than 1MB");
+        Validate.isTrue(machineDefinition.getNetworkMbps() >= 1, "Network speed must be equal to or greater than 1Mbps");
+    }
+
+    private void validateName(String name) {
+        Validate.notNull(name, "Name must not be null");
+        Validate.isTrue(!name.trim().isEmpty(), "Name must not be empty or only whitespace");
+    }
+}


### PR DESCRIPTION
### Context

This PR is the fourth one of an effort to split a [larger PR](https://github.com/Netflix/mantis/pull/623) into manageable parts.

This PR introduces a new class `SkuSizeSpec` and updates the existing class `SkuTypeSpec` to include a size attribute.

To describe varied Task Executors of the same size, the proposal suggests creating multiple SKUs and storing variables like runtime JDK in existing SKU metadata field. This approach leads to an increasing list of SKU-IDs to be shown to users during worker size selection. To keep the selection user-friendly, we will instead enrich SKUs with a size attribute which includes a 't-shirt size' label.

Key changes include:

* Introducing SkuSizeSpec Class: This new class includes the 't-shirt size' label/name that is to be displayed to the user, along with the machine resources definition.

* Updating SkuTypeSpec Class: The existing SkuTypeSpec class has been updated to include a size attribute of the new SkuSizeSpec class.

* Marking Existing Fields as Deprecated: The existing machine definition fields, cpuCoreCount, memorySizeInMB, networkMbps, and diskSizeInMB, have been marked as deprecated. These fields will be removed in a future PR after the upgrade of the existing skus.

These changes provide the basis for moving forward with the proposed scheduling constraints updates. This PR only introduces the new class and updates the SkuTypeSpec to include the size, but does not change any scheduling logic. 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
