### PR TITLE
Increase mantis.sse.numConsumerThreads maximum from 8 to 64.

### DIFF
--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/ParameterUtils.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/ParameterUtils.java
@@ -128,7 +128,7 @@ public class ParameterUtils {
 
         ParameterDefinition<Integer> sse_numConsumerThreads = new IntParameter()
                 .name("mantis.sse.numConsumerThreads")
-                .validator(Validators.range(1, 8))
+                .validator(Validators.range(1, 64))
                 .description("number of consumer threads draining the queue to write to SSE")
                 .defaultValue(1)
                 .build();


### PR DESCRIPTION
### Context
We're experimenting with increasing the throughput of our "Ingest" (source) jobs. Typical rules of thumb on thread pool sizes for IO bound task are generally larger than the number of CPUs available as IO threads spend a lot of time waiting (not CPU bound). We're also using 8 vCPU boxes but I figured there was little harm in adding a lot of headroom.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
