### PR TITLE
Introduce job autoscaler manager

### DIFF
--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobAutoScaler.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobAutoScaler.java
@@ -90,14 +90,16 @@ public class JobAutoScaler {
     private final SchedulingInfo schedulingInfo;
     private final PublishSubject<Event> subject;
     private final Context context;
+    private final JobAutoscalerManager jobAutoscalerManager;
 
     JobAutoScaler(String jobId, SchedulingInfo schedulingInfo, MantisMasterGateway masterClientApi,
-                  Context context) {
+                  Context context, JobAutoscalerManager jobAutoscalerManager) {
         this.jobId = jobId;
         this.masterClientApi = masterClientApi;
         this.schedulingInfo = schedulingInfo;
-        subject = PublishSubject.create();
+        this.subject = PublishSubject.create();
         this.context = context;
+        this.jobAutoscalerManager = jobAutoscalerManager;
     }
 
     Observer<Event> getObserver() {

--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobAutoscalerManager.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobAutoscalerManager.java
@@ -19,21 +19,24 @@ package io.mantisrx.server.worker.jobmaster;
 import java.util.Properties;
 
 /**
- * Failover status client interface to get the failover status of current region
+ * A manager to control autoscaling of a job. This allows a runtime control to autoscaling behavior
+ * without necessitating a job redeployment.
+ * An example use is disabling scale up or scale down during a maintenance window.
+ * Yet another example is during region failovers when a failed over region shouldn't scale down
  */
 public interface JobAutoscalerManager {
 
     JobAutoscalerManager DEFAULT = new NoopJobAutoscalerManager();
 
     /**
-     * Knobs to toggle autoscaling scale ups
+     * Knobs to toggle autoscaler scale ups
      */
     default boolean isScaleUpEnabled() {
         return true;
     }
 
     /**
-     * Knobs to toggle autoscaling scale downs
+     * Knobs to toggle autoscaler scale downs
      */
     default boolean isScaleDownEnabled() {
         return true;

--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobAutoscalerManager.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobAutoscalerManager.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.worker.jobmaster;
+
+import java.util.Properties;
+
+/**
+ * Failover status client interface to get the failover status of current region
+ */
+public interface JobAutoscalerManager {
+
+    JobAutoscalerManager DEFAULT = new NoopJobAutoscalerManager();
+
+    /**
+     * Knobs to toggle autoscaling scale ups
+     */
+    default boolean isScaleUpEnabled() {
+        return true;
+    }
+
+    /**
+     * Knobs to toggle autoscaling scale downs
+     */
+    default boolean isScaleDownEnabled() {
+        return true;
+    }
+
+    /**
+     * Noop implementation of {@link JobAutoscalerManager} that always returns true
+     * for isScaleUpEnabled, isScaleDownEnabled
+     */
+    class NoopJobAutoscalerManager implements JobAutoscalerManager {
+
+        private NoopJobAutoscalerManager() {
+        }
+
+        @SuppressWarnings("unused")
+        public static JobAutoscalerManager valueOf(Properties properties) {
+            return DEFAULT;
+        }
+    }
+}

--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobMasterService.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobMasterService.java
@@ -68,12 +68,13 @@ public class JobMasterService implements Service {
                             final Context context,
                             final Action0 observableOnCompleteCallback,
                             final Action1<Throwable> observableOnErrorCallback,
-                            final Action0 observableOnTerminateCallback) {
+                            final Action0 observableOnTerminateCallback,
+                            final JobAutoscalerManager jobAutoscalerManager) {
         this.jobId = jobId;
         this.workerMetricsClient = workerMetricsClient;
         this.autoScaleMetricsConfig = autoScaleMetricsConfig;
         this.masterClientApi = masterClientApi;
-        this.jobAutoScaler = new JobAutoScaler(jobId, schedInfo, masterClientApi, context);
+        this.jobAutoScaler = new JobAutoScaler(jobId, schedInfo, masterClientApi, context, jobAutoscalerManager);
         this.metricObserver = new WorkerMetricHandler(jobId, jobAutoScaler.getObserver(), masterClientApi, autoScaleMetricsConfig).initAndGetMetricDataObserver();
         this.observableOnCompleteCallback = observableOnCompleteCallback;
         this.observableOnErrorCallback = observableOnErrorCallback;

--- a/mantis-runtime-executor/src/test/java/io/mantisrx/server/worker/jobmaster/JobAutoScalerTest.java
+++ b/mantis-runtime-executor/src/test/java/io/mantisrx/server/worker/jobmaster/JobAutoScalerTest.java
@@ -89,7 +89,7 @@ public class JobAutoScalerTest {
         Context context = mock(Context.class);
         when(context.getWorkerMapObservable()).thenReturn(Observable.empty());
 
-        final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context);
+        final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context, JobAutoscalerManager.DEFAULT);
         jobAutoScaler.start();
         final Observer<JobAutoScaler.Event> jobAutoScalerObserver = jobAutoScaler.getObserver();
 
@@ -168,7 +168,7 @@ public class JobAutoScalerTest {
         Context context = mock(Context.class);
         when(context.getWorkerMapObservable()).thenReturn(Observable.empty());
 
-        final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context);
+        final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context, JobAutoscalerManager.DEFAULT);
         jobAutoScaler.start();
         final Observer<JobAutoScaler.Event> jobAutoScalerObserver = jobAutoScaler.getObserver();
 
@@ -212,7 +212,7 @@ public class JobAutoScalerTest {
         Context context = mock(Context.class);
         when(context.getWorkerMapObservable()).thenReturn(Observable.empty());
 
-        final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context);
+        final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context, JobAutoscalerManager.DEFAULT);
         jobAutoScaler.start();
         final Observer<JobAutoScaler.Event> jobAutoScalerObserver = jobAutoScaler.getObserver();
 
@@ -266,7 +266,7 @@ public class JobAutoScalerTest {
         Context context = mock(Context.class);
         when(context.getWorkerMapObservable()).thenReturn(Observable.empty());
 
-        final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context);
+        final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context, JobAutoscalerManager.DEFAULT);
         jobAutoScaler.start();
         final Observer<JobAutoScaler.Event> jobAutoScalerObserver = jobAutoScaler.getObserver();
 
@@ -312,7 +312,7 @@ public class JobAutoScalerTest {
             Context context = mock(Context.class);
             when(context.getWorkerMapObservable()).thenReturn(Observable.empty());
 
-            final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context);
+            final JobAutoScaler jobAutoScaler = new JobAutoScaler(jobId, new SchedulingInfo(schedulingInfoMap), mockMasterClientApi, context, JobAutoscalerManager.DEFAULT);
             jobAutoScaler.start();
             final Observer<JobAutoScaler.Event> jobAutoScalerObserver = jobAutoScaler.getObserver();
 
@@ -357,7 +357,7 @@ public class JobAutoScalerTest {
                 "    \"scaleUpMultiplier\": 1.5" +
                 "  }" +
                 "}";
-        final JobAutoScaler jobAutoScaler = new JobAutoScaler("jobId", null, null, null);
+        final JobAutoScaler jobAutoScaler = new JobAutoScaler("jobId", null, null, null, JobAutoscalerManager.DEFAULT);
         ClutchConfiguration config = jobAutoScaler.getClutchConfiguration(json).get(1);
 
         ClutchRpsPIDConfig expected = new ClutchRpsPIDConfig(0.0, Tuple.of(30.0, 0.0), 0.0, 0.0, Option.of(75.0), Option.of(30.0), Option.of(0.0), Option.of(1.5), Option.of(1.0));

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
@@ -69,6 +69,10 @@ public interface WorkerConfiguration extends CoreConfiguration {
     @Default("io.mantisrx.runtime.loader.cgroups.CgroupsMetricsCollector")
     String getMetricsCollectorClassName();
 
+    @Config("mantis.taskexecutor.runtime.jobautoscalermanager")
+    @Default("io.mantisrx.server.worker.jobmaster.NoopJobAutoscalerManager")
+    String getJobAutoscalerManagerClassName();
+
     // ------------------------------------------------------------------------
     //  heartbeat connection related configurations
     // ------------------------------------------------------------------------

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationUtils.java
@@ -50,6 +50,7 @@ public class WorkerConfigurationUtils {
             .localStorageDir(configSource.getLocalStorageDir())
             .metricsCollector(configSource.getUsageSupplier())
             .metricsCollectorClass(configSource.getMetricsCollectorClassName())
+            .jobAutoscalerManagerClassName(configSource.getJobAutoscalerManagerClassName())
             .metricsPort(configSource.getMetricsPort())
             .metricsPublisher(configSource.getMetricsPublisher())
             .metricsPublisherFrequencyInSeconds(configSource.getMetricsPublisherFrequencyInSeconds())

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfigurationWritable.java
@@ -77,6 +77,7 @@ public class WorkerConfigurationWritable implements WorkerConfiguration {
     int asyncHttpClientReadTimeoutMs;
     String leaderMonitorFactory;
     String metricsCollectorClass;
+    String jobAutoscalerManagerClassName;
 
 
     @JsonIgnore


### PR DESCRIPTION
### Context

This will allow runtime control over autoscaler, toggling on/off decisions to scale up and scale down a mantis job stage.
A use-case for this could be disabling autoscaler during a failover period to disable scale down.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
