### PR TITLE
Fix blobstore fallback error type

### DIFF
--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/BlobStore.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/BlobStore.java
@@ -118,7 +118,7 @@ public interface BlobStore extends Closeable {
             {
                 return blobStore.get(blobUrl);
             }
-            catch (IOException e) {
+            catch (Exception e) {
                 log.error("Get blob error, fallback to next blobstore", e);
             }
 


### PR DESCRIPTION
### Context

The underlying blob store use runtime exceptions for auth-related errors.
Switching catch to use base exception type.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
