### PR TITLE
Use XXH3 when hashing values for MantisGroups

### DIFF
--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/WorkerPublisherRemoteObservable.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/WorkerPublisherRemoteObservable.java
@@ -146,12 +146,12 @@ public class WorkerPublisherRemoteObservable<T> implements WorkerPublisher<T> {
         if (stage instanceof ScalarToGroup || stage instanceof GroupToGroup) {
             return PushServers.infiniteStreamLegacyTcpNestedMantisGroup(
                 config, (Observable) toServe, expiryTimeInSecs, keyEncoder,
-                HashFunctions.ketama());
+                HashFunctions.xxh3());
         }
         // ScalarToKey or KeyTKey
         return PushServers.infiniteStreamLegacyTcpNestedGroupedObservable(
             config, (Observable) toServe, expiryTimeInSecs, keyEncoder,
-            HashFunctions.ketama());
+            HashFunctions.xxh3());
     }
 
     private boolean useSpsc() {


### PR DESCRIPTION
### Context
Uses the XXH3 hash function for hashing keys onto the ring. I incorrectly assumed that the uniformity assumption in both hash functions would make `ketama` hash correctly onto the `XXH3` ring but that has not been what we're seeing.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
