### PR TITLE
Reassigned httpServerBuilder after enableHttps

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
@@ -234,7 +234,7 @@ public class MasterApiAkkaService extends BaseService {
             .newServerAt("0.0.0.0", port);
 
         if(this.httpsConnectionContext != null) {
-            httpServerBuilder.enableHttps(this.httpsConnectionContext);
+            httpServerBuilder = httpServerBuilder.enableHttps(this.httpsConnectionContext);
         }
 
         final CompletionStage<ServerBinding> binding = httpServerBuilder


### PR DESCRIPTION
### Context

Assigning `httpServerBuilder` with the result of `enableHttps()` - I'd forgotten to check how the builder was working, the scala implementation is returning a new copy on ever method call, not mutating itself. 

See code here: https://github.com/akka/akka-http/blob/0e2a451d93a2ed0b8c87ced245c21f563122e80d/akka-http-core/src/main/scala/akka/http/scaladsl/ServerBuilder.scala#L141

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
