### PR TITLE
DynamoDB leadership election: return leadership success status

### DIFF
--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBStore.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBStore.java
@@ -165,7 +165,7 @@ public class DynamoDBStore implements IKeyValueStore {
         expressionAttributeValues.put(PK, AttributeValue.builder().s(tableName).build());
         expressionAttributeValues.put(SK, AttributeValue.builder().s(String.format("%s#%s", partitionKey, secondaryKey)).build());
         final DeleteItemRequest request = DeleteItemRequest.builder()
-                .tableName(tableName)
+                .tableName(this.mantisTable)
                 .key(expressionAttributeValues)
                 .build();
         final DeleteItemResponse response = this.client.deleteItem(request);


### PR DESCRIPTION
### Context
DynamoDB leadership election: return leadership success status in `tryToBecomeLeader`.

We would like to capture leadership metrics. This change allows users to extend the class and inject instrumentation of the `tryToBecomeLeader` loop.

Also, small bug fix for dynamoDB delete where we are using the incorrect tablename.

cc @kmg-stripe 

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
