### PR TITLE
enable consumers to implement MasterMain and rename LeadershipManager to remove ZK

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/ServiceLifecycle.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/ServiceLifecycle.java
@@ -33,14 +33,14 @@ public class ServiceLifecycle {
     private static final Logger logger = LoggerFactory.getLogger(ServiceLifecycle.class);
     private LinkedList<BaseService> servicesList = new LinkedList<BaseService>();
 
-    void addService(BaseService service) {
+    public void addService(BaseService service) {
         if (!servicesList.isEmpty()) {
             service.addPredecessor(servicesList.getLast());
         }
         servicesList.add(service);
     }
 
-    void start() {
+    public void start() {
         for (BaseService service : servicesList) {
             try {
                 logger.info("Starting service " + service.getMyServiceCount() + ": " + service);
@@ -53,13 +53,13 @@ public class ServiceLifecycle {
         }
     }
 
-    void becomeLeader() {
+    public void becomeLeader() {
         for (BaseService service : servicesList) {
             service.enterActiveMode();
         }
     }
 
-    void shutdown() {
+    public void shutdown() {
         if (!servicesList.isEmpty()) {
             Iterator<BaseService> iterator = servicesList.descendingIterator();
             while (iterator.hasNext()) {


### PR DESCRIPTION
### Context

In order for teams to re-implement the MasterMain functionality of the Mantis Server the ServiceLifecycle functions need to be available to teams. I've changed those to be public, but I'm happy to find another solution or extract an interface here.

UPDATE: I am reverting this part of the change.

Second the LeadershipManagerZKImpl to the best of my knowledge is a ZK independent leadership manager. We are implementing a leader elector based on DynamoDB and are able to use this LeadershipManager without modifying it. This name change is proposing to reflect the fact other teams can reuse the Leadership Manager when implementing their own leader election.

In order to change this name it appears I'll need to deprecate as some tests are failing. I'll consider this in a future PR to expand leader election options in Mantis.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
