### PR TITLE
ConsistentHashingRouter: Use XXH3 instead of 4 byte ketama for consis…

### DIFF
--- a/mantis-network/build.gradle
+++ b/mantis-network/build.gradle
@@ -22,7 +22,7 @@ ext {
 dependencies {
     api "io.netty:netty-handler:$nettyVersion"
     implementation "io.mantisrx:mql-jvm:$mqlVersion"
-    implementation "net.openhft:zero-allocation-hashing:0.16"
+    implementation "net.openhft:zero-allocation-hashing:0.+"
     api project(':mantis-common')
     compileOnly libraries.spectatorApi
     testImplementation libraries.spectatorApi

--- a/mantis-network/build.gradle
+++ b/mantis-network/build.gradle
@@ -22,10 +22,11 @@ ext {
 dependencies {
     api "io.netty:netty-handler:$nettyVersion"
     implementation "io.mantisrx:mql-jvm:$mqlVersion"
+    implementation "net.openhft:zero-allocation-hashing:0.16"
     api project(':mantis-common')
     compileOnly libraries.spectatorApi
     testImplementation libraries.spectatorApi
-    
+
     testImplementation libraries.junitJupiter
     testImplementation libraries.mockitoCore
     testImplementation libraries.slf4jLog4j12

--- a/mantis-network/dependencies.lock
+++ b/mantis-network/dependencies.lock
@@ -4,31 +4,6 @@
             "locked": "1.18.20"
         }
     },
-    "baseline-exact-dependencies-main": {
-        "io.mantisrx:mql-jvm": {
-            "locked": "3.4.0"
-        }
-    },
-    "baseline-exact-dependencies-test": {
-        "com.netflix.spectator:spectator-api": {
-            "locked": "1.3.10"
-        },
-        "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.4.2"
-        },
-        "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.4.2"
-        },
-        "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.4.2"
-        },
-        "org.mockito:mockito-core": {
-            "locked": "2.0.111-beta"
-        },
-        "org.slf4j:slf4j-log4j12": {
-            "locked": "1.7.0"
-        }
-    },
     "compileClasspath": {
         "com.google.code.findbugs:jsr305": {
             "firstLevelTransitive": [
@@ -91,6 +66,9 @@
             ],
             "locked": "1.3.8"
         },
+        "net.openhft:zero-allocation-hashing": {
+            "locked": "0.16"
+        },
         "org.jctools:jctools-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -116,7 +94,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.10.5"
+            "locked": "1.1.10.7"
         }
     },
     "lombok": {
@@ -201,6 +179,9 @@
             ],
             "locked": "1.0"
         },
+        "net.openhft:zero-allocation-hashing": {
+            "locked": "0.16"
+        },
         "org.jctools:jctools-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -223,7 +204,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.10.5"
+            "locked": "1.1.10.7"
         }
     },
     "testAnnotationProcessor": {
@@ -293,6 +274,9 @@
             ],
             "locked": "1.3.8"
         },
+        "net.openhft:zero-allocation-hashing": {
+            "locked": "0.16"
+        },
         "org.jctools:jctools-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -330,7 +314,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.10.5"
+            "locked": "1.1.10.7"
         }
     },
     "testRuntimeClasspath": {
@@ -413,6 +397,9 @@
             ],
             "locked": "1.0"
         },
+        "net.openhft:zero-allocation-hashing": {
+            "locked": "0.16"
+        },
         "org.jctools:jctools-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
@@ -447,7 +434,7 @@
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-common"
             ],
-            "locked": "1.1.10.5"
+            "locked": "1.1.10.7"
         }
     }
 }

