### PR TITLE
Client Should Not Retry 400

### DIFF
--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/BadRequestException.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/BadRequestException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.server.master.client;
+
+public class BadRequestException extends Exception {
+    public BadRequestException(String msg) {
+        super(String.format("Server returned bad request: %s", msg));
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
@@ -715,6 +715,12 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                                 JobIdNotFoundException notFoundException = new JobIdNotFoundException(jobId);
                                 retryObject.setErrorRef(notFoundException);
                                 return Observable.error(notFoundException);
+                            } else if (HttpResponseStatus.BAD_REQUEST.equals(response.getStatus())) {
+                                logger.error("GET assignmentresults bad request: {}", response.getStatus());
+                                BadRequestException badRequestException =
+                                    new BadRequestException(String.format("Error calling assignmentresults for jobId=%s", jobId));
+                                retryObject.setErrorRef(badRequestException);
+                                return Observable.error(badRequestException);
                             } else if (!HttpResponseStatus.OK.equals(response.getStatus())) {
                                 logger.error("GET assignmentresults failed: {}", response.getStatus());
                                 return Observable.error(new Exception(response.getStatus().reasonPhrase()));


### PR DESCRIPTION
### Context

We noticed that workers will retry `400` from the master.  This should fail fast with an error.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [X] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
