### PR TITLE
Fix maven missing deps: upgrade nebula + gradle

### DIFF
--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -16,10 +16,12 @@ jobs:
         java: [ 8 ]
     name: CI with Java ${{ matrix.java }}
     steps:
+      - name: Setup Git
+        run: |
+          git config --global user.name "Mantis OSS Maintainers"
+          git config --global user.email "mantis-oss-dev@googlegroups.com"
+      - name: Setup jdk
       - uses: actions/checkout@v1
-      - run: |
-        git config --global user.name "Mantis OSS Maintainers"
-        git config --global user.email "mantis-oss-dev@googlegroups.com"
       - name: Setup jdk
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -20,7 +20,6 @@ jobs:
         run: |
           git config --global user.name "Mantis OSS Maintainers"
           git config --global user.email "mantis-oss-dev@googlegroups.com"
-      - name: Setup jdk
       - uses: actions/checkout@v1
       - name: Setup jdk
         uses: actions/setup-java@v1

--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -17,6 +17,9 @@ jobs:
     name: CI with Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v1
+      - run: |
+        git config --global user.name "Mantis OSS Maintainers"
+        git config --global user.email "mantis-oss-dev@googlegroups.com"
       - name: Setup jdk
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -12,10 +12,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Git
+        run: |
+          git config --global user.name "Mantis OSS Maintainers"
+          git config --global user.email "mantis-oss-dev@googlegroups.com"
       - uses: actions/checkout@v2
-      - run: |
-        git config --global user.name "Mantis OSS Maintainers"
-        git config --global user.email "mantis-oss-dev@googlegroups.com"
       - name: Setup jdk
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/nebula-publish.yml
+++ b/.github/workflows/nebula-publish.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: |
+        git config --global user.name "Mantis OSS Maintainers"
+        git config --global user.email "mantis-oss-dev@googlegroups.com"
       - name: Setup jdk
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -15,11 +15,12 @@ jobs:
     environment:
       name: Integrate Pull Request # Our protected environment variable
     steps:
-      - name: Checkout PR
-        uses: actions/checkout@v3
+      - name: Setup Git
         run: |
           git config --global user.name "Mantis OSS Maintainers"
           git config --global user.email "mantis-oss-dev@googlegroups.com"
+      - name: Checkout PR
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup jdk

--- a/.github/workflows/nebula-snapshot.yml
+++ b/.github/workflows/nebula-snapshot.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout PR
         uses: actions/checkout@v3
+        run: |
+          git config --global user.name "Mantis OSS Maintainers"
+          git config --global user.email "mantis-oss-dev@googlegroups.com"
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup jdk

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -39,6 +39,10 @@ jobs:
       packages: write
 
     steps:
+      - name: Setup Git
+        run: |
+          git config --global user.name "Mantis OSS Maintainers"
+          git config --global user.email "mantis-oss-dev@googlegroups.com"
       - name: Checkout PR
         uses: actions/checkout@v3
       - name: Setup jdk

--- a/baseline.gradle
+++ b/baseline.gradle
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-allprojects {
-    apply plugin: 'com.palantir.baseline-idea'
-}
+// allprojects {
+//     apply plugin: 'com.palantir.baseline-idea'
+// }
 
-subprojects {
-    // Currently, if any subproject applies the blanket Baseline plugin, it forces the Baseline plugin
-    // to be applied to ALL projects. And we are not prepared to address all of the build errors that
-    // occur as a result at this time.
+// subprojects {
+//     // Currently, if any subproject applies the blanket Baseline plugin, it forces the Baseline plugin
+//     // to be applied to ALL projects. And we are not prepared to address all of the build errors that
+//     // occur as a result at this time.
 
-    apply plugin: 'com.palantir.baseline-exact-dependencies'
-    apply plugin: 'com.palantir.baseline-format'
-}
+//     apply plugin: 'com.palantir.baseline-exact-dependencies'
+//     apply plugin: 'com.palantir.baseline-format'
+// }

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     dependencies {
         classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:11.5.0'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:11.+'
-        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.7-rc.1'
+        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.7-rc.3'
         classpath "io.freefair.gradle:lombok-plugin:6.+"
         classpath 'eu.appsatori:gradle-fatjar-plugin:0.3'
         classpath("com.github.johnrengelman:shadow:8.1.1")

--- a/build.gradle
+++ b/build.gradle
@@ -22,16 +22,17 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
         maven { url 'https://artifacts-oss.netflix.net/maven-oss-releases' }
+        maven { url 'https://artifacts-oss.netflix.net/maven-oss-candidates' }
     }
     dependencies {
-        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:10.6.0'
+        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:11.5.0'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:11.+'
-        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.+'
-        classpath "io.freefair.gradle:lombok-plugin:5.3.3.3"
+        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.6-rc.3'
+        classpath "io.freefair.gradle:lombok-plugin:6.+"
         classpath 'eu.appsatori:gradle-fatjar-plugin:0.3'
-        classpath("gradle.plugin.com.github.jengelman.gradle.plugins:shadow:7.0.0")
+        classpath("com.github.johnrengelman:shadow:8.1.1")
         classpath 'gradle.plugin.org.inferred:gradle-processors:3.3.0'
-        classpath 'com.palantir.baseline:gradle-baseline-java:4.0.0'
+        // classpath 'com.palantir.baseline:gradle-baseline-java:4.+'
         classpath 'com.bmuschko:gradle-docker-plugin:6.7.0'
         classpath "com.palantir.gradle.gitversion:gradle-git-version:3.0.0"
     }
