### PR TITLE
Add clientIP to scheduleInfo API log + chatty log cleanup

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/ExecuteStageRequest.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/ExecuteStageRequest.java
@@ -123,7 +123,7 @@ public class ExecuteStageRequest implements Serializable {
         this.schedulingInfo = schedulingInfo;
         this.durationType = durationType;
         this.heartbeatIntervalSecs = (heartbeatIntervalSecs > 0) ? heartbeatIntervalSecs : DEFAULT_HEARTBEAT_INTERVAL_SECS;
-        log.info("heartbeat interval {}, using {}", heartbeatIntervalSecs, this.heartbeatIntervalSecs);
+        log.debug("heartbeat interval {}, using {}", heartbeatIntervalSecs, this.heartbeatIntervalSecs);
         this.hasJobMaster = schedulingInfo != null && schedulingInfo.forStage(0) != null;
         this.subscriptionTimeoutSecs = subscriptionTimeoutSecs;
         this.minRuntimeSecs = minRuntimeSecs;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v0/JobDiscoveryRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v0/JobDiscoveryRoute.java
@@ -76,13 +76,14 @@ public class JobDiscoveryRoute extends BaseRoute {
         return route(
                 get(() -> route(
                         path(segment("assignmentresults").slash(PathMatchers.segment()), (jobId) ->
-                                parameterOptional(
+                                extractClientIP(clientIp ->
+                                    parameterOptional(
                                         StringUnmarshallers.BOOLEAN,
                                         "sendHB",
                                         (sendHeartbeats) -> {
                                             logger.debug(
-                                                    "/assignmentresults/{} called",
-                                                    jobId);
+                                                    "/assignmentresults/{} called by {}",
+                                                    jobId, clientIp);
                                             schedulingInfoStreamGET.increment();
                                             JobClusterManagerProto.GetJobSchedInfoRequest req =
                                                     new JobClusterManagerProto.GetJobSchedInfoRequest(
@@ -123,7 +124,7 @@ public class JobDiscoveryRoute extends BaseRoute {
                                                                     jobId);
                                                         }
                                                     });
-                                        })
+                                        }))
                         ),
                         path(segment("namedjobs").slash(PathMatchers.segment()), (jobCluster) ->
                                 parameterOptional(

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
@@ -365,10 +365,10 @@ public class JobsRoute extends BaseRoute {
     private Route getJobInstanceRoute(Optional<String> clusterName, String jobId) {
         String endpoint;
         if (clusterName.isPresent()) {
-            logger.info("GET /api/v1/jobClusters/{}/jobs/{} called", clusterName.get(), jobId);
+            logger.debug("GET /api/v1/jobClusters/{}/jobs/{} called", clusterName.get(), jobId);
             endpoint = HttpRequestMetrics.Endpoints.JOB_CLUSTER_INSTANCE_JOBS;
         } else {
-            logger.info("GET /api/v1/jobs/{} called", jobId);
+            logger.debug("GET /api/v1/jobs/{} called", jobId);
             endpoint = HttpRequestMetrics.Endpoints.JOBS;
         }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -155,13 +155,13 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                 .match(GetClusterUsageResponse.class, this::onGetClusterUsageResponse)
                 .match(GetClusterIdleInstancesResponse.class, this::onGetClusterIdleInstancesResponse)
                 .match(GetRuleSetResponse.class,
-                    s -> log.info("[{}] Refreshed rule size: {}", s.getClusterID(), s.getRules().size()))
+                    s -> log.debug("[{}] Refreshed rule size: {}", s.getClusterID(), s.getRules().size()))
                 .match(SetResourceClusterScalerStatusRequest.class, req -> {
                     onSetScalerStatus(req);
                     getSender().tell(Ack.getInstance(), self());
                 })
                 .match(ExpireSetScalerStatusRequest.class, this::onExpireSetScalerStatus)
-                .match(Ack.class, ack -> log.info("Received ack from {}", sender()))
+                .match(Ack.class, ack -> log.debug("Received ack from {}", sender()))
                 .build();
     }
 
@@ -203,7 +203,7 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                     log.info("Informing scale decision: {}", decisionO.get());
                     switch (decisionO.get().getType()) {
                         case ScaleDown:
-                            log.info("Scaling down, fetching idle instances.");
+                            log.info("Scaling down, fetching idle instances: {}.", decisionO.get());
                             this.numScaleDown.increment();
                             this.resourceClusterActor.tell(
                                 GetClusterIdleInstancesRequest.builder()
@@ -274,7 +274,7 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
     }
 
     private void onTriggerClusterRuleRefreshRequest(TriggerClusterRuleRefreshRequest req) {
-        log.info("{}: Requesting cluster rule refresh", this.clusterId);
+        log.debug("{}: Requesting cluster rule refresh", this.clusterId);
         this.fetchRuleSet();
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/resources/application.conf
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/resources/application.conf
@@ -966,7 +966,7 @@ akka {
 
       # Enables/disables the addition of a `Remote-Address` header
       # holding the clients (remote) IP address.
-      remote-address-header = off
+      remote-address-header = on
 
       # Enables/disables the addition of a `Raw-Request-URI` header holding the
       # original raw request URI as the client has sent it.


### PR DESCRIPTION
### Context

Add client IP tracking to the log to get schedule Info to help detect unexpected callers.
Reduce some chatty logs.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
