### PR TITLE
DynamoDB Leader Monitor: On Next Should Always Provide MasterDescription

### DIFF
--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitor.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitor.java
@@ -144,7 +144,7 @@ public class DynamoDBMasterMonitor extends BaseService implements MasterMonitor 
                 (previousDescription == null) ? MASTER_NULL : previousDescription;
         if (!prev.equals(next)) {
             logger.info("leader changer information previous {} and next {}", prev.getHostname(), next.getHostname());
-            masterSubject.onNext(nextDescription);
+            masterSubject.onNext(next);
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitor.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitor.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -43,7 +42,7 @@ public class DynamoDBMasterMonitor extends BaseService implements MasterMonitor 
 
     private static final Logger logger = LoggerFactory.getLogger(DynamoDBMasterMonitor.class);
 
-    private static final MasterDescription MASTER_NULL =
+    public static final MasterDescription MASTER_NULL =
             new MasterDescription("NONE", "localhost", -1, -1, -1, "uri://", -1, -1L);
     private final ThreadFactory monitorThreadFactory = r -> {
         Thread thread = new Thread(r);
@@ -66,7 +65,6 @@ public class DynamoDBMasterMonitor extends BaseService implements MasterMonitor 
     private final Duration gracefulShutdown;
 
     private final BehaviorSubject<MasterDescription> masterSubject;
-    private final AtomicReference<MasterDescription> latestMaster = new AtomicReference<>();
 
     private final ObjectMapper jsonMapper = DefaultObjectMapper.getInstance();
 
@@ -74,7 +72,7 @@ public class DynamoDBMasterMonitor extends BaseService implements MasterMonitor 
      * Creates a MasterMonitor backed by DynamoDB. This should be used if you are using a {@link DynamoDBLeaderElector}
      */
     public DynamoDBMasterMonitor() {
-        masterSubject = BehaviorSubject.create();
+        masterSubject = BehaviorSubject.create(MASTER_NULL);
         final DynamoDBConfig conf = DynamoDBClientSingleton.getDynamoDBConf();
         pollInterval = Duration.parse(conf.getDynamoDBLeaderHeartbeatDuration());
         gracefulShutdown = Duration.parse(conf.getDynamoDBMonitorGracefulShutdownDuration());
@@ -138,10 +136,8 @@ public class DynamoDBMasterMonitor extends BaseService implements MasterMonitor 
     }
 
     private void updateLeader(@Nullable MasterDescription nextDescription) {
-        final MasterDescription previousDescription = latestMaster.getAndSet(nextDescription);
+        final MasterDescription prev = Optional.ofNullable(masterSubject.getValue()).orElse(MASTER_NULL);
         final MasterDescription next = (nextDescription == null) ? MASTER_NULL : nextDescription;
-        final MasterDescription prev =
-                (previousDescription == null) ? MASTER_NULL : previousDescription;
         if (!prev.equals(next)) {
             logger.info("leader changer information previous {} and next {}", prev.getHostname(), next.getHostname());
             masterSubject.onNext(next);
@@ -173,6 +169,6 @@ public class DynamoDBMasterMonitor extends BaseService implements MasterMonitor 
     @Override
     @Nullable
     public MasterDescription getLatestMaster() {
-        return latestMaster.get();
+        return Optional.ofNullable(masterSubject.getValue()).orElse(MASTER_NULL);
     }
 }

--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/test/java/io/mantisrx/extensions/dynamodb/DynamoDBClientSingletonTest.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/test/java/io/mantisrx/extensions/dynamodb/DynamoDBClientSingletonTest.java
@@ -34,6 +34,8 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
+
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -128,7 +130,17 @@ public class DynamoDBClientSingletonTest {
             .atMost(Duration.ofSeconds(3L))
             .pollDelay(Duration.ofSeconds(1L))
             .untilAsserted(() -> assertEquals(leaders[2], monitor.getLatestMaster()));
-        testSubscriber.assertValues(leaders);
+
+        // We can, depending on timing, sometimes get a MASTER_NULL value which is safe to ignore.
+        MasterDescription[] actualLeaders = testSubscriber.getOnNextEvents().stream()
+            .filter(md -> md != DynamoDBMasterMonitor.MASTER_NULL)
+            .collect(Collectors.toList())
+            .toArray(new MasterDescription[]{});
+
+        assertEquals(leaders.length, actualLeaders.length);
+        assertEquals(leaders[0], actualLeaders[0]);
+        assertEquals(leaders[1], actualLeaders[1]);
+        assertEquals(leaders[2], actualLeaders[2]);
         monitor.shutdown();
 
         dynamoDb.createKVTable(table);

--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/test/java/io/mantisrx/extensions/dynamodb/DynamoDBClientSingletonTest.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/test/java/io/mantisrx/extensions/dynamodb/DynamoDBClientSingletonTest.java
@@ -35,7 +35,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;


### PR DESCRIPTION
This is an extension of @kmg-stripe 's fix in https://github.com/Netflix/mantis/pull/691 that is ready to merge.

### Context

The DynamoDBMasterMonitor had cases where it may propagate a `null` value when `getLatestMaster()` is called, despite having some protections against it. I've removed the `AtomicReference` to the latest and just rely on the `BehaviorSubject` to return the latest value.


### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