--- a/mantis-network/dependencies.lock
+++ b/mantis-network/dependencies.lock
@@ -67,7 +67,7 @@
             "locked": "1.3.8"
         },
         "net.openhft:zero-allocation-hashing": {
-            "locked": "0.16"
+            "locked": "0.26ea0"
         },
         "org.jctools:jctools-core": {
             "firstLevelTransitive": [
@@ -180,7 +180,7 @@
             "locked": "1.0"
         },
         "net.openhft:zero-allocation-hashing": {
-            "locked": "0.16"
+            "locked": "0.26ea0"
         },
         "org.jctools:jctools-core": {
             "firstLevelTransitive": [
@@ -275,7 +275,7 @@
             "locked": "1.3.8"
         },
         "net.openhft:zero-allocation-hashing": {
-            "locked": "0.16"
+            "locked": "0.26ea0"
         },
         "org.jctools:jctools-core": {
             "firstLevelTransitive": [
@@ -398,7 +398,7 @@
             "locked": "1.0"
         },
         "net.openhft:zero-allocation-hashing": {
-            "locked": "0.16"
+            "locked": "0.26ea0"
         },
         "org.jctools:jctools-core": {
             "firstLevelTransitive": [

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/HashFunctions.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/HashFunctions.java
@@ -18,6 +18,7 @@ package io.reactivex.mantis.network.push;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import net.openhft.hashing.LongHashFunction;
 
 
 public class HashFunctions {
@@ -35,6 +36,26 @@ public class HashFunctions {
                         | (bKey[0] & 0xFF);
             }
         };
+    }
+
+    public static HashFunction ketamaExtended() {
+        return new HashFunction() {
+            @Override
+            public long computeHash(byte[] keyBytes) {
+                byte[] bKey = computeMd5(keyBytes);
+                return ((long) (bKey[6] & 0xFF) << 48)
+                    | ((long) (bKey[5] & 0xFF) << 40)
+                    | ((long) (bKey[4] & 0xFF) << 32)
+                    | ((long) (bKey[3] & 0xFF) << 24)
+                    | ((long) (bKey[2] & 0xFF) << 16)
+                    | ((long) (bKey[1] & 0xFF) << 8)
+                    | (bKey[0] & 0xFF);
+            }
+        };
+    }
+
+    public static HashFunction xxh3() {
+        return bytes -> LongHashFunction.xx3().hashBytes(bytes);
     }
 
     public static byte[] computeMd5(byte[] keyBytes) {

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/HashFunctions.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/HashFunctions.java
@@ -38,22 +38,6 @@ public class HashFunctions {
         };
     }
 
-    public static HashFunction ketamaExtended() {
-        return new HashFunction() {
-            @Override
-            public long computeHash(byte[] keyBytes) {
-                byte[] bKey = computeMd5(keyBytes);
-                return ((long) (bKey[6] & 0xFF) << 48)
-                    | ((long) (bKey[5] & 0xFF) << 40)
-                    | ((long) (bKey[4] & 0xFF) << 32)
-                    | ((long) (bKey[3] & 0xFF) << 24)
-                    | ((long) (bKey[2] & 0xFF) << 16)
-                    | ((long) (bKey[1] & 0xFF) << 8)
-                    | (bKey[0] & 0xFF);
-            }
-        };
-    }
-
     public static HashFunction xxh3() {
         return bytes -> LongHashFunction.xx3().hashBytes(bytes);
     }

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/Routers.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/Routers.java
@@ -45,7 +45,7 @@ public class Routers {
                                 .put(valueBytes) // value bytes
                                 .array();
             }
-        }, HashFunctions.ketama());
+        }, HashFunctions.xxh3());
     }
 
     private static byte[] dataPayload(byte[] data) {

--- a/mantis-network/src/test/java/io/reactivex/mantis/network/push/ConsistentHashingRouterTest.java
+++ b/mantis-network/src/test/java/io/reactivex/mantis/network/push/ConsistentHashingRouterTest.java
@@ -78,6 +78,25 @@ public class ConsistentHashingRouterTest {
         assertEquals(ringEntries.size(), ring.size());
     }
 
+    @Test
+    public void shouldNotHaveHashCollisionsLargeJob() {
+
+        int numberOfRingEntriesPerSlot = 1000;
+        List<String> ringEntries = generateStageToStageSlots("2", 500, 4)
+            .stream()
+            .flatMap(slot -> IntStream.range(0, numberOfRingEntriesPerSlot)
+                .boxed()
+                .map(entryNum -> slot + "-" + entryNum))
+            .collect(Collectors.toList());
+
+        HashFunction hashFunction = HashFunctions.xxh3();
+
+        Set<Long> ring = new HashSet<>();
+        ringEntries.stream().forEach(entry -> ring.add(hashFunction.computeHash(entry.getBytes())));
+
+        assertEquals(ringEntries.size(), ring.size());
+    }
+
     /**
      * Generates slot ids that look the same as those that come from mantis stages.
      * Example: stage_2_index_38_partition_1

--- a/mantis-network/src/test/java/io/reactivex/mantis/network/push/ConsistentHashingRouterTest.java
+++ b/mantis-network/src/test/java/io/reactivex/mantis/network/push/ConsistentHashingRouterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.mantis.network.push;
+
+import org.junit.jupiter.api.Test;
+import rx.subjects.PublishSubject;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConsistentHashingRouterTest {
+
+    @Test
+    public void shouldNotHaveHashCollisionsUsingKetamaExtended() {
+        final AtomicLong hashInvocationCounter = new AtomicLong(0);
+        HashFunction instrumentedKetama = bytes -> {
+            hashInvocationCounter.getAndIncrement();
+            return HashFunctions.ketamaExtended().computeHash(bytes);
+        };
+
+        ConsistentHashingRouter<String, String> router = new ConsistentHashingRouter<>("test-router", x -> x.getKeyBytes(), instrumentedKetama);
+
+        PublishSubject<List<byte[]>> subj = PublishSubject.create();
+        Set<AsyncConnection<KeyValuePair<String, String>>> connections = generateStageToStageSlots("2", 40, 2).stream()
+            .map(slot -> new AsyncConnection<KeyValuePair<String, String>>("fakehost", 123456, slot, slot, "test-group", subj, x -> true))
+            .collect(Collectors.toSet());
+
+        List<KeyValuePair<String, String>> data = new ArrayList<>();
+        data.add(new KeyValuePair<>(12345, "12345".getBytes(), "test-value"));
+
+        router.route(connections, data);
+        router.route(connections, data);
+
+        // We should perform 1000 hashes per connection, and used a cached value on subsequent calls
+        assertEquals(connections.size() * 1000, hashInvocationCounter.get());
+    }
+
+    @Test
+    public void shouldNotHaveHashCollisionsStageToStage() {
+
+        int numberOfRingEntriesPerSlot = 1000;
+        List<String> ringEntries = generateStageToStageSlots("2", 40, 2)
+            .stream()
+            .flatMap(slot -> IntStream.range(0, numberOfRingEntriesPerSlot)
+                .boxed()
+                .map(entryNum -> slot + "-" + entryNum))
+            .collect(Collectors.toList());
+
+        HashFunction hashFunction = HashFunctions.xxh3();
+
+        Set<Long> ring = new HashSet<>();
+        ringEntries.stream().forEach(entry -> ring.add(hashFunction.computeHash(entry.getBytes())));
+
+        assertEquals(ringEntries.size(), ring.size());
+    }
+
+    /**
+     * Generates slot ids that look the same as those that come from mantis stages.
+     * Example: stage_2_index_38_partition_1
+     * @param stage The stage number as a string.
+     * @param indices The number of indices. Typically the number of workers in said stage.
+     * @param partitions The number of partitions the stage uses when connecting upstream.
+     * @return A List of slotId / AsyncConnection id values for use in testing.
+     */
+    private List<String> generateStageToStageSlots(String stage, int indices, int partitions) {
+        return IntStream.range(0, indices).boxed().map(index -> "stage_" + stage + "_index_" + index)
+            .flatMap(prefix -> IntStream.range(1, partitions+1).boxed().map(partition -> prefix + "_partition_" + partition))
+            .collect(Collectors.toList());
+    }
+}

