### PR TITLE
Add GetDisabledTaskExecutors Api + scaler handling on disabled TEs

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -85,6 +85,8 @@ public interface ResourceCluster extends ResourceClusterGateway {
 
     CompletableFuture<List<TaskExecutorID>> getBusyTaskExecutors(Map<String, String> attributes);
 
+    CompletableFuture<List<TaskExecutorID>> getDisabledTaskExecutors(Map<String, String> attributes);
+
     default CompletableFuture<List<TaskExecutorID>> getUnregisteredTaskExecutors() {
         return getUnregisteredTaskExecutors(Collections.emptyMap());
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
@@ -216,6 +216,12 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
                     (clusterName) -> pathEndOrSingleSlash(() -> concat(
                         get(() -> mkTaskExecutorsRoute(getClusterID(clusterName), (rc, req) -> rc.getBusyTaskExecutors(req.getAttributes())))))
                 ),
+                // /{}/getBusyTaskExecutors
+                path(
+                    PathMatchers.segment().slash("getDisabledTaskExecutors"),
+                    (clusterName) -> pathEndOrSingleSlash(() -> concat(
+                        get(() -> mkTaskExecutorsRoute(getClusterID(clusterName), (rc, req) -> rc.getDisabledTaskExecutors(req.getAttributes())))))
+                ),
                 // /{}/getAvailableTaskExecutors
                 path(
                     PathMatchers.segment().slash("getAvailableTaskExecutors"),

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
@@ -78,6 +78,7 @@ import lombok.extern.slf4j.Slf4j;
  * /api/v1/resourceClusters/{}/getResourceOverview                    (GET)
  * /api/v1/resourceClusters/{}/getRegisteredTaskExecutors             (GET)
  * /api/v1/resourceClusters/{}/getBusyTaskExecutors                   (GET)
+ * /api/v1/resourceClusters/{}/getDisabledTaskExecutors               (GET)
  * /api/v1/resourceClusters/{}/getAvailableTaskExecutors              (GET)
  * /api/v1/resourceClusters/{}/getUnregisteredTaskExecutors           (GET)
  * /api/v1/resourceClusters/{}/scaleSku                               (POST)
@@ -216,7 +217,7 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
                     (clusterName) -> pathEndOrSingleSlash(() -> concat(
                         get(() -> mkTaskExecutorsRoute(getClusterID(clusterName), (rc, req) -> rc.getBusyTaskExecutors(req.getAttributes())))))
                 ),
-                // /{}/getBusyTaskExecutors
+                // /{}/getDisabledTaskExecutors
                 path(
                     PathMatchers.segment().slash("getDisabledTaskExecutors"),
                     (clusterName) -> pathEndOrSingleSlash(() -> concat(

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/DisableTaskExecutorsRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/DisableTaskExecutorsRequest.java
@@ -41,7 +41,7 @@ public class DisableTaskExecutorsRequest {
     Optional<TaskExecutorID> taskExecutorID;
 
     boolean isRequestByAttributes() {
-        return attributes.size() > 0;
+        return attributes != null && attributes.size() > 0;
     }
 
     boolean isExpired(Instant now) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
@@ -101,7 +101,7 @@ interface ExecutorStateManager {
         e -> e.getValue().isAvailable();
 
     Predicate<Entry<TaskExecutorID, TaskExecutorState>> isDisabled =
-        e -> e.getValue().isDisabled();
+        e -> e.getValue().isDisabled() && e.getValue().isRegistered();
 
     Predicate<Entry<TaskExecutorID, TaskExecutorState>> isAssigned =
         e -> e.getValue().isAssigned();

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
@@ -421,11 +421,6 @@ class ExecutorStateManagerImpl implements ExecutorStateManager {
                 return;
             }
 
-            // do not count the disabled TEs.
-            if (value.isDisabled()) {
-                return;
-            }
-
             Optional<String> groupKeyO =
                 req.getGroupKeyFunc().apply(value.getRegistration());
 
@@ -437,7 +432,7 @@ class ExecutorStateManagerImpl implements ExecutorStateManager {
             String groupKey = groupKeyO.get();
 
             Pair<Integer, Integer> kvState = Pair.of(
-                value.isAvailable() ? 1 : 0,
+                value.isAvailable() && !value.isDisabled() ? 1 : 0,
                 value.isRegistered() ? 1 : 0);
 
             if (usageByGroupKey.containsKey(groupKey)) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -26,6 +26,7 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequ
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAssignedTaskExecutorRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAvailableTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetBusyTaskExecutorsRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetDisabledTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetJobArtifactsToCacheRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetRegisteredTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetTaskExecutorStatusRequest;
@@ -113,6 +114,16 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
         return Patterns.ask(
                 resourceClusterManagerActor,
                 new GetBusyTaskExecutorsRequest(clusterID, attributes), askTimeout)
+            .thenApply(TaskExecutorsList.class::cast)
+            .toCompletableFuture()
+            .thenApply(l -> l.getTaskExecutors());
+    }
+
+    @Override
+    public CompletableFuture<List<TaskExecutorID>> getDisabledTaskExecutors(Map<String, String> attributes) {
+        return Patterns.ask(
+                resourceClusterManagerActor,
+                new GetDisabledTaskExecutorsRequest(clusterID, attributes), askTimeout)
             .thenApply(TaskExecutorsList.class::cast)
             .toCompletableFuture()
             .thenApply(l -> l.getTaskExecutors());

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -27,6 +27,7 @@ import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetActiveJobsRequ
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAssignedTaskExecutorRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetAvailableTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetBusyTaskExecutorsRequest;
+import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetDisabledTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetJobArtifactsToCacheRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetRegisteredTaskExecutorsRequest;
 import io.mantisrx.master.resourcecluster.ResourceClusterActor.GetTaskExecutorStatusRequest;
@@ -122,6 +123,7 @@ class ResourceClustersManagerActor extends AbstractActor {
 
                 .match(GetRegisteredTaskExecutorsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
                 .match(GetBusyTaskExecutorsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
+                .match(GetDisabledTaskExecutorsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
                 .match(GetAvailableTaskExecutorsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
                 .match(GetUnregisteredTaskExecutorsRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))
                 .match(GetTaskExecutorStatusRequest.class, req -> getRCActor(req.getClusterID()).forward(req, context()))


### PR DESCRIPTION
### Context
Adding api to query disabled TEs.
[update]
Updating the logic for:
* Add condition for disabled TEs metrics to only include active (registered) TEs.
* Include disabled TEs in auto scaler usage so disabled TEs won't pollute the scale-up calculation.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