@@ -104,9 +105,8 @@ project.snapshot.configure { finalizedBy printAllReleasedArtifacts }
 subprojects {
     apply plugin: 'java-library'
 
-    // Apply lombok plugin and disabled the default config file generation.
+    // Apply lombok plugin.
     apply plugin: "io.freefair.lombok"
-    generateLombokConfig.enabled = false
     lombok {
         version = "1.18.20"
     }
@@ -186,4 +186,4 @@ subprojects {
     }
 }
 
-apply from: file('baseline.gradle')
+// apply from: file('baseline.gradle')

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     dependencies {
         classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:11.5.0'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:11.+'
-        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.7-rc.3'
+        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.7-rc.4'
         classpath "io.freefair.gradle:lombok-plugin:6.+"
         classpath 'eu.appsatori:gradle-fatjar-plugin:0.3'
         classpath("com.github.johnrengelman:shadow:8.1.1")

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     dependencies {
         classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:11.5.0'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:11.+'
-        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.6-rc.3'
+        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.6-rc.4'
         classpath "io.freefair.gradle:lombok-plugin:6.+"
         classpath 'eu.appsatori:gradle-fatjar-plugin:0.3'
         classpath("com.github.johnrengelman:shadow:8.1.1")

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ buildscript {
     dependencies {
         classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:11.5.0'
         classpath 'com.netflix.nebula:nebula-dependency-recommender:11.+'
-        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.6-rc.4'
+        classpath 'io.mantisrx:mantis-gradle-plugin:1.2.7-rc.1'
         classpath "io.freefair.gradle:lombok-plugin:6.+"
         classpath 'eu.appsatori:gradle-fatjar-plugin:0.3'
         classpath("com.github.johnrengelman:shadow:8.1.1")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/mantis-connectors/mantis-connector-job/build.gradle
+++ b/mantis-connectors/mantis-connector-job/build.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-apply plugin: 'mantis'
-
 ext {
     gsonVersion = '2.8.+'
 }

--- a/mantis-connectors/mantis-connector-kafka/build.gradle
+++ b/mantis-connectors/mantis-connector-kafka/build.gradle
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-apply plugin: 'mantis'
-
 ext {
     archaiusVersion = '2.3.+'
     spectatorVersion = '0.82.+'

--- a/mantis-connectors/mantis-connector-publish/build.gradle
+++ b/mantis-connectors/mantis-connector-publish/build.gradle
@@ -27,3 +27,10 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+tasks.named('compileJava') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}
+tasks.named('delombok') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}

--- a/mantis-control-plane/mantis-control-plane-client/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-client/build.gradle
@@ -26,3 +26,10 @@ dependencies {
     testImplementation libraries.spectatorApi
     testImplementation(testFixtures(project(":mantis-common")))
 }
+
+tasks.named('compileJava') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}
+tasks.named('delombok') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}

--- a/mantis-control-plane/mantis-control-plane-core/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-core/build.gradle
@@ -59,3 +59,4 @@ task copyLibs(type: Copy) {
 }
 
 jar.dependsOn copyLibs
+compileTestFixturesJava.dependsOn copyLibs

--- a/mantis-control-plane/mantis-control-plane-dynamodb/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/build.gradle
@@ -68,3 +68,10 @@ test {
         maxRetries = 1
     }
 }
+
+tasks.named('compileJava') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}
+tasks.named('delombok') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -120,3 +120,10 @@ test {
         maxRetries = 1
     }
 }
+
+tasks.named('compileJava') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}
+tasks.named('delombok') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}

--- a/mantis-control-plane/mantis-control-plane-store/mantis-control-plane-store-dynamodb/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-store/mantis-control-plane-store-dynamodb/build.gradle
@@ -65,3 +65,10 @@ test {
         maxRetries = 1
     }
 }
+
+tasks.named('compileJava') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}
+tasks.named('delombok') {
+    dependsOn project(':mantis-control-plane:mantis-control-plane-core').tasks.named('jar')
+}

--- a/mantis-publish/mantis-publish-netty/build.gradle
+++ b/mantis-publish/mantis-publish-netty/build.gradle
@@ -40,7 +40,6 @@ test {
 }
 
 shadowJar {
-    classifier = null
     relocate('com.fasterxml', 'io.mantisrx.shaded.com.fasterxml')
     relocate('io.netty', 'io.mantisrx.shaded.io.netty')
     relocate('META-INF/native/libnetty', 'META-INF/native/libio_mantisrx_shaded_netty')

--- a/mantis-server/mantis-server-agent/build.gradle
+++ b/mantis-server/mantis-server-agent/build.gradle
@@ -87,5 +87,6 @@ docker {
 dockerSyncBuildContext.dependsOn(pushServerJob.getTasksByName("mantisZipArtifact", false))
 dockerSyncBuildContext.dependsOn(mantisExamplesSineFunctionMantisZipArtifact)
 dockerSyncBuildContext.dependsOn(installDist)
+dockerSyncBuildContext.dependsOn(project.tasks.processTestResources)
 
 mainClassName = "io.mantisrx.server.agent.AgentV2Main"

--- a/mantis-shaded/build.gradle
+++ b/mantis-shaded/build.gradle
@@ -71,7 +71,6 @@ dependencies {
 }
 
 shadowJar {
-    classifier = null
     configurations = [project.configurations.shaded]
 
     exclude 'META-INF/LICENSE'


### PR DESCRIPTION
### Context

To fix the removed maven dependencies, the Nebula oss version + gradle version needs to be updated.
* New gradle (8.x) is also causing error on the extra copyLibs task in control-plane-core which now requires explicit declaration on downstream consumers.
* Baseline plugin new version requires jdk17. Disable for now.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
