### PR TITLE
Change Job discovery to use most recent launched job

### DIFF
--- a/mantis-testcontainers/src/test/java/TestContainerHelloWorld.java
+++ b/mantis-testcontainers/src/test/java/TestContainerHelloWorld.java
@@ -226,6 +226,7 @@ public class TestContainerHelloWorld {
         }
 
         // test sse
+        Thread.sleep(Duration.ofSeconds(5).toMillis());
         String cmd = "curl -N -H \"Accept: text/event-stream\"  \"localhost:5055\" & sleep 3; kill $!";
         Container.ExecResult lsResult = agent0.execInContainer("bash", "-c", cmd);
         String stdout = lsResult.getStdout();


### PR DESCRIPTION
### Context
I would like to revive this [PR](https://github.com/Netflix/mantis/pull/549) from @hmitnflx to use the last launched job state instead of the last submitted to avoid downstream consumer jobs being stuck with a new submission at an error state or too long time to allocate resources.

* Replace discovery subject source from last submitted to last launched.
* Fixed and added UT.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
