### PR TITLE
DynamoDB Leader Monitor: On Next Should Always Provide MasterDescription

### DIFF
--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitor.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitor.java
@@ -144,7 +144,7 @@ public class DynamoDBMasterMonitor extends BaseService implements MasterMonitor 
                 (previousDescription == null) ? MASTER_NULL : previousDescription;
         if (!prev.equals(next)) {
             logger.info("leader changer information previous {} and next {}", prev.getHostname(), next.getHostname());
-            masterSubject.onNext(nextDescription);
+            masterSubject.onNext(next);
         }
     }
 


### PR DESCRIPTION
It appears that specifying null to the observer results in a weird terminal condition where all values after null are not observed.

ToDo(kmg): Need to verify this and create or add to the unit tests.

### Context

Explain context and other details for this pull request.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
