### PR TITLE
[WIP] Add a way to overwrite existing disable task cluster requests

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/master/resourcecluster/ResourceCluster.java
@@ -148,9 +148,15 @@ public interface ResourceCluster extends ResourceClusterGateway {
      * @param expiry     instant at which the request can be marked as complete. this is important
      *                   because we cannot be constantly checking if new task executors match the
      *                   disabled criteria or not.
+     * @param overwriteExisting allows resetting the stored state for a set of executors that match the attributes. If set to false, the request will be ignored if there is already a request for the same set of attributes.
+     *                                  See the {@link io.mantisrx.master.resourcecluster.DisableTaskExecutorsRequest} class for more details. By default, this is set to false.
      * @return a future that completes when the underlying operation is registered by the system
      */
-    CompletableFuture<Ack> disableTaskExecutorsFor(Map<String, String> attributes, Instant expiry, Optional<TaskExecutorID> taskExecutorID);
+    CompletableFuture<Ack> disableTaskExecutorsFor(Map<String, String> attributes, Instant expiry, Optional<TaskExecutorID> taskExecutorID, Boolean overwriteExisting);
+
+    default CompletableFuture<Ack> disableTaskExecutorsFor(Map<String, String> attributes, Instant expiry, Optional<TaskExecutorID> taskExecutorID) {
+        return disableTaskExecutorsFor(attributes, expiry, taskExecutorID, false);
+    }
 
     /**
      * Enables/Disables scaler for a given skuID of a given clusterID

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
@@ -334,7 +334,8 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
             return withFuture(gateway.getClusterFor(clusterID).disableTaskExecutorsFor(
                 request.getAttributes(),
                 Instant.now().plus(Duration.ofHours(request.getExpirationDurationInHours())),
-                request.getTaskExecutorID()));
+                request.getTaskExecutorID(),
+                request.getOverwriteExisting()));
         });
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/DisableTaskExecutorsRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/DisableTaskExecutorsRequest.java
@@ -40,6 +40,8 @@ public class DisableTaskExecutorsRequest {
 
     Optional<TaskExecutorID> taskExecutorID;
 
+    Boolean overwriteExisting;
+
     boolean isRequestByAttributes() {
         return attributes != null && attributes.size() > 0;
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterAkkaImpl.java
@@ -263,8 +263,9 @@ class ResourceClusterAkkaImpl extends ResourceClusterGatewayAkkaImpl implements 
     public CompletableFuture<Ack> disableTaskExecutorsFor(
         Map<String, String> attributes,
         Instant expiry,
-        Optional<TaskExecutorID> taskExecutorID) {
-        final DisableTaskExecutorsRequest msg = new DisableTaskExecutorsRequest(attributes, clusterID, expiry, taskExecutorID);
+        Optional<TaskExecutorID> taskExecutorID,
+        Boolean overwriteExisting) {
+        final DisableTaskExecutorsRequest msg = new DisableTaskExecutorsRequest(attributes, clusterID, expiry, taskExecutorID, overwriteExisting);
 
         return
             Patterns

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterScalerActor.java
@@ -256,7 +256,7 @@ public class ResourceClusterScalerActor extends AbstractActorWithTimers {
                 Collections.emptyMap(),
                 this.clusterId,
                 Instant.now().plus(Duration.ofMinutes(60)),
-                Optional.of(id)),
+                Optional.of(id), true),
                 self()
         ));
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/DisableTaskExecutorsRequest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/proto/DisableTaskExecutorsRequest.java
@@ -32,4 +32,6 @@ public class DisableTaskExecutorsRequest {
     Long expirationDurationInHours;
 
     Optional<TaskExecutorID> taskExecutorID;
+
+    Boolean overwriteExisting = false;
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/payloads/ResourceClustersPayloads.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/payloads/ResourceClustersPayloads.java
@@ -51,6 +51,15 @@ public class ResourceClustersPayloads {
         "  }\n" +
         "}";
 
+    public static final String RESOURCE_CLUSTER_DISABLE_TASK_EXECUTORS_PAYLOAD_WITH_OVERWRITE = "" +
+        "{\n" +
+        "  \"expirationDurationInHours\": 19,\n" +
+        "  \"attributes\": {\n" +
+        "    \"attr1\": \"attr1\"\n" +
+        "  },\n" +
+        "  \"overwriteExisting\": true\n" +
+        "}";
+
     public static final Map<String, String> RESOURCE_CLUSTER_DISABLE_TASK_EXECUTORS_ATTRS =
         ImmutableMap.of("attr1", "attr1");
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/DisableTaskExecutorsRequestTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/DisableTaskExecutorsRequestTest.java
@@ -28,13 +28,13 @@ import org.junit.Test;
 
 public class DisableTaskExecutorsRequestTest {
     private static final DisableTaskExecutorsRequest R1 =
-        new DisableTaskExecutorsRequest(ImmutableMap.of("attr1", "attr1"), ClusterID.of("cluster1"), Instant.now(), Optional.empty());
+        new DisableTaskExecutorsRequest(ImmutableMap.of("attr1", "attr1"), ClusterID.of("cluster1"), Instant.now(), Optional.empty(), false);
     private static final DisableTaskExecutorsRequest R2 =
-        new DisableTaskExecutorsRequest(ImmutableMap.of("attr2", "attr2"), ClusterID.of("cluster1"), Instant.now(), Optional.empty());
+        new DisableTaskExecutorsRequest(ImmutableMap.of("attr2", "attr2"), ClusterID.of("cluster1"), Instant.now(), Optional.empty(), false);
     private static final DisableTaskExecutorsRequest R3 =
-        new DisableTaskExecutorsRequest(ImmutableMap.of("attr1", "attr1"), ClusterID.of("cluster2"), Instant.now(), Optional.empty());
+        new DisableTaskExecutorsRequest(ImmutableMap.of("attr1", "attr1"), ClusterID.of("cluster2"), Instant.now(), Optional.empty(), false);
     private static final DisableTaskExecutorsRequest R4 =
-        new DisableTaskExecutorsRequest(ImmutableMap.of("attr1", "attr1"), ClusterID.of("cluster1"), Instant.now().plus(Duration.ofDays(1)), Optional.empty());
+        new DisableTaskExecutorsRequest(ImmutableMap.of("attr1", "attr1"), ClusterID.of("cluster1"), Instant.now().plus(Duration.ofDays(1)), Optional.empty(), true);
 
     @Test
     public void checkIfDifferentRequestsHaveDifferentHashes() {


### PR DESCRIPTION
### Context

At Stripe, we're looking to use blue-green deploys for the mantis agents and have drafted a workflow that goes as below. This PR adds the capability to enable a set of agents that were previously disabled using a `DisableTaskExecutorsRequest`. This is done through adding an optional field `overwriteExisting` to the request. I tried to keep the changes minimal and backwards compatible. If the `overwriteExisting` is missing in the request, everything should behave as it did before.

The orchestration workflow we have drafted is as follows:
- Let's assume we have a `blue` stack deployed for mantis agents.
- We deploy the new version of the mantis agents as a new stack we'll call `green`.
- Issue a request to expire the existing / active "disable requests" for the green stack using a request similar to the one below:
```
curl -L \
  --header "Content-Type: application/json" \
  --header "Accept: application/json" \
  --data '{"attributes": {"asg_name": "green-asg-identifier"}, "overwriteExisting": true, "expirationDurationInHours": "0"}' \
  http://master.service/api/v1/resourceClusters/DEFAULT_CLUSTER/disableTaskExecutors
```

This kicks off the part of the code that issues `ExpireDisableTaskExecutorsRequest` and removes the `DisableTaskExecutorsRequest` stored as we have the `overwriteExisting` set to true. 
- Issue a request to disable the `blue` stack
```
curl -L \
  --header "Content-Type: application/json" \
  --header "Accept: application/json" \
  --data '{"attributes": {"asg_name": "blue-asg-identifier"}, "overwriteExisting": true, "expirationDurationInHours": "non-zero-value-that-wont-expire-soon"}' \
  http://master.service/api/v1/resourceClusters/DEFAULT_CLUSTER/disableTaskExecutors
```
- Wait until the workloads / jobs move to the green stack to finalize the deployment.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
