### PR TITLE
MantisMasterClientApi: Handle HTTP 400 on GET assignmentresults

### DIFF
--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
@@ -715,6 +715,11 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                                 JobIdNotFoundException notFoundException = new JobIdNotFoundException(jobId);
                                 retryObject.setErrorRef(notFoundException);
                                 return Observable.error(notFoundException);
+                            } else if (HttpResponseStatus.BAD_REQUEST.equals(response.getStatus())) {
+                                logger.error("GET assignmentresults bad request: {}", response.getStatus());
+                                Exception ex = new Exception(response.getStatus().reasonPhrase());
+                                retryObject.setErrorRef(ex);
+                                return Observable.error(ex);
                             } else if (!HttpResponseStatus.OK.equals(response.getStatus())) {
                                 logger.error("GET assignmentresults failed: {}", response.getStatus());
                                 return Observable.error(new Exception(response.getStatus().reasonPhrase()));


### PR DESCRIPTION
### Context

In [some instances](https://github.com/Netflix/mantis/blob/1e29767d3517cd5763bf8c76cf707beb2e2c2760/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java#L1916) the `GET assignmentresults` request can return a 400. Presently the `MantisMasterClientApi` will abandon the `GET assignmentresults` request on a 404 response signaling the job does not exist, but it treats all other status codes as retryable and enters a retry loop that tops out at `INT_MAX`. 

We're observing the agent getting into a state where a thread is effectively looping forever calling this endpoint despite the fact that the rest of the job has shut down.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
