### PR TITLE
Fix leaked schedulingChanges connections

### DIFF
--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/JobIdNotFoundException.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/JobIdNotFoundException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.master.client;
+
+public class JobIdNotFoundException extends Exception {
+    public JobIdNotFoundException(String jobId) {
+        super(String.format("JobId %s not found", jobId));
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v0/JobDiscoveryRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v0/JobDiscoveryRoute.java
@@ -35,6 +35,7 @@ import io.mantisrx.master.api.akka.route.handlers.JobDiscoveryRouteHandler;
 import io.mantisrx.master.api.akka.route.proto.JobClusterInfo;
 import io.mantisrx.master.api.akka.route.proto.JobDiscoveryRouteProto;
 import io.mantisrx.master.api.akka.route.utils.StreamingUtils;
+import io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.server.core.JobSchedulingInfo;
 import io.mantisrx.server.master.domain.JobId;
@@ -97,6 +98,16 @@ public class JobDiscoveryRoute extends BaseRoute {
                                             return completeAsync(
                                                     schedulingInfoRespCS,
                                                     r -> {
+                                                        if (r.responseCode.equals(ResponseCode.CLIENT_ERROR_NOT_FOUND)) {
+                                                            logger.warn(
+                                                                "Sched info stream not found for job {}",
+                                                                jobId);
+                                                            return complete(
+                                                                StatusCodes.NOT_FOUND,
+                                                                "Sched info stream not found for job " +
+                                                                    jobId);
+                                                        }
+
                                                         Optional<Observable<JobSchedulingInfo>> schedInfoStreamO = r
                                                                 .getSchedInfoStream();
                                                         if (schedInfoStreamO.isPresent()) {


### PR DESCRIPTION
### Context

We are seeing a high frequency of unexpected calls to the "assignmentResults" API to closed jobs in a prod instance, which turns out to be connections stuck in an infinite retry policy on the observable created by mantisClient.

The fix here added the error handling to both server API response (return 404 on closed jobs) and client-side (escape the infinite retry if getting 404 response).


### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
