### PR TITLE
Allow user specified concurrency for Scalar to Group and Group to Scalar

### DIFF
--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/GroupToScalar.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/GroupToScalar.java
@@ -56,7 +56,7 @@ public class GroupToScalar<K, T, R> extends StageConfig<T, R> {
 
     GroupToScalar(GroupToScalarComputation<K, T, R> computation,
                   Config<K, T, R> config, Codec<K> inputKeyCodec, Codec<T> inputCodec) {
-        super(config.description, inputKeyCodec, inputCodec, config.codec, config.inputStrategy, config.parameters);
+        super(config.description, inputKeyCodec, inputCodec, config.codec, config.inputStrategy, config.parameters, config.concurrency);
         this.computation = computation;
         this.keyExpireTimeSeconds = config.keyExpireTimeSeconds;
     }
@@ -78,6 +78,7 @@ public class GroupToScalar<K, T, R> extends StageConfig<T, R> {
         // 'stateful group calculation' use case
         // do not allow config override
         private INPUT_STRATEGY inputStrategy = INPUT_STRATEGY.SERIAL;
+        private int concurrency = DEFAULT_STAGE_CONCURRENCY;
         private List<ParameterDefinition<?>> parameters = Collections.emptyList();
 
         /**
@@ -119,6 +120,12 @@ public class GroupToScalar<K, T, R> extends StageConfig<T, R> {
             return this;
         }
 
+        public Config<K, T, R> concurrentInput(final int concurrency) {
+            this.inputStrategy = INPUT_STRATEGY.CONCURRENT;
+			this.concurrency = concurrency;
+            return this;
+        }
+
         public Codec<R> getCodec() {
             return codec;
         }
@@ -134,6 +141,8 @@ public class GroupToScalar<K, T, R> extends StageConfig<T, R> {
         public INPUT_STRATEGY getInputStrategy() {
             return inputStrategy;
         }
+
+        public int getConcurrency() { return concurrency; }
 
         public Config<K, T, R> withParameters(List<ParameterDefinition<?>> params) {
             this.parameters = params;

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/KeyValueStageConfig.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/KeyValueStageConfig.java
@@ -33,7 +33,12 @@ public abstract class KeyValueStageConfig<T, K, R> extends StageConfig<T, R> {
     private final Codec<K> keyCodec;
 
     public KeyValueStageConfig(String description, Codec<?> inputKeyCodec, Codec<T> inputCodec, Codec<K> outputKeyCodec, Codec<R> outputCodec, INPUT_STRATEGY inputStrategy, List<ParameterDefinition<?>> params) {
-        super(description, inputKeyCodec, inputCodec, outputCodec, inputStrategy, params);
+        super(description, inputKeyCodec, inputCodec, outputCodec, inputStrategy, params, DEFAULT_STAGE_CONCURRENCY);
+        this.keyCodec = outputKeyCodec;
+    }
+
+    public KeyValueStageConfig(String description, Codec<?> inputKeyCodec, Codec<T> inputCodec, Codec<K> outputKeyCodec, Codec<R> outputCodec, INPUT_STRATEGY inputStrategy, List<ParameterDefinition<?>> params, int concurrency) {
+        super(description, inputKeyCodec, inputCodec, outputCodec, inputStrategy, params, concurrency);
         this.keyCodec = outputKeyCodec;
     }
 

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/KeyValueStageConfig.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/KeyValueStageConfig.java
@@ -33,8 +33,7 @@ public abstract class KeyValueStageConfig<T, K, R> extends StageConfig<T, R> {
     private final Codec<K> keyCodec;
 
     public KeyValueStageConfig(String description, Codec<?> inputKeyCodec, Codec<T> inputCodec, Codec<K> outputKeyCodec, Codec<R> outputCodec, INPUT_STRATEGY inputStrategy, List<ParameterDefinition<?>> params) {
-        super(description, inputKeyCodec, inputCodec, outputCodec, inputStrategy, params, DEFAULT_STAGE_CONCURRENCY);
-        this.keyCodec = outputKeyCodec;
+        this(description, inputKeyCodec, inputCodec, outputKeyCodec, outputCodec, inputStrategy, params, DEFAULT_STAGE_CONCURRENCY);
     }
 
     public KeyValueStageConfig(String description, Codec<?> inputKeyCodec, Codec<T> inputCodec, Codec<K> outputKeyCodec, Codec<R> outputCodec, INPUT_STRATEGY inputStrategy, List<ParameterDefinition<?>> params, int concurrency) {

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/ScalarToGroup.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/ScalarToGroup.java
@@ -54,7 +54,7 @@ public class ScalarToGroup<T, K, R> extends KeyValueStageConfig<T, K, R> {
 
     public ScalarToGroup(ToGroupComputation<T, K, R> computation,
                   Config<T, K, R> config, Codec<T> inputCodec) {
-        super(config.description, null, inputCodec, config.keyCodec, config.codec, config.inputStrategy, config.parameters);
+        super(config.description, null, inputCodec, config.keyCodec, config.codec, config.inputStrategy, config.parameters, config.concurrency);
         this.computation = computation;
         this.keyExpireTimeSeconds = config.keyExpireTimeSeconds;
 
@@ -76,6 +76,7 @@ public class ScalarToGroup<T, K, R> extends KeyValueStageConfig<T, K, R> {
         private String description;
         // default input type is concurrent for 'grouping' use case
         private INPUT_STRATEGY inputStrategy = INPUT_STRATEGY.CONCURRENT;
+        private int concurrency = DEFAULT_STAGE_CONCURRENCY;
         private long keyExpireTimeSeconds = Long.MAX_VALUE; // never expire by default
         private List<ParameterDefinition<?>> parameters = Collections.emptyList();
 
@@ -108,11 +109,18 @@ public class ScalarToGroup<T, K, R> extends KeyValueStageConfig<T, K, R> {
 
         public Config<T, K, R> serialInput() {
             this.inputStrategy = INPUT_STRATEGY.SERIAL;
+            this.concurrency = 1;
             return this;
         }
 
         public Config<T, K, R> concurrentInput() {
             this.inputStrategy = INPUT_STRATEGY.CONCURRENT;
+            return this;
+        }
+
+        public Config<T, K, R> concurrentInput(final int concurrency) {
+            this.inputStrategy = INPUT_STRATEGY.CONCURRENT;
+			this.concurrency = concurrency;
             return this;
         }
 
@@ -136,6 +144,8 @@ public class ScalarToGroup<T, K, R> extends KeyValueStageConfig<T, K, R> {
         public INPUT_STRATEGY getInputStrategy() {
             return inputStrategy;
         }
+
+        public int getConcurrency() { return concurrency; }
 
         public long getKeyExpireTimeSeconds() {
             return keyExpireTimeSeconds;


### PR DESCRIPTION
### Context
The default concurrency for `ScalarToGroup` and `GroupToScalar` stages is `-1` and thus relies on the number of inner observables when executing the stage. There may be cases such as CPU bound stages where the user wants fine grained control over how many threads are executing the stage logic.

Some discussion in #681 indicates a desire for this, but I agree with @calvin681 that changing defaults shouldn't be done lightly as users have come to expect certain threading behavior with the stages. I think this represents a compromise where unaware users can continue with the default and power users can begin to control threading.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
