### PR TITLE
Moving where the MantisNettyEventsListenerFactory is being set

### DIFF
--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/WorkerExecutionOperationsNetworkStage.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/WorkerExecutionOperationsNetworkStage.java
@@ -23,6 +23,7 @@ import com.mantisrx.common.utils.Closeables;
 import com.netflix.spectator.api.Registry;
 import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.common.metrics.MetricsRegistry;
+import io.mantisrx.common.metrics.netty.MantisNettyEventsListenerFactory;
 import io.mantisrx.common.metrics.spectator.SpectatorRegistryFactory;
 import io.mantisrx.common.network.Endpoint;
 import io.mantisrx.runtime.Context;
@@ -82,6 +83,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import mantis.io.reactivex.netty.RxNetty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
@@ -341,6 +343,7 @@ public class WorkerExecutionOperationsNetworkStage implements WorkerExecutionOpe
                             SpectatorRegistryFactory.getRegistry().getClass().getCanonicalName());
                 }
             }
+            RxNetty.useMetricListenersFactory(new MantisNettyEventsListenerFactory());
             // create job context
             Parameters parameters = ParameterUtils
                     .createContextParameters(rw.getJob().getParameterDefinitions(),

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
@@ -21,7 +21,6 @@ import com.spotify.futures.CompletableFutures;
 import io.mantisrx.common.Ack;
 import io.mantisrx.common.JsonSerializer;
 import io.mantisrx.common.WorkerPorts;
-import io.mantisrx.common.metrics.netty.MantisNettyEventsListenerFactory;
 import io.mantisrx.common.properties.DefaultMantisPropertiesLoader;
 import io.mantisrx.common.properties.MantisPropertiesLoader;
 import io.mantisrx.config.dynamic.LongDynamicProperty;
@@ -69,7 +68,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import mantis.io.reactivex.netty.RxNetty;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -214,7 +212,6 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
 
         masterMonitor = highAvailabilityServices.getMasterClientApi();
         taskStatusUpdateHandler = TaskStatusUpdateHandler.forReportingToGateway(masterMonitor);
-        RxNetty.useMetricListenersFactory(new MantisNettyEventsListenerFactory());
         resourceClusterGatewaySupplier =
             highAvailabilityServices.connectWithResourceManager(clusterID);
         resourceClusterGatewaySupplier.register((oldGateway, newGateway) -> TaskExecutor.this.runAsync(() -> setNewResourceClusterGateway(newGateway)));


### PR DESCRIPTION
### Context

TaskExecutor lifecycle is too early to set the MantisNettyEventsListenerFactory singleton. It has to be set up from the runtime. Since during the TaskExecutor lifecycle, the job is still not set up. So, tags like mantisJobId or mantisJobName are not available yet.  

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
