### PR TITLE
Optional HTTPS connection context

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
@@ -25,7 +25,6 @@ import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.ServerBuilder;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
-import akka.http.javadsl.model.HttpsConnectionContext;
 import akka.http.javadsl.settings.ServerSettings;
 import akka.http.javadsl.settings.WebSocketSettings;
 import akka.stream.Materializer;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
@@ -20,9 +20,12 @@ import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.http.javadsl.Http;
+import akka.http.javadsl.HttpsConnectionContext;
 import akka.http.javadsl.ServerBinding;
+import akka.http.javadsl.ServerBuilder;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.HttpsConnectionContext;
 import akka.http.javadsl.settings.ServerSettings;
 import akka.http.javadsl.settings.WebSocketSettings;
 import akka.stream.Materializer;
@@ -91,6 +94,7 @@ public class MasterApiAkkaService extends BaseService {
     private final Materializer materializer;
     private final ExecutorService executorService;
     private final CountDownLatch serviceLatch = new CountDownLatch(1);
+    private final HttpsConnectionContext httpsConnectionContext;
 
     public MasterApiAkkaService(final MasterMonitor masterMonitor,
                                 final MasterDescription masterDescription,
@@ -101,7 +105,33 @@ public class MasterApiAkkaService extends BaseService {
                                 final int serverPort,
                                 final IMantisPersistenceProvider mantisStorageProvider,
                                 final LifecycleEventPublisher lifecycleEventPublisher,
-                                final ILeadershipManager leadershipManager) {
+                                final ILeadershipManager leadershipManager
+                                ) {
+        this(
+            masterMonitor,
+            masterDescription,
+            jobClustersManagerActor,
+            statusEventBrokerActor,
+            resourceClusters,
+            resourceClustersHostManagerActor,
+            serverPort,
+            mantisStorageProvider,
+            lifecycleEventPublisher,
+            leadershipManager,
+            null
+        );
+    }
+    public MasterApiAkkaService(final MasterMonitor masterMonitor,
+                                final MasterDescription masterDescription,
+                                final ActorRef jobClustersManagerActor,
+                                final ActorRef statusEventBrokerActor,
+                                final ResourceClusters resourceClusters,
+                                final ActorRef resourceClustersHostManagerActor,
+                                final int serverPort,
+                                final IMantisPersistenceProvider mantisStorageProvider,
+                                final LifecycleEventPublisher lifecycleEventPublisher,
+                                final ILeadershipManager leadershipManager,
+                                final HttpsConnectionContext httpsConnectionContext) {
         super(true);
         Preconditions.checkNotNull(masterMonitor, "MasterMonitor");
         Preconditions.checkNotNull(masterDescription, "masterDescription");
@@ -123,6 +153,7 @@ public class MasterApiAkkaService extends BaseService {
         this.system = ActorSystem.create("MasterApiActorSystem");
         this.materializer = Materializer.createMaterializer(system);
         this.mantisMasterRoute = configureApiRoutes(this.system);
+        this.httpsConnectionContext = httpsConnectionContext;
         this.executorService = Executors.newSingleThreadExecutor(r -> {
             Thread t = new Thread(r, "MasterApiAkkaServiceThread");
             t.setDaemon(true);
@@ -200,8 +231,14 @@ public class MasterApiAkkaService extends BaseService {
 
         ServerSettings customServerSettings = defaultSettings.withWebsocketSettings(customWebsocketSettings);
 
-        final CompletionStage<ServerBinding> binding = Http.get(system)
-                .newServerAt("0.0.0.0", port)
+        ServerBuilder httpServerBuilder = Http.get(system)
+            .newServerAt("0.0.0.0", port);
+
+        if(this.httpsConnectionContext != null) {
+            httpServerBuilder.enableHttps(this.httpsConnectionContext);
+        }
+
+        final CompletionStage<ServerBinding> binding = httpServerBuilder
                 .withSettings(customServerSettings)
                 .connectionSource()
                 .to(Sink.foreach(connection -> {


### PR DESCRIPTION
### Context

Added an https connection context that allows that caller of MasterAPIAkkaService to provide TLS settings, I've defined a new constructor that matches the old signature so this should be a no-op for existing usage.


### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
