### PR TITLE
 use jobJarUrl instead of artifactName to avoid stripping path prefixes

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/proto/JobClusterProtoAdapter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/proto/JobClusterProtoAdapter.java
@@ -60,7 +60,9 @@ public class JobClusterProtoAdapter {
 
         final CreateJobClusterRequest request = new CreateJobClusterRequest(new JobClusterDefinitionImpl(
                 jd.getName(),
-                Arrays.asList(new JobClusterConfig(jd.getJobJarFileLocation().toString(),
+                Arrays.asList(new JobClusterConfig(
+                        jd.getJobJarFileLocation().toString(),
+                        jd.getJobJarFileLocation().toString(),
                         System.currentTimeMillis(),
                         jd.getVersion(),
                         jd.getSchedulingInfo()
@@ -180,11 +182,13 @@ public class JobClusterProtoAdapter {
 
         final UpdateJobClusterRequest request = new UpdateJobClusterRequest(new JobClusterDefinitionImpl(
                 jd.getName(),
-                Arrays.asList(new JobClusterConfig(jd.getJobJarFileLocation().toString(),
-                        System.currentTimeMillis(),
-                        jd.getVersion(),
-                        jd.getSchedulingInfo()
-                        )),
+                Arrays.asList(new JobClusterConfig(
+                    jd.getJobJarFileLocation().toString(),
+                    jd.getJobJarFileLocation().toString(),
+                    System.currentTimeMillis(),
+                    jd.getVersion(),
+                    jd.getSchedulingInfo()
+                    )),
                 njd.getOwner(),
                 jd.getUser(),
 
@@ -229,13 +233,13 @@ public class JobClusterProtoAdapter {
 
     public static final JobClusterManagerProto.SubmitJobRequest toSubmitJobClusterRequest(final MantisJobDefinition jd)
         throws InvalidJobException {
-
         final JobClusterManagerProto.SubmitJobRequest request = new JobClusterManagerProto.SubmitJobRequest(
             jd.getName(),
             jd.getUser(),
             new JobDefinition(
                 jd.getName(),
                 jd.getUser(),
+                (jd.getJobJarFileLocation() == null) ? "" : jd.getJobJarFileLocation().toString(),
                 (DataFormatAdapter.extractArtifactName(jd.getJobJarFileLocation())).orElse(""),
                 jd.getVersion(),
                 jd.getParameters(),

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
@@ -1511,6 +1511,7 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
         return
             new JobDefinition.Builder()
                 .withJobSla(new JobSla.Builder().build())
+                .withJobJarUrl(clusterConfig.getJobJarUrl())
                 .withArtifactName(clusterConfig.getArtifactName())
                 .withVersion(clusterConfig.getVersion())
                 .withLabels(clusterDefinition.getLabels())
@@ -1657,6 +1658,9 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
     private void validateJobDefinition(JobDefinition definition) throws InvalidJobRequestException {
         if (definition == null) {
             throw new InvalidJobRequestException("MantisJobDefinition cannot be null");
+        }
+        if (definition.getJobJarUrl() == null) {
+            throw new InvalidJobRequestException("MantisJobDefinition job jobJarUrl attribute cannot be null");
         }
         if (definition.getArtifactName() == null) {
             throw new InvalidJobRequestException("MantisJobDefinition job artifactName attribute cannot be null");
@@ -2174,6 +2178,7 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
                 return;
             }
             JobClusterConfig newConfig = new JobClusterConfig.Builder().from(jobClusterMetadata.getJobClusterDefinition().getJobClusterConfig())
+                // TODO(swada): do we need to add jobJarURL to UpdateJobClusterArtifactRequest as well?
                     .withArtifactName(artifactReq.getArtifactName())
                     .withVersion(artifactReq.getVersion())
                     .withUploadedAt(System.currentTimeMillis())

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
@@ -2178,7 +2178,7 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
                 return;
             }
             JobClusterConfig newConfig = new JobClusterConfig.Builder().from(jobClusterMetadata.getJobClusterDefinition().getJobClusterConfig())
-                // TODO(swada): do we need to add jobJarURL to UpdateJobClusterArtifactRequest as well?
+                    .withJobJarUrl(artifactReq.getjobJarUrl())
                     .withArtifactName(artifactReq.getArtifactName())
                     .withVersion(artifactReq.getVersion())
                     .withUploadedAt(System.currentTimeMillis())

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobDefinitionResolver.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobDefinitionResolver.java
@@ -89,34 +89,35 @@ public class JobDefinitionResolver {
         List<Label> labels = Collections.unmodifiableList(new ArrayList<>(labelMap.values()));
 
         String artifactName = resolvedJobDefn.getArtifactName();
+        String jobJarUrl = resolvedJobDefn.getJobJarUrl();
         SchedulingInfo schedulingInfo = resolvedJobDefn.getSchedulingInfo();
         String version = resolvedJobDefn.getVersion();
         JobClusterConfig jobClusterConfig = null;
 
-        if(!isNull(artifactName) && !isNull(version) && !schedulingInfoNotValid(schedulingInfo)) {
+        if(!isNull(artifactName) && !isNull(jobJarUrl) && !isNull(version) && !schedulingInfoNotValid(schedulingInfo)) {
             // update cluster ?
 
-        } else if(!isNull(artifactName) && !isNull(version) && schedulingInfoNotValid(schedulingInfo)) { // scheduling Info is not given while new artifact is specified
+        } else if(!isNull(artifactName) && !isNull(jobJarUrl) && !isNull(version) && schedulingInfoNotValid(schedulingInfo)) { // scheduling Info is not given while new artifact is specified
 
             // exception
             String msg = String.format("Scheduling info is not specified during Job Submit for cluster %s while new artifact is specified %s. Job Submit fails", jobClusterMetadata.getJobClusterDefinition().getName(), artifactName);
             logger.warn(msg);
             throw new Exception(msg);
 
-        } else if(!isNull(artifactName) && isNull(version) && !schedulingInfoNotValid(schedulingInfo)) { // artifact & schedulingInfo are given
+        } else if(!isNull(artifactName) && !isNull(jobJarUrl)&& isNull(version) && !schedulingInfoNotValid(schedulingInfo)) { // artifact & schedulingInfo are given
 
             // generate new version and update cluster
             version = String.valueOf(System.currentTimeMillis());
             // update cluster ?
 
-        } else if(!isNull(artifactName) && isNull(version) && schedulingInfoNotValid(schedulingInfo)) { // scheduling info not given while new artifact is specified
+        } else if(!isNull(artifactName) && !isNull(jobJarUrl) && isNull(version) && schedulingInfoNotValid(schedulingInfo)) { // scheduling info not given while new artifact is specified
 
             // exception
             String msg = String.format("Scheduling info is not specified during Job Submit for cluster %s while new artifact %s is specified. Job Submit fails", jobClusterMetadata.getJobClusterDefinition().getName(), artifactName);
             logger.warn(msg);
             throw new Exception(msg);
 
-        } else if(isNull(artifactName) && !isNull(version) && !schedulingInfoNotValid(schedulingInfo)) { // version is given & scheduling info is given
+        } else if(isNull(artifactName) && isNull(jobJarUrl) && !isNull(version) && !schedulingInfoNotValid(schedulingInfo)) { // version is given & scheduling info is given
 
             // fetch JobCluster config for version and validate the given schedulingInfo is compatible
             Optional<JobClusterConfig> clusterConfigForVersion = getJobClusterConfigForVersion(jobClusterMetadata, version);
@@ -135,8 +136,9 @@ public class JobDefinitionResolver {
             }
 
             artifactName = jobClusterConfig.getArtifactName();
+            jobJarUrl = jobClusterConfig.getJobJarUrl();
 
-        } else if(isNull(artifactName) && !isNull(version) && schedulingInfoNotValid(schedulingInfo)) { // Only version is given
+        } else if(isNull(artifactName) && isNull(jobJarUrl) && !isNull(version) && schedulingInfoNotValid(schedulingInfo)) { // Only version is given
 
             // fetch JobCluster config for version
             Optional<JobClusterConfig> clusterConfigForVersion = getJobClusterConfigForVersion(jobClusterMetadata, version);
@@ -149,14 +151,16 @@ public class JobDefinitionResolver {
             jobClusterConfig = clusterConfigForVersion.get();
             schedulingInfo = jobClusterConfig.getSchedulingInfo();
             artifactName = jobClusterConfig.getArtifactName();
+            jobJarUrl = jobClusterConfig.getJobJarUrl();
 
 
-        } else if(isNull(artifactName) && isNull(version) && !schedulingInfoNotValid(schedulingInfo)) { // only scheduling info is given
+        } else if(isNull(artifactName) && isNull(jobJarUrl) && isNull(version) && !schedulingInfoNotValid(schedulingInfo)) { // only scheduling info is given
 
             // fetch latest Job Cluster config
             jobClusterConfig = jobClusterMetadata.getJobClusterDefinition().getJobClusterConfig();
             version = jobClusterConfig.getVersion();
             artifactName = jobClusterConfig.getArtifactName();
+            jobJarUrl = jobClusterConfig.getJobJarUrl();
             // set version to it
             // validate given scheduling info is compatible
             if(!validateSchedulingInfo(schedulingInfo, jobClusterConfig.getSchedulingInfo(), jobClusterMetadata)) {
@@ -166,7 +170,7 @@ public class JobDefinitionResolver {
             }
 
 
-        } else if(isNull(artifactName) && isNull(version) && schedulingInfoNotValid(schedulingInfo)){ // Nothing is given. Use the latest on the cluster
+        } else if(isNull(artifactName) && isNull(jobJarUrl) && isNull(version) && schedulingInfoNotValid(schedulingInfo)){ // Nothing is given. Use the latest on the cluster
 
             // fetch latest job cluster config
             jobClusterConfig = jobClusterMetadata.getJobClusterDefinition().getJobClusterConfig();
@@ -175,16 +179,17 @@ public class JobDefinitionResolver {
             // use scheduling info from that.
             schedulingInfo = jobClusterConfig.getSchedulingInfo();
             artifactName = jobClusterConfig.getArtifactName();
+            jobJarUrl = jobClusterConfig.getJobJarUrl();
 
         } else {
             // exception should never get here.
-            throw new Exception(String.format("Invalid case for resolveJobDefinition artifactName %s version %s schedulingInfo %s", artifactName, version, schedulingInfo));
+            throw new Exception(String.format("Invalid case for resolveJobDefinition artifactName %s jobJarUrl %s version %s schedulingInfo %s", jobJarUrl, artifactName, version, schedulingInfo));
         }
 
-        logger.info("Resolved version {}, schedulingInfo {}, artifactName {}", version, schedulingInfo, artifactName);
+        logger.info("Resolved version {}, schedulingInfo {}, artifactName {}, jobJarUrl {}", version, schedulingInfo, artifactName, jobJarUrl);
 
-        if(isNull(artifactName) || isNull(version) || schedulingInfoNotValid(schedulingInfo)) {
-            String msg = String.format(" SchedulingInfo %s or artifact %s or version %s could not be resolved in JobCluster %s. Job Submit fails", schedulingInfo, artifactName, version, jobClusterMetadata.getJobClusterDefinition().getName());
+        if(isNull(artifactName)  || isNull(jobJarUrl)  || isNull(version) || schedulingInfoNotValid(schedulingInfo)) {
+            String msg = String.format(" SchedulingInfo %s or artifact %s or jobJarUrl %s or version %s could not be resolved in JobCluster %s. Job Submit fails", schedulingInfo, artifactName, jobJarUrl, version, jobClusterMetadata.getJobClusterDefinition().getName());
             logger.warn(msg);
             throw new Exception(msg);
         }
@@ -196,6 +201,7 @@ public class JobDefinitionResolver {
                 .withUser(user)
                 .withVersion(version)
                 .withArtifactName(artifactName)
+                .withJobJarUrl(jobJarUrl)
                 .build();
 
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
@@ -323,9 +323,8 @@ public class MantisJobMetadataImpl implements IMantisJobMetadata {
    	 */
    	@Deprecated @Override
    	public URL getJobJarUrl() {
-
    		try {
-            return DataFormatAdapter.generateURL(getArtifactName());
+            return new URL(jobDefinition.getJobJarUrl());
    		} catch (MalformedURLException e) {
    			// should not happen
    			throw new RuntimeException(e);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
@@ -525,6 +525,7 @@ public class JobClusterManagerProto {
 
     public static final class UpdateJobClusterArtifactRequest extends BaseRequest {
         private final String artifactName;
+        private final String jobJarUrl;
         private final String version;
         private final boolean skipSubmit;
         private final String user;
@@ -535,6 +536,7 @@ public class JobClusterManagerProto {
         public UpdateJobClusterArtifactRequest(
                 @JsonProperty("name") final String clusterName,
                 @JsonProperty("url") final String artifact,
+                @JsonProperty("jobJarUrl") final String jobJarUrl,
                 @JsonProperty("version") final String version,
                 @JsonProperty("skipsubmit") final boolean skipSubmit,
                 @JsonProperty("user") final String user) {
@@ -551,6 +553,7 @@ public class JobClusterManagerProto {
 
             this.clusterName = clusterName;
             this.artifactName = artifact;
+            this.jobJarUrl = jobJarUrl != null ? jobJarUrl : "http://" + artifact;
             this.version = version;
             this.skipSubmit = skipSubmit;
             this.user = user;
@@ -558,6 +561,10 @@ public class JobClusterManagerProto {
 
         public String getArtifactName() {
             return artifactName;
+        }
+
+        public String getjobJarUrl() {
+            return jobJarUrl;
         }
 
         public String getVersion() {
@@ -580,6 +587,7 @@ public class JobClusterManagerProto {
         public String toString() {
             return "UpdateJobClusterArtifactRequest{" +
                    "artifactName='" + artifactName + '\'' +
+                   "jobJarUrl='" + jobJarUrl + '\'' +
                    ", version='" + version + '\'' +
                    ", skipSubmit=" + skipSubmit +
                    ", user='" + user + '\'' +

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/DataFormatAdapter.java
@@ -151,11 +151,10 @@ public class DataFormatAdapter {
 
     public static NamedJob.Jar convertJobClusterConfigToJar(JobClusterConfig jConfig) throws MalformedURLException {
         SchedulingInfo sInfo = jConfig.getSchedulingInfo();
-        String name = jConfig.getArtifactName();
         long uploadedAt = jConfig.getUploadedAt();
         String version = jConfig.getVersion();
 
-        return new NamedJob.Jar(generateURL(name), uploadedAt, version, sInfo);
+        return new NamedJob.Jar(new URL(jConfig.getJobJarUrl()), uploadedAt, version, sInfo);
     }
 
     public static JobClusterConfig convertJarToJobClusterConfig(NamedJob.Jar jar ) {
@@ -164,13 +163,13 @@ public class DataFormatAdapter {
         Optional<String> artifactName = extractArtifactName(jar.getUrl());
         String version = jar.getVersion();
         return new JobClusterConfig.Builder()
+                .withJobJarUrl(jar.getUrl().toString())
                 .withArtifactName(artifactName.orElse(""))
                 .withVersion(version)
                 .withSchedulingInfo(jar.getSchedulingInfo())
                 .withUploadedAt(jar.getUploadedAt())
                 .build();
     }
-
 
 
     public static URL generateURL(String artifactName) throws MalformedURLException {
@@ -484,7 +483,7 @@ public class DataFormatAdapter {
 
         // generate job defn
         JobDefinition jobDefn = new JobDefinition(archJob.getName(), archJob.getUser(),
-                artifactName.orElse(""), null,archJob.getParameters(), archJob.getSla(),
+                jarUrl == null ? "" : jarUrl.toString(), artifactName.orElse(""), null, archJob.getParameters(), archJob.getSla(),
                 archJob.getSubscriptionTimeoutSecs(),schedulingInfo, archJob.getNumStages(),archJob.getLabels(), null);
         Optional<JobId> jIdOp = JobId.fromId(archJob.getJobId());
         if(!jIdOp.isPresent()) {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobClusterConfig.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobClusterConfig.java
@@ -109,8 +109,8 @@ public class JobClusterConfig {
         public Builder() {}
 
         public Builder withJobJarUrl(String jobJarUrl) {
-            Preconditions.checkNotNull(jobJarUrl, "artifactName cannot be null");
-            Preconditions.checkArgument(!jobJarUrl.isEmpty(), "ArtifactName cannot be empty");
+            Preconditions.checkNotNull(jobJarUrl, "jobJarUrl cannot be null");
+            Preconditions.checkArgument(!jobJarUrl.isEmpty(), "jobJarUrl cannot be empty");
             this.jobJarUrl = jobJarUrl;
             return this;
         }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobClusterConfig.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobClusterConfig.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 
 public class JobClusterConfig {
 
+    private final String jobJarUrl;
     private final String artifactName;
     private final String version;
     private final long uploadedAt;
@@ -34,12 +35,14 @@ public class JobClusterConfig {
 
     @JsonCreator
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public JobClusterConfig(@JsonProperty("artifactName") String artifactName,
+    public JobClusterConfig(@JsonProperty("jobJarUrl") String jobJarUrl,
+                            @JsonProperty("artifactName") String artifactName,
                             @JsonProperty("uploadedAt") long uploadedAt,
                             @JsonProperty("version") String version,
                             @JsonProperty("schedulingInfo") SchedulingInfo schedulingInfo
 
     ) {
+        this.jobJarUrl = jobJarUrl;
         this.artifactName = artifactName;
         this.uploadedAt = uploadedAt;
         this.version = (version == null || version.isEmpty()) ?
@@ -47,6 +50,10 @@ public class JobClusterConfig {
                 version;
         this.schedulingInfo = schedulingInfo;
 
+    }
+
+    public String getJobJarUrl() {
+        return jobJarUrl;
     }
 
     public String getArtifactName() {
@@ -68,7 +75,7 @@ public class JobClusterConfig {
 
     @Override
     public String toString() {
-        return "JobClusterConfig [artifactName=" + artifactName + ", version=" + version + ", uploadedAt=" + uploadedAt
+        return "JobClusterConfig [jobJarUrl=" + jobJarUrl + ", artifactName=" + artifactName + ", version=" + version + ", uploadedAt=" + uploadedAt
                 + ", schedulingInfo=" + schedulingInfo + "]";
     }
 
@@ -78,6 +85,7 @@ public class JobClusterConfig {
         if (o == null || getClass() != o.getClass()) return false;
         JobClusterConfig that = (JobClusterConfig) o;
         return uploadedAt == that.uploadedAt &&
+                Objects.equals(jobJarUrl, that.jobJarUrl) &&
                 Objects.equals(artifactName, that.artifactName) &&
                 Objects.equals(version, that.version) &&
                 Objects.equals(schedulingInfo, that.schedulingInfo);
@@ -86,11 +94,12 @@ public class JobClusterConfig {
     @Override
     public int hashCode() {
 
-        return Objects.hash(artifactName, version, uploadedAt, schedulingInfo);
+        return Objects.hash(jobJarUrl, artifactName, version, uploadedAt, schedulingInfo);
     }
 
     public static class Builder {
 
+        String jobJarUrl;
         String artifactName;
         String version;
         long uploadedAt = -1;
@@ -98,6 +107,13 @@ public class JobClusterConfig {
 
 
         public Builder() {}
+
+        public Builder withJobJarUrl(String jobJarUrl) {
+            Preconditions.checkNotNull(jobJarUrl, "artifactName cannot be null");
+            Preconditions.checkArgument(!jobJarUrl.isEmpty(), "ArtifactName cannot be empty");
+            this.jobJarUrl = jobJarUrl;
+            return this;
+        }
 
         public Builder withArtifactName(String artifactName) {
             Preconditions.checkNotNull(artifactName, "artifactName cannot be null");
@@ -126,6 +142,7 @@ public class JobClusterConfig {
         }
 
         public Builder from(JobClusterConfig config) {
+            jobJarUrl = config.getJobJarUrl();
             artifactName = config.getArtifactName();
             version = config.getVersion();
             uploadedAt = config.getUploadedAt();
@@ -135,11 +152,12 @@ public class JobClusterConfig {
 
         // TODO add validity checks for SchedulingInfo, MachineDescription etc
         public JobClusterConfig build() {
+            Preconditions.checkNotNull(jobJarUrl);
             Preconditions.checkNotNull(artifactName);
             Preconditions.checkNotNull(schedulingInfo);
             this.uploadedAt = (uploadedAt == -1) ? System.currentTimeMillis() : uploadedAt;
             this.version = (version == null || version.isEmpty()) ? "" + System.currentTimeMillis() : version;
-            return new JobClusterConfig(artifactName, uploadedAt, version, schedulingInfo);
+            return new JobClusterConfig(jobJarUrl, artifactName, uploadedAt, version, schedulingInfo);
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobDefinition.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobDefinition.java
@@ -55,6 +55,7 @@ public class JobDefinition {
 
     private final String name;
     private final String user;
+    private final String jobJarUrl;
     private final String artifactName;
     private final String version;
 
@@ -80,6 +81,7 @@ public class JobDefinition {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public JobDefinition(@JsonProperty("name") String name,
                          @JsonProperty("user") String user,
+                         @JsonProperty("jobJarUrl") String jobJarUrl,
                          @JsonProperty("artifactName") String artifactName,
                          @JsonProperty("version") String version,
                          @JsonProperty("parameters") List<Parameter> parameters,
@@ -124,6 +126,7 @@ public class JobDefinition {
                 Pair::getLeft,
                 Pair::getRight
             ));
+        this.jobJarUrl = jobJarUrl;
         postProcess();
         validate(true);
     }
@@ -225,6 +228,10 @@ public class JobDefinition {
         return user;
     }
 
+    public String getJobJarUrl() {
+        return jobJarUrl;
+    }
+
     public String getArtifactName() {
         return artifactName;
     }
@@ -301,6 +308,7 @@ public class JobDefinition {
 
         private List<Label> labels;
 
+        private String jobJarUrl = null;
         private String artifactName = null;
         private String version = null;
 
@@ -316,6 +324,11 @@ public class JobDefinition {
 
         public Builder withName(String name) {
             this.name = name;
+            return this;
+        }
+
+        public Builder withJobJarUrl(String jobJarUrl) {
+            this.jobJarUrl = jobJarUrl;
             return this;
         }
 
@@ -382,6 +395,7 @@ public class JobDefinition {
             this.withLabels(jobDefinition.getLabels());
             this.withName(jobDefinition.name);
             this.withArtifactName(jobDefinition.artifactName);
+            this.withJobJarUrl(jobDefinition.jobJarUrl);
             this.withVersion(jobDefinition.getVersion());
             return this;
         }
@@ -410,7 +424,7 @@ public class JobDefinition {
             }
             Preconditions.checkArgument(withNumberOfStages > 0, "Number of stages cannot be less than 0");
             return new JobDefinition(
-                    name, user, artifactName, version, parameters, jobSla,
+                    name, user, jobJarUrl, artifactName, version, parameters, jobSla,
                     subscriptionTimeoutSecs, schedulingInfo, withNumberOfStages, labels, deploymentStrategy);
         }
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/com/netflix/mantis/master/scheduler/TestHelpers.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/com/netflix/mantis/master/scheduler/TestHelpers.java
@@ -41,6 +41,7 @@ public class TestHelpers {
                                                             final MachineDefinition machineDefinition) {
         try {
         	JobDefinition jobDefinition = new JobDefinition.Builder()
+                .withJobJarUrl("http://jar")
                 .withArtifactName("jar")
                 .withSchedulingInfo(new SchedulingInfo(Collections.singletonMap(0,
                     StageSchedulingInfo.builder()

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -775,7 +775,7 @@ public class JobClusterAkkaTest {
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
 
-        UpdateJobClusterArtifactRequest req = new UpdateJobClusterArtifactRequest(clusterName, "a1", "1.0.1", true, "user");
+        UpdateJobClusterArtifactRequest req = new UpdateJobClusterArtifactRequest(clusterName, "a1", "http://a1", "1.0.1", true, "user");
 
         jobClusterActor.tell(req, probe.getRef());
         UpdateJobClusterArtifactResponse resp = probe.expectMsgClass(UpdateJobClusterArtifactResponse.class);
@@ -814,7 +814,7 @@ public class JobClusterAkkaTest {
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
 
-        UpdateJobClusterArtifactRequest req = new UpdateJobClusterArtifactRequest(clusterName, "a1", "0.0.1", true, "user");
+        UpdateJobClusterArtifactRequest req = new UpdateJobClusterArtifactRequest(clusterName, "a1", "http://a1", "0.0.1", true, "user");
 
         jobClusterActor.tell(req, probe.getRef());
         UpdateJobClusterArtifactResponse resp = probe.expectMsgClass(UpdateJobClusterArtifactResponse.class);
@@ -851,7 +851,7 @@ public class JobClusterAkkaTest {
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(SUCCESS, createResp.responseCode);
 
-        UpdateJobClusterArtifactRequest req = new UpdateJobClusterArtifactRequest(clusterName, "a1", "1.0.1", true, "user");
+        UpdateJobClusterArtifactRequest req = new UpdateJobClusterArtifactRequest(clusterName, "a1", "http://a1", "1.0.1", true, "user");
 
         jobClusterActor.tell(req, probe.getRef());
         UpdateJobClusterArtifactResponse resp = probe.expectMsgClass(UpdateJobClusterArtifactResponse.class);
@@ -875,7 +875,7 @@ public class JobClusterAkkaTest {
 
         // Update again
 
-        req = new UpdateJobClusterArtifactRequest(clusterName, "a2", "1.0.3", true, "user");
+        req = new UpdateJobClusterArtifactRequest(clusterName, "a2", "http:/a2", "1.0.3", true, "user");
 
         jobClusterActor.tell(req, probe.getRef());
         resp = probe.expectMsgClass(UpdateJobClusterArtifactResponse.class);
@@ -2058,7 +2058,7 @@ public class JobClusterAkkaTest {
             // Update artifact with skip submit = false
             String artifact = "newartifact.zip";
             String version = "0.0.2";
-            jobClusterActor.tell(new UpdateJobClusterArtifactRequest(clusterName, artifact, version,false, user), probe.getRef());
+            jobClusterActor.tell(new UpdateJobClusterArtifactRequest(clusterName, artifact, "http://" + artifact, version,false, user), probe.getRef());
             UpdateJobClusterArtifactResponse resp = probe.expectMsgClass(UpdateJobClusterArtifactResponse.class);
 
             // ensure new job was launched

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -222,8 +222,10 @@ public class JobClusterAkkaTest {
     }
 
     private JobClusterDefinitionImpl createFakeJobClusterDefn(String clusterName, List<Label> labels, SLA sla, SchedulingInfo schedulingInfo)  {
+        String artifactName = "myart";
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-                .withArtifactName("myart")
+                .withJobJarUrl("http://" + artifactName)
+                .withArtifactName(artifactName)
                 .withSchedulingInfo(schedulingInfo)
                 .withVersion("0.0.1")
                 .build();
@@ -303,6 +305,7 @@ public class JobClusterAkkaTest {
                 .withLabels(labelList)
                 .withSchedulingInfo(schedulingInfo)
                 .withDeploymentStrategy(deploymentStrategy)
+                .withJobJarUrl("http://" + artifactName)
                 .withArtifactName(artifactName)
                 .withVersion(artifactVersion)
                 .withSubscriptionTimeoutSecs(subsTimeoutSecs)
@@ -440,6 +443,7 @@ public class JobClusterAkkaTest {
         Label l = new Label("labelname","labelvalue");
         labels.add(l);
         String clusterName = "testJobClusterUpdateAndDelete";
+        String artifactName = "myart";
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, labels);
@@ -450,7 +454,8 @@ public class JobClusterAkkaTest {
 
 
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-                .withArtifactName("myart")
+                .withJobJarUrl("http://" + artifactName)
+                .withArtifactName(artifactName)
                 .withSchedulingInfo(SINGLE_WORKER_SCHED_INFO)
                 .withVersion("0.0.2")
                 .build();
@@ -1085,6 +1090,7 @@ public class JobClusterAkkaTest {
     public void testJobSubmitWithVersionAndNoSchedInfo() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithVersionAndNoSchedInfo";
+        String artifactName = "myart2";
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
@@ -1095,7 +1101,8 @@ public class JobClusterAkkaTest {
         assertEquals(SUCCESS, createResp.responseCode);
 
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-                .withArtifactName("myart2")
+                .withJobJarUrl("http://" + artifactName)
+                .withArtifactName(artifactName)
                 .withSchedulingInfo(TWO_WORKER_SCHED_INFO)
                 .withVersion("0.0.2")
                 .build();

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobDefinitionResolverTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobDefinitionResolverTest.java
@@ -93,15 +93,17 @@ public class JobDefinitionResolverTest {
 
         String version = "0.0.2";
         String artifactName = "myArt2";
+        String artifactUrl = "http://foo/bar/" + artifactName;
         SchedulingInfo schedulingInfo = TWO_WORKER_SCHED_INFO;
 
         try {
-            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl("http://" + artifactName).withArtifactName(artifactName).withName(clusterName).withSchedulingInfo(schedulingInfo).withVersion(version).build();
+            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl(artifactUrl).withArtifactName(artifactName).withName(clusterName).withSchedulingInfo(schedulingInfo).withVersion(version).build();
             JobDefinitionResolver resolver = new JobDefinitionResolver();
             JobDefinition resolvedJobDefinition = resolver.getResolvedJobDefinition("user", givenJobDefn, jobClusterMetadata);
 
             // assert the specified values are being used
             assertEquals(artifactName, resolvedJobDefinition.getArtifactName());
+            assertEquals(artifactUrl, resolvedJobDefinition.getJobJarUrl().toString());
             assertEquals(schedulingInfo, resolvedJobDefinition.getSchedulingInfo());
             assertEquals(version, resolvedJobDefinition.getVersion());
 
@@ -123,12 +125,13 @@ public class JobDefinitionResolverTest {
 
         // Only ArtifactName and schedInfo is specified
         try {
-            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl("http://" + artifactName).withArtifactName(artifactName).withName(clusterName).withSchedulingInfo(schedulingInfo).build();
+            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl(artifactUrl).withArtifactName(artifactName).withName(clusterName).withSchedulingInfo(schedulingInfo).build();
             JobDefinitionResolver resolver = new JobDefinitionResolver();
             JobDefinition resolvedJobDefinition = resolver.getResolvedJobDefinition("user", givenJobDefn, jobClusterMetadata);
 
             // assert the specified values are being used
             assertEquals(artifactName, resolvedJobDefinition.getArtifactName());
+            assertEquals(artifactUrl, resolvedJobDefinition.getJobJarUrl().toString());
             assertEquals(schedulingInfo, resolvedJobDefinition.getSchedulingInfo());
             // assert a version no was generated
             assertTrue(resolvedJobDefinition.getVersion()!= null && !resolvedJobDefinition.getVersion().isEmpty());
@@ -171,10 +174,11 @@ public class JobDefinitionResolverTest {
 
         String version = "0.0.2";
         String artifactName = "myArt2";
+        String artifactUrl = "http://foo/bar/" + artifactName;
 
         // Only new artifact and version is specified
         try {
-            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl("http://" + artifactName).withArtifactName(artifactName).withName(clusterName).withVersion(version).build();
+            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl(artifactUrl).withArtifactName(artifactName).withName(clusterName).withVersion(version).build();
             JobDefinitionResolver resolver = new JobDefinitionResolver();
             JobDefinition resolvedJobDefinition = resolver.getResolvedJobDefinition("user", givenJobDefn, jobClusterMetadata);
             fail();
@@ -228,6 +232,7 @@ public class JobDefinitionResolverTest {
 
             // artifact will get populated using the given version.
             assertEquals(DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getArtifactName());
+            assertEquals("http://" + DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getJobJarUrl().toString());
             // scheduling info will be the one specified by us
             assertEquals(schedulingInfo, resolvedJobDefinition.getSchedulingInfo());
             // version should match what we set.
@@ -257,6 +262,7 @@ public class JobDefinitionResolverTest {
 
             // assert the artifact is inherited
             assertEquals(DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getArtifactName());
+            assertEquals("http://" + DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getJobJarUrl().toString());
             // assert the scheduling info is inherited
             assertEquals(SINGLE_WORKER_SCHED_INFO, resolvedJobDefinition.getSchedulingInfo());
             // assert a version is the one we gave
@@ -312,6 +318,7 @@ public class JobDefinitionResolverTest {
 
             // artifact will get populated using the given version.
             assertEquals(DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getArtifactName());
+            assertEquals("http://" + DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getJobJarUrl().toString());
             // scheduling info will be the one specified by us
             assertEquals(schedulingInfo, resolvedJobDefinition.getSchedulingInfo());
             // version should match the latest on the cluster
@@ -341,6 +348,7 @@ public class JobDefinitionResolverTest {
 
             // assert the artifact is inherited
             assertEquals(DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getArtifactName());
+            assertEquals("http://" + DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getJobJarUrl().toString());
             // assert the scheduling info is inherited
             assertEquals(SINGLE_WORKER_SCHED_INFO, resolvedJobDefinition.getSchedulingInfo());
             // assert a version is the dfeault one.
@@ -371,6 +379,7 @@ public class JobDefinitionResolverTest {
 
             // assert the artifact is inherited
             assertEquals(DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getArtifactName());
+            assertEquals("http://" + DEFAULT_ARTIFACT_NAME, resolvedJobDefinition.getJobJarUrl().toString());
             // assert the scheduling info is inherited
             assertEquals(SINGLE_WORKER_SCHED_INFO, resolvedJobDefinition.getSchedulingInfo());
             // assert a version is the dfeault one.
@@ -467,6 +476,7 @@ public class JobDefinitionResolverTest {
         Optional<JobClusterConfig> config = resolver.getJobClusterConfigForVersion(jobClusterMetadata, DEFAULT_VERSION);
         assertTrue(config.isPresent());
         assertEquals(DEFAULT_ARTIFACT_NAME, config.get().getArtifactName());
+        assertEquals("http://" + DEFAULT_ARTIFACT_NAME, config.get().getJobJarUrl());
         assertEquals(DEFAULT_VERSION, config.get().getVersion());
         assertEquals(SINGLE_WORKER_SCHED_INFO, config.get().getSchedulingInfo());
 
@@ -474,6 +484,7 @@ public class JobDefinitionResolverTest {
         Optional<JobClusterConfig> config2 = resolver.getJobClusterConfigForVersion(jobClusterMetadata, "0.0.2");
         assertTrue(config2.isPresent());
         assertEquals("artifact2", config2.get().getArtifactName());
+        assertEquals("http://artifact2", config2.get().getJobJarUrl());
         assertEquals("0.0.2", config2.get().getVersion());
         assertEquals(TWO_WORKER_SCHED_INFO, config2.get().getSchedulingInfo());
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobDefinitionResolverTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobDefinitionResolverTest.java
@@ -57,6 +57,7 @@ public class JobDefinitionResolverTest {
 
     private JobClusterDefinitionImpl createFakeJobClusterDefn(String clusterName, List<Label> labels, List<Parameter> parameters, SLA sla, SchedulingInfo schedulingInfo)  {
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
+                .withJobJarUrl("http://" + DEFAULT_ARTIFACT_NAME)
                 .withArtifactName(DEFAULT_ARTIFACT_NAME)
                 .withSchedulingInfo(schedulingInfo)
                 .withVersion(DEFAULT_VERSION)
@@ -95,7 +96,7 @@ public class JobDefinitionResolverTest {
         SchedulingInfo schedulingInfo = TWO_WORKER_SCHED_INFO;
 
         try {
-            JobDefinition givenJobDefn = new JobDefinition.Builder().withArtifactName(artifactName).withName(clusterName).withSchedulingInfo(schedulingInfo).withVersion(version).build();
+            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl("http://" + artifactName).withArtifactName(artifactName).withName(clusterName).withSchedulingInfo(schedulingInfo).withVersion(version).build();
             JobDefinitionResolver resolver = new JobDefinitionResolver();
             JobDefinition resolvedJobDefinition = resolver.getResolvedJobDefinition("user", givenJobDefn, jobClusterMetadata);
 
@@ -122,7 +123,7 @@ public class JobDefinitionResolverTest {
 
         // Only ArtifactName and schedInfo is specified
         try {
-            JobDefinition givenJobDefn = new JobDefinition.Builder().withArtifactName(artifactName).withName(clusterName).withSchedulingInfo(schedulingInfo).build();
+            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl("http://" + artifactName).withArtifactName(artifactName).withName(clusterName).withSchedulingInfo(schedulingInfo).build();
             JobDefinitionResolver resolver = new JobDefinitionResolver();
             JobDefinition resolvedJobDefinition = resolver.getResolvedJobDefinition("user", givenJobDefn, jobClusterMetadata);
 
@@ -173,7 +174,7 @@ public class JobDefinitionResolverTest {
 
         // Only new artifact and version is specified
         try {
-            JobDefinition givenJobDefn = new JobDefinition.Builder().withArtifactName(artifactName).withName(clusterName).withVersion(version).build();
+            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl("http://" + artifactName).withArtifactName(artifactName).withName(clusterName).withVersion(version).build();
             JobDefinitionResolver resolver = new JobDefinitionResolver();
             JobDefinition resolvedJobDefinition = resolver.getResolvedJobDefinition("user", givenJobDefn, jobClusterMetadata);
             fail();
@@ -185,7 +186,7 @@ public class JobDefinitionResolverTest {
 
         // Only new artifact is specified
         try {
-            JobDefinition givenJobDefn = new JobDefinition.Builder().withArtifactName(artifactName).withName(clusterName).build();
+            JobDefinition givenJobDefn = new JobDefinition.Builder().withJobJarUrl("http://" + artifactName).withArtifactName(artifactName).withName(clusterName).build();
             JobDefinitionResolver resolver = new JobDefinitionResolver();
             JobDefinition resolvedJobDefinition = resolver.getResolvedJobDefinition("user", givenJobDefn, jobClusterMetadata);
             fail();
@@ -429,13 +430,16 @@ public class JobDefinitionResolverTest {
 
         String clusterName = "lookupJobClusterConfigTest";
         JobClusterConfig clusterConfig1 = new JobClusterConfig.Builder()
+                .withJobJarUrl("http://" + DEFAULT_ARTIFACT_NAME)
                 .withArtifactName(DEFAULT_ARTIFACT_NAME)
                 .withSchedulingInfo(SINGLE_WORKER_SCHED_INFO)
                 .withVersion(DEFAULT_VERSION)
                 .build();
 
+        String artifactName = "artifact2";
         JobClusterConfig clusterConfig2 = new JobClusterConfig.Builder()
-                .withArtifactName("artifact2")
+                .withJobJarUrl("http://" + artifactName)
+                .withArtifactName(artifactName)
                 .withSchedulingInfo(TWO_WORKER_SCHED_INFO)
                 .withVersion("0.0.2")
                 .build();

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/LabelManagerTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/LabelManagerTest.java
@@ -194,6 +194,7 @@ public class LabelManagerTest {
             .withParameters(Lists.newArrayList())
             .withLabels(labelList)
             .withSchedulingInfo(JobClusterAkkaTest.SINGLE_WORKER_SCHED_INFO)
+            .withJobJarUrl("http://" + artifactName)
             .withArtifactName(artifactName)
             .withVersion(version)
             .withSubscriptionTimeoutSecs(1)

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobClusterManagerAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobClusterManagerAkkaTest.java
@@ -1147,6 +1147,7 @@ public class JobClusterManagerAkkaTest {
         UpdateJobClusterArtifactRequest req = new JobClusterManagerProto.UpdateJobClusterArtifactRequest(
             clusterName,
             "myjar",
+            "http://myjar",
             "1.0.1",
             true,
             "user");

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobClusterManagerAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobClusterManagerAkkaTest.java
@@ -185,10 +185,10 @@ public class JobClusterManagerAkkaTest {
         final String name,
         List<Label> labels,
         WorkerMigrationConfig migrationConfig) {
-
+        String artifactName = "myart";
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-            .withArtifactName("myart")
-
+            .withJobJarUrl("http://" + artifactName)
+            .withArtifactName(artifactName)
             .withSchedulingInfo(new SchedulingInfo.Builder().numberOfStages(1)
                 .singleWorkerStageWithConstraints(
                     new MachineDefinition(
@@ -234,6 +234,7 @@ public class JobClusterManagerAkkaTest {
                     Lists.newArrayList(),
                     Lists.newArrayList())
                 .build())
+            .withJobJarUrl("http://myart")
             .withArtifactName("myart")
             .withSubscriptionTimeoutSecs(0)
             .withUser("njoshi")
@@ -1010,8 +1011,10 @@ public class JobClusterManagerAkkaTest {
             JobClusterManagerProto.CreateJobClusterResponse.class);
         assertEquals(SUCCESS_CREATED, createResp.responseCode);
 
+        String artifactName = "myart2";
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-            .withArtifactName("myart2")
+            .withJobJarUrl("http://" + artifactName)
+            .withArtifactName(artifactName)
             .withSchedulingInfo(TWO_WORKER_SCHED_INFO)
             .withVersion("0.0.2")
             .build();

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestHelper.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestHelper.java
@@ -120,9 +120,10 @@ public class JobTestHelper {
     }
 
     public static IJobClusterDefinition generateJobClusterDefinition(String name, SchedulingInfo schedInfo, WorkerMigrationConfig migrationConfig) {
+        String artifactName = "myart";
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-            .withArtifactName("myart")
-
+            .withJobJarUrl("http://" + artifactName)
+            .withArtifactName(artifactName)
             .withSchedulingInfo(schedInfo)
             .withVersion("0.0.1")
             .build();
@@ -148,6 +149,7 @@ public class JobTestHelper {
             .withParameters(Lists.newArrayList())
             .withLabels(Lists.newArrayList())
             .withSchedulingInfo(schedInfo)
+            .withJobJarUrl("http://myart")
             .withArtifactName("myart")
             .withSubscriptionTimeoutSecs(0)
             .withUser("njoshi")

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
@@ -238,6 +238,7 @@ public class JobTestLifecycle {
                     .withParameters(Lists.newArrayList())
                     .withLabels(Lists.newArrayList())
                     .withSchedulingInfo(schedInfo)
+                    .withJobJarUrl("http://myart")
                     .withArtifactName("myart")
                     .withSubscriptionTimeoutSecs(30)
                     .withUser("njoshi")

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
@@ -271,6 +271,8 @@ public class JobTestLifecycle {
             assertEquals(JobState.Accepted,resp.getJobMetadata().get().getState());
 
             assertTrue(resp.getJobMetadata().get().getStageMetadata(1).isPresent());
+            assertEquals(resp.getJobMetadata().get().getJobJarUrl().toString(), "http://myart");
+            assertEquals(resp.getJobMetadata().get().getArtifactName(), "myart");
 
             // send launched event
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
@@ -81,7 +81,7 @@ public class DataFormatAdapterTest {
         long uploadedAt = 1234l;
         String artifactName = "artifact1";
         String version = "0.0.1";
-        JobClusterConfig config = new JobClusterConfig(artifactName, uploadedAt, version, DEFAULT_SCHED_INFO);
+        JobClusterConfig config = new JobClusterConfig("http://" + artifactName, artifactName, uploadedAt, version, DEFAULT_SCHED_INFO);
 
         try {
             NamedJob.Jar convertedJar = DataFormatAdapter.convertJobClusterConfigToJar(config);
@@ -211,6 +211,7 @@ public class DataFormatAdapterTest {
 
         long uAt = 1234l;
         JobClusterConfig jobClusterConfig =  new JobClusterConfig.Builder()
+                .withJobJarUrl("http://" + artifactName)
                 .withArtifactName(artifactName)
                 .withSchedulingInfo(DEFAULT_SCHED_INFO)
                 .withVersion(version)
@@ -310,6 +311,7 @@ public class DataFormatAdapterTest {
 
         long uAt = 1234l;
         JobClusterConfig jobClusterConfig =  new JobClusterConfig.Builder()
+            .withJobJarUrl("http://" + artifactName)
             .withArtifactName(artifactName)
             .withSchedulingInfo(DEFAULT_SCHED_INFO)
             .withVersion(version)
@@ -835,6 +837,7 @@ public class DataFormatAdapterTest {
         JobSla jobSla = new JobSla(100,10,JobSla.StreamSLAType.Lossy,MantisJobDurationType.Perpetual,"userType");
 
         JobDefinition jobDefn = new JobDefinition.Builder()
+                                                    .withJobJarUrl("http://" + artifactName)
                                                     .withArtifactName(artifactName)
                                                     .withName(clusterName)
                                                     .withLabels(labels)

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/DataFormatAdapterTest.java
@@ -293,6 +293,7 @@ public class DataFormatAdapterTest {
         assertEquals(DEFAULT_SCHED_INFO,clusterConfig1.getSchedulingInfo());
         assertEquals(version,clusterConfig1.getVersion());
         assertEquals(artifactName, clusterConfig1.getArtifactName());
+        assertEquals("http://" + artifactName, clusterConfig1.getJobJarUrl());
 
     }
 
@@ -394,6 +395,7 @@ public class DataFormatAdapterTest {
         assertEquals(DEFAULT_SCHED_INFO,clusterConfig1.getSchedulingInfo());
         assertEquals(version,clusterConfig1.getVersion());
         assertEquals(artifactName, clusterConfig1.getArtifactName());
+        assertEquals("http://" + artifactName, clusterConfig1.getJobJarUrl());
 
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/JobClusterConfigTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/JobClusterConfigTest.java
@@ -31,16 +31,18 @@ import org.junit.Test;
 
 public class JobClusterConfigTest {
     private static final SchedulingInfo DEFAULT_SCHED_INFO = new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2), Lists.newArrayList(), Lists.newArrayList()).build();
+    private static final String DEFAULT_ARTIFACT_NAME = "myart";
+    private static final String DEFAULT_JOB_JAR_URL = "http://" + DEFAULT_ARTIFACT_NAME;
+
 
     @Test
     public void happyTest() {
         String name = "happyTest";
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-                .withArtifactName("myart")
-
+                .withJobJarUrl(DEFAULT_JOB_JAR_URL)
+                .withArtifactName(DEFAULT_ARTIFACT_NAME)
                 .withSchedulingInfo(DEFAULT_SCHED_INFO)
                 .withVersion("0.0.1")
-
                 .build();
         try {
             final JobClusterDefinitionImpl fakeJobCluster = new JobClusterDefinitionImpl.Builder()
@@ -60,10 +62,9 @@ public class JobClusterConfigTest {
     @Test(expected = Exception.class)
     public void noSchedInfoFails() {
         String name = "noSchedInfoFails";
-
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-                .withArtifactName("myart")
-
+                .withJobJarUrl(DEFAULT_JOB_JAR_URL)
+                .withArtifactName(DEFAULT_ARTIFACT_NAME)
                 .withSchedulingInfo(null)
                 .withVersion("0.0.1")
                 .build();
@@ -83,8 +84,8 @@ public class JobClusterConfigTest {
         String name = "noArtifactNameFails";
 
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
+                .withJobJarUrl(DEFAULT_JOB_JAR_URL)
                 .withArtifactName(null)
-
                 .withSchedulingInfo(DEFAULT_SCHED_INFO)
                 .withVersion("0.0.1")
                 .build();
@@ -98,13 +99,33 @@ public class JobClusterConfigTest {
                 .withMigrationConfig(WorkerMigrationConfig.DEFAULT)
                 .build();
     }
+
+    @Test(expected = Exception.class)
+    public void noJobJarUrlFails() {
+        String name = "noArtifactNameFails";
+        JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
+            .withJobJarUrl(null)
+            .withArtifactName(DEFAULT_ARTIFACT_NAME)
+            .withSchedulingInfo(DEFAULT_SCHED_INFO)
+            .withVersion("0.0.1")
+            .build();
+        final JobClusterDefinitionImpl fakeJobCluster = new JobClusterDefinitionImpl.Builder()
+            .withJobClusterConfig(clusterConfig)
+            .withName(name)
+            .withUser("nj")
+            .withParameters(Lists.newArrayList())
+            .withIsReadyForJobMaster(true)
+            .withOwner(new JobOwner("Nick", "Mantis", "desc", "nma@netflix.com", "repo"))
+            .withMigrationConfig(WorkerMigrationConfig.DEFAULT)
+            .build();
+    }
+
     @Test
     public void noVersionAutogenerate() {
         String name = "noArtifactNameFails";
-
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-                .withArtifactName("myart")
-
+                .withJobJarUrl(DEFAULT_JOB_JAR_URL)
+                .withArtifactName(DEFAULT_ARTIFACT_NAME)
                 .withSchedulingInfo(DEFAULT_SCHED_INFO)
                 .build();
         final JobClusterDefinitionImpl fakeJobCluster = new JobClusterDefinitionImpl.Builder()
@@ -125,8 +146,8 @@ public class JobClusterConfigTest {
     public void jobClusterDefnTest() {
         String name = "jobClusterDefnTest";
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-                .withArtifactName("myart")
-
+                .withJobJarUrl(DEFAULT_JOB_JAR_URL)
+                .withArtifactName(DEFAULT_ARTIFACT_NAME)
                 .withSchedulingInfo(DEFAULT_SCHED_INFO)
                 .withVersion("0.0.1")
                 .build();

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/JobClusterConfigTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/domain/JobClusterConfigTest.java
@@ -27,6 +27,7 @@ import io.mantisrx.runtime.WorkerMigrationConfig;
 import io.mantisrx.runtime.descriptor.SchedulingInfo;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 
 public class JobClusterConfigTest {
@@ -118,6 +119,32 @@ public class JobClusterConfigTest {
             .withOwner(new JobOwner("Nick", "Mantis", "desc", "nma@netflix.com", "repo"))
             .withMigrationConfig(WorkerMigrationConfig.DEFAULT)
             .build();
+    }
+
+    public void jobJarUrlMultiComponentPath() {
+        String name = "jobJarUrlMultiComponentPath";
+        JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
+            .withJobJarUrl("http://foo/bar/baz/" + DEFAULT_ARTIFACT_NAME)
+            .withArtifactName(DEFAULT_ARTIFACT_NAME)
+            .withSchedulingInfo(DEFAULT_SCHED_INFO)
+            .withVersion("0.0.1")
+            .build();
+        try {
+            final JobClusterDefinitionImpl fakeJobCluster = new JobClusterDefinitionImpl.Builder()
+                .withJobClusterConfig(clusterConfig)
+                .withName(name)
+                .withUser("nj")
+                .withParameters(Lists.newArrayList())
+                .withIsReadyForJobMaster(true)
+                .withOwner(new JobOwner("Nick", "Mantis", "desc", "nma@netflix.com", "repo"))
+                .withMigrationConfig(WorkerMigrationConfig.DEFAULT)
+                .withLabel(new Label(SystemLabels.MANTIS_RESOURCE_CLUSTER_NAME_LABEL.label, "testcluster"))
+                .build();
+
+            assertEquals(fakeJobCluster.getJobClusterConfig().getJobJarUrl(), "http://foo/bar/baz/" + DEFAULT_ARTIFACT_NAME);
+        } catch(Exception e) {
+            fail();
+        }
     }
 
     @Test

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/persistence/FileBasedStoreTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/server/master/persistence/FileBasedStoreTest.java
@@ -77,12 +77,12 @@ public class FileBasedStoreTest {
     }
 
     private JobClusterDefinitionImpl createFakeJobClusterDefn(String clusterName, List<Label> labels)  {
+        String artifactName = "myart";
         JobClusterConfig clusterConfig = new JobClusterConfig.Builder()
-                .withArtifactName("myart")
-
+                .withJobJarUrl("http://" + artifactName)
+                .withArtifactName(artifactName)
                 .withSchedulingInfo(new SchedulingInfo.Builder().numberOfStages(1).singleWorkerStageWithConstraints(new MachineDefinition(1, 10, 10, 10, 2), Lists.newArrayList(), Lists.newArrayList()).build())
                 .withVersion("0.0.1")
-
                 .build();
 
         return new JobClusterDefinitionImpl.Builder()


### PR DESCRIPTION
### Context
This is a fork of @sarahwada-stripe's PR (#706).  I'll take this over, since she is OOO.

@Andyz26 - I addressed the few comments in the original PR.  I'll get back to this next week and will add the requested backwards compatible tests.

I wanted to open a PR to kick off a discussion about the jobJarURL format that the mantis-master expects. It looks like the mantis-master expects the jobJarURL in the JobConfig to have a single path component, e.g. `https://my-job-jar.zip`, and drops path information when there are multiple path elements, e.g. `https://git-sha-prefix/my-job-jar.zip`.

A reproduction of the behavior that I've observed is:
1. Write a jobConfig with `jobJarFileLocation` like `https://git-sha-prefix/my-job-jar.zip`
2. Master submits a job to agent with the jobJarUrl `https://git-sha-prefix/my-job-jar.zip`
3. On master restart, the master strips the path prefixes, and persists the jobJarUrl `https://my-job-jar.zip` to the KV persistence store.
4. If a job is resubmitted to an agent, it's submitted with the jobJarUrl `https://my-job-jar.zip`.

I've narrowed down this behavior to a few places:
1. When a job is read from the KV store, various configurations (like `JobClusterConfig`) only store the **artifactName**, and do not store the full jobJarUrl.
2. When a job is sent to the agent or persisted, the master uses `generateURL(artifactName)` to generate the jobJarUrl, losing the path prefix information.

I'm curious if there is a deeper mantis or Netflix reason for this behavior, and if changing this behavior will break any other assumptions within Mantis. Also, FWIW we can't use a chained `PrefixedBlobStore` because these prefixes are dynamic.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable

Tested E2E on local mantis cluster (master + DynamoDB + agent)