### PR TITLE
Fixes to Source Job Connector and Master Monitor Logging

### DIFF
--- a/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/MantisClient.java
@@ -113,6 +113,12 @@ public class MantisClient {
         this.clientWrapper = clientWrapper;
     }
 
+    public MantisClient(HighAvailabilityServices haServices) {
+        haServices.awaitRunning();
+        clientWrapper = new MasterClientWrapper(haServices.getMasterClientApi());
+        this.disablePingFiltering = false;
+    }
+
     public MantisClient(MasterClientWrapper clientWrapper) {
         this(clientWrapper, false);
     }

--- a/mantis-client/src/main/java/io/mantisrx/client/MantisSSEJob.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/MantisSSEJob.java
@@ -23,6 +23,7 @@ import io.mantisrx.runtime.descriptor.SchedulingInfo;
 import io.mantisrx.runtime.parameter.Parameter;
 import io.mantisrx.runtime.parameter.SinkParameters;
 import io.mantisrx.server.master.client.ConditionalRetry;
+import io.mantisrx.server.master.client.HighAvailabilityServices;
 import io.mantisrx.server.master.client.NoSuchJobException;
 import io.reactivx.mantis.operators.DropOperator;
 import java.io.Closeable;
@@ -179,10 +180,6 @@ public class MantisSSEJob implements Closeable {
         private Observer<SinkConnectionsStatus> sinkConnectionsStatusObserver = null;
         private long dataRecvTimeoutSecs = 5;
 
-        public Builder(Properties properties) {
-            this(new MantisClient(properties));
-        }
-
         public Builder() {
             Properties properties = new Properties();
             properties.setProperty("mantis.zookeeper.connectionTimeMs", "1000");
@@ -191,8 +188,16 @@ public class MantisSSEJob implements Closeable {
             properties.setProperty("mantis.zookeeper.connectString", System.getenv("mantis.zookeeper.connectString"));
             properties.setProperty("mantis.zookeeper.root", System.getenv("mantis.zookeeper.root"));
             properties.setProperty("mantis.zookeeper.leader.announcement.path",
-                    System.getenv("mantis.zookeeper.leader.announcement.path"));
+                System.getenv("mantis.zookeeper.leader.announcement.path"));
             mantisClient = new MantisClient(properties);
+        }
+
+        public Builder(HighAvailabilityServices haServices) {
+            this(new MantisClient(haServices));
+        }
+
+        public Builder(Properties properties) {
+            this(new MantisClient(properties));
         }
 
         public Builder(MantisClient mantisClient) {

--- a/mantis-connectors/mantis-connector-job-source/build.gradle
+++ b/mantis-connectors/mantis-connector-job-source/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation project(":mantis-runtime")
     implementation project(":mantis-client")
     implementation project(":mantis-control-plane:mantis-control-plane-core")
+    implementation project(":mantis-control-plane:mantis-control-plane-client")
     implementation project(":mantis-publish:mantis-publish-core")
 
     implementation "com.google.code.gson:gson:$gsonVersion"

--- a/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/core/MantisSourceJobConnectorFactory.java
+++ b/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/core/MantisSourceJobConnectorFactory.java
@@ -19,6 +19,6 @@ package io.mantisrx.connector.job.core;
 public class MantisSourceJobConnectorFactory {
 
     public static MantisSourceJobConnector getConnector() {
-        return new MantisSourceJobConnector();
+        return new MantisSourceJobConnector(false);
     }
 }

--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/master/MasterDescription.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/master/MasterDescription.java
@@ -49,6 +49,9 @@ public class MasterDescription {
     private final long createTime;
     private final int consolePort;
 
+    public static final MasterDescription MASTER_NULL =
+        new MasterDescription("NONE", "localhost", -1, -1, -1, "uri://", -1, -1L);
+
     @JsonCreator
     @JsonIgnoreProperties(ignoreUnknown = true)
     public MasterDescription(

--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/test/java/io/mantisrx/extensions/dynamodb/DynamoDBClientSingletonTest.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/test/java/io/mantisrx/extensions/dynamodb/DynamoDBClientSingletonTest.java
@@ -132,7 +132,7 @@ public class DynamoDBClientSingletonTest {
 
         // We can, depending on timing, sometimes get a MASTER_NULL value which is safe to ignore.
         MasterDescription[] actualLeaders = testSubscriber.getOnNextEvents().stream()
-            .filter(md -> md != DynamoDBMasterMonitor.MASTER_NULL)
+            .filter(md -> md != MasterDescription.MASTER_NULL)
             .collect(Collectors.toList())
             .toArray(new MasterDescription[]{});
 

--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/test/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitorTest.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/test/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitorTest.java
@@ -15,7 +15,6 @@
  */
 package io.mantisrx.extensions.dynamodb;
 
-import static io.mantisrx.extensions.dynamodb.DynamoDBMasterMonitor.MASTER_NULL;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.times;
@@ -79,7 +78,7 @@ public class DynamoDBMasterMonitorTest {
         TestSubscriber<MasterDescription> testSubscriber = new TestSubscriber<>();
         m.getMasterObservable().subscribe(testSubscriber);
         m.start();
-        assertEquals(MASTER_NULL, m.getLatestMaster());
+        assertEquals(MasterDescription.MASTER_NULL, m.getLatestMaster());
         lockSupport.takeLock(lockKey, otherMaster);
         await()
                 .atLeast(DynamoDBLockSupportRule.heartbeatDuration)
@@ -93,7 +92,7 @@ public class DynamoDBMasterMonitorTest {
                 .pollDelay(DynamoDBLockSupportRule.heartbeatDuration)
                 .atMost(Duration.ofMillis(DynamoDBLockSupportRule.heartbeatDuration.toMillis()*2))
                 .untilAsserted(() -> assertEquals(m.getLatestMaster(), thatMaster));
-        testSubscriber.assertValues(MASTER_NULL, otherMaster, thatMaster);
+        testSubscriber.assertValues(MasterDescription.MASTER_NULL, otherMaster, thatMaster);
         m.shutdown();
     }
 
@@ -134,7 +133,7 @@ public class DynamoDBMasterMonitorTest {
             .atLeast(DynamoDBLockSupportRule.heartbeatDuration)
             .pollDelay(DynamoDBLockSupportRule.heartbeatDuration)
             .atMost(Duration.ofMillis(DynamoDBLockSupportRule.heartbeatDuration.toMillis()*2))
-            .untilAsserted(() -> assertEquals(MASTER_NULL, m.getLatestMaster()));
+            .untilAsserted(() -> assertEquals(MasterDescription.MASTER_NULL, m.getLatestMaster()));
         lockSupport.releaseLock(lockKey);
 
         m.shutdown();


### PR DESCRIPTION
1. All source job connectors have ZK config hard-coded due to parameter-less
`MantisSourceJobConnectorFactory`.  Configuring a `MantisClient` in this context
doesn't make sense, since we can reference the configured `HighAvailabilityServices`

2. `DynamoDBMasterMonitor` was erroneously logging parse errors when reading
leadership info from the DB.

3. `HighAvailabilityServicesImpl` was setting the leader state to NULL, which lead
to `ResourceClusterGatewayClient` constructing an invalid URI.  Updating to not
update the `ResourceClusterGatewayClient` when master is NULL.

### Context

Explain context and other details for this pull request.

### Checklist

- [X] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
