### PR TITLE
Allow disabled job to load if it contains invalid state

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
@@ -115,6 +115,7 @@ public class DataFormatAdapter {
                         .withLabels(nJob.getLabels())
                         .withParameters(nJob.getParameters())
                         .withJobClusterConfigs(DataFormatAdapter.convertJarsToJobClusterConfigs(nJob.getJars()))
+                        .withIsDisabled(nJob.getDisabled())
                         .build())
                 .build();
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobClusterDefinitionImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobClusterDefinitionImpl.java
@@ -59,7 +59,8 @@ public class JobClusterDefinitionImpl implements IJobClusterDefinition {
                                     @JsonProperty("migrationConfig") WorkerMigrationConfig migrationConfig,
                                     @JsonProperty("isReadyForJobMaster") boolean isReadyForJobMaster,
                                     @JsonProperty("parameters") List<Parameter> parameters,
-                                    @JsonProperty("labels") List<Label> labels
+                                    @JsonProperty("labels") List<Label> labels,
+                                    @JsonProperty("isDisabled") boolean isDisabled
     ) {
         Preconditions.checkNotNull(jobClusterConfigs);
         Preconditions.checkArgument(!jobClusterConfigs.isEmpty());
@@ -75,14 +76,27 @@ public class JobClusterDefinitionImpl implements IJobClusterDefinition {
         this.user = user;
 
         // Todo move the resource cluster label to a property
-        Preconditions.checkNotNull(labels, "labels cannot be empty.");
-        Preconditions.checkArgument(
-            labels.stream()
-                .anyMatch(l ->
-                    l.getName().equalsIgnoreCase(SystemLabels.MANTIS_RESOURCE_CLUSTER_NAME_LABEL.label)),
-            "Missing required label: " + SystemLabels.MANTIS_RESOURCE_CLUSTER_NAME_LABEL.label);
+        if (!isDisabled) {
+            Preconditions.checkNotNull(labels, "labels cannot be empty.");
+            Preconditions.checkArgument(
+                labels.stream()
+                    .anyMatch(l ->
+                        l.getName().equalsIgnoreCase(SystemLabels.MANTIS_RESOURCE_CLUSTER_NAME_LABEL.label)),
+                "Missing required label: " + SystemLabels.MANTIS_RESOURCE_CLUSTER_NAME_LABEL.label);
+        }
     }
 
+    public JobClusterDefinitionImpl(String name,
+        List<JobClusterConfig> jobClusterConfigs,
+        JobOwner owner,
+        String user,
+        SLA sla,
+        WorkerMigrationConfig migrationConfig,
+        boolean isReadyForJobMaster,
+        List<Parameter> parameters,
+        List<Label> labels) {
+        this(name, jobClusterConfigs, owner, user, sla, migrationConfig, isReadyForJobMaster, parameters, labels, false);
+    }
 
     /* (non-Javadoc)
      * @see io.mantisrx.server.master.domain.IJobClusterDefinition#getOwner()
@@ -313,6 +327,7 @@ public class JobClusterDefinitionImpl implements IJobClusterDefinition {
         String user = "default";
         List<Parameter> parameters = Lists.newArrayList();
         List<Label> labels = Lists.newArrayList();
+        boolean isDisabled = false;
 
         public Builder() {}
 
@@ -384,6 +399,10 @@ public class JobClusterDefinitionImpl implements IJobClusterDefinition {
             return this;
         }
 
+        public Builder withIsDisabled(boolean isDisabled) {
+            this.isDisabled = isDisabled;
+            return this;
+        }
 
         public Builder from(IJobClusterDefinition defn) {
             migrationConfig = defn.getWorkerMigrationConfig();
@@ -435,7 +454,17 @@ public class JobClusterDefinitionImpl implements IJobClusterDefinition {
             Preconditions.checkNotNull(user);
             Preconditions.checkNotNull(jobClusterConfigs);
             Preconditions.checkArgument(!jobClusterConfigs.isEmpty());
-            return new JobClusterDefinitionImpl(name, jobClusterConfigs, owner, user, sla, migrationConfig, isReadyForJobMaster, parameters, labels);
+            return new JobClusterDefinitionImpl(
+                name,
+                jobClusterConfigs,
+                owner,
+                user,
+                sla,
+                migrationConfig,
+                isReadyForJobMaster,
+                parameters,
+                labels,
+                isDisabled);
         }
 
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
@@ -296,6 +296,106 @@ public class DataFormatAdapterTest {
     }
 
     @Test
+    public void jobClusterMetadataConversionTestDisabledInvalidJob() {
+        String artifactName = "artifact1";
+        String version = "0.0.1";
+        List<Parameter> parameterList = new ArrayList<>();
+        Parameter parameter = new Parameter("param1", "value1");
+        parameterList.add(parameter);
+
+
+        List<Label> labels = new ArrayList<>();
+        Label label = new Label("label1", "labelvalue1");
+        labels.add(label);
+
+        long uAt = 1234l;
+        JobClusterConfig jobClusterConfig =  new JobClusterConfig.Builder()
+            .withArtifactName(artifactName)
+            .withSchedulingInfo(DEFAULT_SCHED_INFO)
+            .withVersion(version)
+            .withUploadedAt(uAt)
+            .build();
+
+        String clusterName = "clusterName1";
+        JobOwner owner = new JobOwner("Neeraj", "Mantis", "desc", "nma@netflix.com", "repo");
+        boolean isReadyForMaster = true;
+        SLA sla = new SLA(1, 10, null, null);
+        JobClusterDefinitionImpl clusterDefn = new JobClusterDefinitionImpl.Builder()
+            .withJobClusterConfig(jobClusterConfig)
+            .withName(clusterName)
+            .withUser("user1")
+            .withIsReadyForJobMaster(isReadyForMaster)
+            .withOwner(owner)
+            .withMigrationConfig(WorkerMigrationConfig.DEFAULT)
+            .withSla(sla)
+            .withParameters(parameterList)
+            .withLabels(labels)
+            .withIsDisabled(true)
+            .build();
+
+        int lastJobCnt = 10;
+        boolean disabled = true;
+        IJobClusterMetadata clusterMeta = new JobClusterMetadataImpl.Builder()
+            .withJobClusterDefinition(clusterDefn)
+            .withLastJobCount(lastJobCnt)
+            .withIsDisabled(disabled)
+            .build();
+
+        NamedJob namedJob = DataFormatAdapter.convertJobClusterMetadataToNamedJob(clusterMeta);
+
+        assertEquals(disabled,namedJob.getDisabled());
+        assertEquals(clusterName, namedJob.getName());
+        assertEquals(lastJobCnt,namedJob.getLastJobCount());
+        assertEquals(1, namedJob.getLabels().size());
+        assertEquals(label, namedJob.getLabels().get(0));
+        assertEquals(owner, namedJob.getOwner());
+        assertEquals(isReadyForMaster, namedJob.getIsReadyForJobMaster());
+        assertEquals(WorkerMigrationConfig.DEFAULT, namedJob.getMigrationConfig());
+
+        // assert parameters
+        assertEquals(parameterList.size(), namedJob.getParameters().size());
+        assertEquals(parameter, namedJob.getParameters().get(0));
+
+        // assert sla
+        assertEquals(sla.getMin(), namedJob.getSla().getMin());
+        assertEquals(sla.getMax(), namedJob.getSla().getMax());
+
+        // assert jar info
+        assertEquals(1, namedJob.getJars().size());
+
+        // jar info
+        NamedJob.Jar jar = namedJob.getJars().get(0);
+        assertEquals(uAt, jar.getUploadedAt());
+        assertEquals(DEFAULT_SCHED_INFO,jar.getSchedulingInfo());
+        assertEquals(version, jar.getVersion());
+        assertEquals(artifactName, DataFormatAdapter.extractArtifactName(jar.getUrl()).orElse(""));
+
+        IJobClusterMetadata reconvertedJobCluster = DataFormatAdapter.convertNamedJobToJobClusterMetadata(namedJob);
+
+        assertEquals(disabled,reconvertedJobCluster.isDisabled());
+        assertEquals(clusterName,reconvertedJobCluster.getJobClusterDefinition().getName());
+        assertEquals(lastJobCnt,reconvertedJobCluster.getLastJobCount());
+        assertEquals(1, reconvertedJobCluster.getJobClusterDefinition().getLabels().size());
+        assertEquals(label, reconvertedJobCluster.getJobClusterDefinition().getLabels().get(0));
+        assertEquals(owner, reconvertedJobCluster.getJobClusterDefinition().getOwner());
+        assertEquals(isReadyForMaster,reconvertedJobCluster.getJobClusterDefinition().getIsReadyForJobMaster());
+        assertEquals(WorkerMigrationConfig.DEFAULT,reconvertedJobCluster.getJobClusterDefinition().getWorkerMigrationConfig());
+
+        assertEquals(parameterList.size(), reconvertedJobCluster.getJobClusterDefinition().getParameters().size());
+        assertEquals(parameter, reconvertedJobCluster.getJobClusterDefinition().getParameters().get(0));
+
+        assertEquals(sla.getMin(), reconvertedJobCluster.getJobClusterDefinition().getSLA().getMin());
+        assertEquals(sla.getMax(), reconvertedJobCluster.getJobClusterDefinition().getSLA().getMax());
+
+        JobClusterConfig clusterConfig1 = reconvertedJobCluster.getJobClusterDefinition().getJobClusterConfig();
+        assertEquals(uAt,clusterConfig1.getUploadedAt());
+        assertEquals(DEFAULT_SCHED_INFO,clusterConfig1.getSchedulingInfo());
+        assertEquals(version,clusterConfig1.getVersion());
+        assertEquals(artifactName, clusterConfig1.getArtifactName());
+
+    }
+
+    @Test
     public void completedJobToNamedJobCompletedJobTest() {
         String name = "name";
         String jobId = "name-1";


### PR DESCRIPTION
### Context

Allow job cluster loading on disabled job cluster definitions if the cluster definition misses required parameters to maintain proper back compat.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
