### PR TITLE
Prevent per-node scheduling fallback during batch scheduling retry 

### DIFF
--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: |
             - ${{ runner.os }}-gradlewrapper-
       - name: Build with Gradle
-        run: ./gradlew --info --stacktrace build --warning-mode=all
+        run: ./gradlew --info --stacktrace build akkatest --warning-mode=all
         env:
           CI_NAME: github_actions
           CI_BUILD_NUMBER: ${{ github.sha }}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareSchedulerActor.java
@@ -173,18 +173,14 @@ class ResourceClusterAwareSchedulerActor extends AbstractActorWithTimers {
 
     private void onFailedToBatchScheduleRequestEvent(FailedToBatchScheduleRequestEvent event) {
         batchSchedulingFailures.increment();
-        if (event.getAttempt() >= this.maxScheduleRetries) {
-            log.error("Failed to submit the batch request {} because of ", event.getScheduleRequestEvent(), event.getThrowable());
-        } else {
-            Duration timeout = Duration.ofMillis(intervalBetweenRetries.toMillis());
-            log.error("Failed to submit the request {}; Retrying in {} because of ",
-                event.getScheduleRequestEvent(), timeout, event.getThrowable());
+        Duration timeout = Duration.ofMillis(intervalBetweenRetries.toMillis());
+        log.warn("BatchScheduleRequest failed to allocate resource: {}; Retrying in {} because of ",
+            event.getScheduleRequestEvent(), timeout, event.getThrowable());
 
-            getTimers().startSingleTimer(
-                getBatchSchedulingQueueKeyFor(event.getScheduleRequestEvent().getJobId()),
-                event.onRetry(),
-                timeout);
-        }
+        getTimers().startSingleTimer(
+            getBatchSchedulingQueueKeyFor(event.getScheduleRequestEvent().getJobId()),
+            event.onRetry(),
+            timeout);
     }
 
     private void onScheduleRequestEvent(ScheduleRequestEvent event) {

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -56,6 +56,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -114,7 +115,14 @@ import io.mantisrx.server.core.JobCompletedReason;
 import io.mantisrx.server.core.Status;
 import io.mantisrx.server.core.Status.TYPE;
 import io.mantisrx.server.core.domain.WorkerId;
-import io.mantisrx.server.master.domain.*;
+import io.mantisrx.server.master.domain.DataFormatAdapter;
+import io.mantisrx.server.master.domain.IJobClusterDefinition;
+import io.mantisrx.server.master.domain.JobClusterConfig;
+import io.mantisrx.server.master.domain.JobClusterDefinitionImpl;
+import io.mantisrx.server.master.domain.JobClusterDefinitionImpl.CompletedJob;
+import io.mantisrx.server.master.domain.JobDefinition;
+import io.mantisrx.server.master.domain.JobId;
+import io.mantisrx.server.master.domain.SLA;
 import io.mantisrx.server.master.persistence.IMantisPersistenceProvider;
 import io.mantisrx.server.master.persistence.KeyValueBasedPersistenceProvider;
 import io.mantisrx.server.master.persistence.MantisJobStore;
@@ -123,6 +131,7 @@ import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.server.master.scheduler.WorkerEvent;
 import io.mantisrx.server.master.store.FileBasedStore;
 import io.mantisrx.server.master.store.NamedJob;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableList;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
 import java.io.File;
 import java.time.Duration;
@@ -643,6 +652,18 @@ public class JobClusterAkkaTest {
                     .withJobDefinition(jobDefn)
                     .withJobState(JobState.Completed)
                     .build();
+            when(jobStoreMock.loadCompletedJobsForCluster(any(), anyInt(), any()))
+                // .thenReturn(ImmutableList.of());
+                .thenReturn(ImmutableList.of(
+                    new CompletedJob(
+                        completedJobMock.getClusterName(),
+                        completedJobMock.getJobId().getId(),
+                        "v1",
+                        JobState.Completed,
+                        -1L,
+                        -1L,
+                        completedJobMock.getUser(),
+                        completedJobMock.getLabels())));
             when(jobStoreMock.getArchivedJob(any())).thenReturn(of(completedJobMock));
             doAnswer((Answer) invocation -> {
                 storeCompletedCalled.countDown();

--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/MantisHttpClientImpl.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/MantisHttpClientImpl.java
@@ -81,7 +81,7 @@ public class MantisHttpClientImpl<I, O> extends HttpClientImpl<I, O> {
     }
 
     protected void trackConnection(Channel channel) {
-        log.info("Tracking connection: {}", channel.toString());
+        log.debug("Tracking connection: {}", channel.toString());
         synchronized (connectionTracker) {
             if (isClosed.get()) {
                 log.info("Http client is already closed. Close the channel immediately. {}", channel);


### PR DESCRIPTION
### Context
Currently, when a new job gets submitted, all the workers get scheduled in batch to have an all-or-nothing manner. However, the job actor heartbeat check will also try to re-schedule a worker if it's "stuck" in the allocation phase for too long (based on the worker-heartbeat-timeout config). Thus the batch scheduling gets invalidated after some timeout (which could be problematic for larger jobs when we need more time to get the requested resource allocated from the cluster auto scaler).

Behavior changes here:
* Batch scheduling failure will retry without attempt limit. (We will rely on the cancel request message from its job actor to interrupt).
* JobActor heartbeat routine will not act on unscheduled workers.
* fixed the akka-tests and added these back to the CI build.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