--- a/mantis-network/src/test/java/io/reactivex/mantis/network/push/ConsistentHashingRouterTest.java
+++ b/mantis-network/src/test/java/io/reactivex/mantis/network/push/ConsistentHashingRouterTest.java
@@ -39,7 +39,7 @@ public class ConsistentHashingRouterTest {
         final AtomicLong hashInvocationCounter = new AtomicLong(0);
         HashFunction instrumentedKetama = bytes -> {
             hashInvocationCounter.getAndIncrement();
-            return HashFunctions.ketamaExtended().computeHash(bytes);
+            return HashFunctions.xxh3().computeHash(bytes);
         };
 
         ConsistentHashingRouter<String, String> router = new ConsistentHashingRouter<>("test-router", x -> x.getKeyBytes(), instrumentedKetama);


### PR DESCRIPTION
Eliminates a repeatable hash collision with a 40 worker stage 2. We can either go with extending the bits in `ketama` or using `xxh3`. I'm recommending `xxh3`. 

### Context
We ran into hash collisions when hashing slots on a 40 worker stage 2. This was a bit unexpected but very repeatable in the unit tests. If either of the unit tests added are run with the `ketama` hash function used in Mantis by default the tests will fail. One test will compute 40,000 hashes per call to `route`. The other will compute 39999 unique hashes from 40000 ring buffer entries. The values used are real values generated by a 40 worker stage 2 on a `GroupToScalar` stage.

**Note for Netflix**: I'd check logs from stage 1 of any of your jobs that have over 28 or more indices on the second stage. Its very likely that the difference in resource cluster types (you're using higher CPU to Network ratio boxes as well as Intel vs our ARM) is hiding the fact that some jobs might be doing ring recomputation on every chunk send. You should see the log line `Recomputing ring due to difference in number of connections versus cache` being spammed very frequently on impacted jobs.

Our investigation shows:

```
stage_2_index_28_partition_1-241 collided with: 
stage_2_index_2_partition_2-213
stage_2_index_6_partition_1-126 collided with: 
stage_2_index_34_partition_2-876
```

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
