### PR TITLE
Use metrics collector from configuration in RuntimeTaskImpl.

### DIFF
--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/RuntimeTaskImpl.java
@@ -102,7 +102,7 @@ public class RuntimeTaskImpl extends AbstractIdleService implements RuntimeTask 
             this.wrappedExecuteStageRequest =
                 new WrappedExecuteStageRequest(PublishSubject.create(), executeStageRequest);
 
-            configWritable.setMetricsCollector(createMetricsCollector(this.config.getMetricsCollectorClass()));
+            configWritable.setMetricsCollector(createMetricsCollector(this.config.getMetricsCollectorClassName()));
         } catch (IOException | InvocationTargetException | IllegalAccessException | ClassNotFoundException |
                  NoSuchMethodException e) {
             throw new RuntimeException(e);

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
@@ -65,6 +65,10 @@ public interface WorkerConfiguration extends CoreConfiguration {
     @Default("5055")
     int getSinkPort();
 
+    @Config("mantis.taskexecutor.metrics.collector")
+    @Default("io.mantisrx.runtime.loader.cgroups.CgroupsMetricsCollector")
+    String getMetricsCollector();
+
     // ------------------------------------------------------------------------
     //  heartbeat connection related configurations
     // ------------------------------------------------------------------------

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
@@ -67,7 +67,7 @@ public interface WorkerConfiguration extends CoreConfiguration {
 
     @Config("mantis.taskexecutor.metrics.collector")
     @Default("io.mantisrx.runtime.loader.cgroups.CgroupsMetricsCollector")
-    String getMetricsCollectorClass();
+    String getMetricsCollectorClassName();
 
     // ------------------------------------------------------------------------
     //  heartbeat connection related configurations

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
@@ -67,7 +67,7 @@ public interface WorkerConfiguration extends CoreConfiguration {
 
     @Config("mantis.taskexecutor.metrics.collector")
     @Default("io.mantisrx.runtime.loader.cgroups.CgroupsMetricsCollector")
-    String getMetricsCollector();
+    String getMetricsCollectorClass();
 
     // ------------------------------------------------------------------------
     //  heartbeat connection related configurations

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
@@ -49,6 +49,7 @@ public class WorkerConfigurationUtils {
             .leaderAnnouncementPath(configSource.getLeaderAnnouncementPath())
             .localStorageDir(configSource.getLocalStorageDir())
             .metricsCollector(configSource.getUsageSupplier())
+            .metricsCollectorClass(configSource.getMetricsCollectorClass())
             .metricsPort(configSource.getMetricsPort())
             .metricsPublisher(configSource.getMetricsPublisher())
             .metricsPublisherFrequencyInSeconds(configSource.getMetricsPublisherFrequencyInSeconds())

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
@@ -49,7 +49,7 @@ public class WorkerConfigurationUtils {
             .leaderAnnouncementPath(configSource.getLeaderAnnouncementPath())
             .localStorageDir(configSource.getLocalStorageDir())
             .metricsCollector(configSource.getUsageSupplier())
-            .metricsCollectorClass(configSource.getMetricsCollectorClass())
+            .metricsCollectorClass(configSource.getMetricsCollectorClassName())
             .metricsPort(configSource.getMetricsPort())
             .metricsPublisher(configSource.getMetricsPublisher())
             .metricsPublisherFrequencyInSeconds(configSource.getMetricsPublisherFrequencyInSeconds())

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
@@ -162,7 +162,7 @@ public class WorkerConfigurationWritable implements WorkerConfiguration {
     }
 
     @Override
-    public String getMetricsCollectorClass() {
+    public String getMetricsCollectorClassName() {
         return this.metricsCollectorClass;
     }
 

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
@@ -73,6 +73,7 @@ public class WorkerConfigurationWritable implements WorkerConfiguration {
     int asyncHttpClientConnectionTimeoutMs;
     int asyncHttpClientRequestTimeoutMs;
     int asyncHttpClientReadTimeoutMs;
+    String metricsCollectorClass;
 
     @JsonIgnore
     MetricsPublisher metricsPublisher;
@@ -158,6 +159,11 @@ public class WorkerConfigurationWritable implements WorkerConfiguration {
     @Override
     public int getSinkPort() {
         return this.sinkPort;
+    }
+
+    @Override
+    public String getMetricsCollectorClass() {
+        return this.metricsCollectorClass;
     }
 
     @Override


### PR DESCRIPTION
### Summary
Use metrics collector from configuration in `RuntimeTaskImpl`.

### Context
Currently `CgroupsMetricsCollector` is hard-coded in `RuntimeTaskImpl.java`, so if it is overridden using the ` mantis.taskexecutor.metrics.collector` field in the Mantis agent properties, that isn't respected. This change uses the dynamically loaded implementation of `MetricsCollector`.

This change is a continuation of https://github.com/Netflix/mantis/pull/648.
