### PR TITLE
Rename LeadershipManagerZkImpl to LeadershipManagerImpl

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/LeadershipManagerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/LeadershipManagerImpl.java
@@ -34,9 +34,9 @@ import org.slf4j.LoggerFactory;
 import rx.functions.Func0;
 
 
-public class LeadershipManagerZkImpl implements ILeadershipManager {
+public class LeadershipManagerImpl implements ILeadershipManager {
 
-    private static final Logger logger = LoggerFactory.getLogger(LeadershipManagerZkImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(LeadershipManagerImpl.class);
     private final Gauge isLeaderGauge;
     private final Gauge isLeaderReadyGauge;
     private final AtomicBoolean firstTimeLeaderMode = new AtomicBoolean(false);
@@ -46,7 +46,7 @@ public class LeadershipManagerZkImpl implements ILeadershipManager {
     private volatile boolean isReady = false;
     private volatile Instant becameLeaderAt;
 
-    public LeadershipManagerZkImpl(final MasterConfiguration config,
+    public LeadershipManagerImpl(final MasterConfiguration config,
                                    final ServiceLifecycle serviceLifecycle) {
         this.config = config;
         this.serviceLifecycle = serviceLifecycle;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -119,7 +119,7 @@ public class MasterMain implements Service {
         try {
             ConfigurationProvider.initialize(configFactory);
             this.config = ConfigurationProvider.getConfig();
-            leadershipManager = new LeadershipManagerZkImpl(config, mantisServices);
+            leadershipManager = new LeadershipManagerImpl(config, mantisServices);
 
             Thread t = new Thread(this::shutdown);
             t.setDaemon(true);


### PR DESCRIPTION
### Context

LeadershipManagerZkImpl has no Zk dependencies. Therefore, we should rename it.

### Checklist

- [X] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [X] Extended README or added javadocs where applicable
