### PR TITLE
Ensure Master Monitor Can Read Lock ByteBuffer More than Once

### DIFF
--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitor.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitor.java
@@ -149,6 +149,11 @@ public class DynamoDBMasterMonitor extends BaseService implements MasterMonitor 
     }
 
     private MasterDescription bytesToMaster(ByteBuffer data) {
+        // It is possible that the underlying buffer is read more than once,
+        // so if the offset of the buffer is at the end, rewind, so we can read it.
+        if (!data.hasRemaining()) {
+            data.rewind();
+        }
         final byte[] bytes = new byte[data.remaining()];
         data.get(bytes);
         try {


### PR DESCRIPTION
It is possible that the DynamoDBMasterMonitor checks for the current leader more often than the underlying ByteBuffer is updated by the DynamoDB library.  In this case, we should rewind the buffer.

We can also optionally create a separate config for the lock client update and the monitor check leader interval to ensure check leader is called less frequently than the lock client updates.

### Context

Explain context and other details for this pull request.

### Checklist

- [X] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
