### PR TITLE
Fix WorkersByJobId: Filtered Workers Not Empty Check

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/persistence/KeyValueBasedPersistenceProvider.java
@@ -386,9 +386,11 @@ public class KeyValueBasedPersistenceProvider implements IMantisPersistenceProvi
                 })
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
-            workersByJobId
-                .computeIfAbsent(workers.get(0).getJobId(), k -> Lists.newArrayList())
-                .addAll(workers);
+            if(!workers.isEmpty()) {
+                workersByJobId
+                    .computeIfAbsent(workers.get(0).getJobId(), k -> Lists.newArrayList())
+                    .addAll(workers);
+            }
         }
         return workersByJobId;
     }


### PR DESCRIPTION
### Context

I forgot to update the previous PR with this fix.  We have enough cruft lying around from all of the churn, that we hit cases where we get a NPE when we cannot parse the worker payload in `getAllWorkersByJobId`.  This checks to ensure `workers` is not empty before referencing the first element of `workers`.

### Checklist

- [X] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
