### PR TITLE
Add a buffering functionality to the SseWorkerConnection

### DIFF
--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnection.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnection.java
@@ -305,6 +305,7 @@ public class SseWorkerConnection {
         }
         return response.getContent()
                 .lift(new DropOperator<ServerSentEvent>(metricGroupId))
+                .rebatchRequests(this.bufferSize <= 0 ? 1 : this.bufferSize)
                 .flatMap((ServerSentEvent t1) -> {
                     lastDataReceived.set(System.currentTimeMillis());
                     if (isConnected.get() && isReceivingData.compareAndSet(false, true))

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
@@ -152,8 +152,9 @@ public class SseWorkerConnectionTest {
     @Test
     public void testStreamContentBuffersBeforeDrop() throws Exception {
         int bufferSize = 20;
+        int totalEvents = 100;
         SpectatorRegistryFactory.setRegistry(new DefaultRegistry());
-        String metricGroupString = "testmetric_2";
+        String metricGroupString = "testmetric_buffer";
         MetricGroupId metricGroupId = new MetricGroupId(metricGroupString);
         SseWorkerConnection workerConnection = new SseWorkerConnection("connection_type",
             "hostname",
@@ -181,7 +182,7 @@ public class SseWorkerConnectionTest {
 
         workerConnection.streamContent(response, b -> {}, 600, "delimiter").subscribeOn(testScheduler).subscribe(subscriber);
 
-        testScheduler.advanceTimeBy(100, TimeUnit.SECONDS);
+        testScheduler.advanceTimeBy(totalEvents, TimeUnit.SECONDS);
         subscriber.assertValueCount(1);
         List<MantisServerSentEvent> events = subscriber.getOnNextEvents();
         assertEquals("0", events.get(0).getEventAsString());
@@ -192,6 +193,6 @@ public class SseWorkerConnectionTest {
         logger.info("next: {}", onNextCounter.value());
         logger.info("drop: {}", droppedCounter.value());
         assertTrue(onNextCounter.value() >= bufferSize); // Should pull at least the buffer even though we requested 1.
-        assertTrue(droppedCounter.value() <= 100); // We should not drop any of the buffer.
+        assertTrue(droppedCounter.value() <= totalEvents - bufferSize ); // We should not drop any of the buffer.
     }
 }

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
@@ -153,7 +153,7 @@ public class SseWorkerConnectionTest {
     public void testStreamContentBuffersBeforeDrop() throws Exception {
         int bufferSize = 20;
         SpectatorRegistryFactory.setRegistry(new DefaultRegistry());
-        String metricGroupString = "testmetric";
+        String metricGroupString = "testmetric_2";
         MetricGroupId metricGroupId = new MetricGroupId(metricGroupString);
         SseWorkerConnection workerConnection = new SseWorkerConnection("connection_type",
             "hostname",
@@ -192,6 +192,6 @@ public class SseWorkerConnectionTest {
         logger.info("next: {}", onNextCounter.value());
         logger.info("drop: {}", droppedCounter.value());
         assertTrue(onNextCounter.value() >= bufferSize); // Should pull at least the buffer even though we requested 1.
-        assertTrue(droppedCounter.value() <= 80); // We should not drop any of the buffer.
+        assertTrue(droppedCounter.value() <= 100); // We should not drop any of the buffer.
     }
 }

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
@@ -148,4 +148,51 @@ public class SseWorkerConnectionTest {
         logger.info("Connection tracker size: {}", client.connectionTrackerSize());
         assertEquals(0, client.connectionTrackerSize());
     }
+
+    @Test
+    public void testStreamContentBuffersBeforeDrop() throws Exception {
+        int bufferSize = 50;
+        int dataPoints = 100;
+        SpectatorRegistryFactory.setRegistry(new DefaultRegistry());
+        String metricGroupString = "testmetric";
+        MetricGroupId metricGroupId = new MetricGroupId(metricGroupString);
+        SseWorkerConnection workerConnection = new SseWorkerConnection("connection_type",
+            "hostname",
+            80,
+            b -> {},
+            b -> {},
+            t -> {},
+            600,
+            false,
+            new CopyOnWriteArraySet<>(),
+            bufferSize,
+            null,
+            true,
+            metricGroupId);
+        HttpClientResponse<ServerSentEvent> response = mock(HttpClientResponse.class);
+        TestScheduler testScheduler = Schedulers.test();
+
+        // Events are just "0", "1", "2", ...
+        Observable<ServerSentEvent> contentObs = Observable.interval(1, TimeUnit.SECONDS, testScheduler)
+            .map(t -> new ServerSentEvent(Unpooled.copiedBuffer(Long.toString(t), Charset.defaultCharset())));
+
+        when(response.getContent()).thenReturn(contentObs);
+
+        TestSubscriber<MantisServerSentEvent> subscriber = new TestSubscriber<>(1);
+
+        workerConnection.streamContent(response, b -> {}, 600, "delimiter").subscribeOn(testScheduler).subscribe(subscriber);
+
+        testScheduler.advanceTimeBy(dataPoints, TimeUnit.SECONDS);
+        subscriber.assertValueCount(1);
+        List<MantisServerSentEvent> events = subscriber.getOnNextEvents();
+        assertEquals("0", events.get(0).getEventAsString());
+
+        Metrics metrics = MetricsRegistry.getInstance().getMetric(metricGroupId);
+        Counter onNextCounter = metrics.getCounter(DropOperator.Counters.onNext.toString());
+        Counter droppedCounter = metrics.getCounter(DropOperator.Counters.dropped.toString());
+        logger.info("next: {}", onNextCounter.value());
+        logger.info("drop: {}", droppedCounter.value());
+        assertTrue(onNextCounter.value() >= bufferSize); // Should pull AT LEAST the buffer.
+        assertTrue(droppedCounter.value() <=  dataPoints - bufferSize); // We should not drop any of the buffer.
+    }
 }

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
@@ -151,8 +151,7 @@ public class SseWorkerConnectionTest {
 
     @Test
     public void testStreamContentBuffersBeforeDrop() throws Exception {
-        int bufferSize = 50;
-        int dataPoints = 100;
+        int bufferSize = 20;
         SpectatorRegistryFactory.setRegistry(new DefaultRegistry());
         String metricGroupString = "testmetric";
         MetricGroupId metricGroupId = new MetricGroupId(metricGroupString);
@@ -182,7 +181,7 @@ public class SseWorkerConnectionTest {
 
         workerConnection.streamContent(response, b -> {}, 600, "delimiter").subscribeOn(testScheduler).subscribe(subscriber);
 
-        testScheduler.advanceTimeBy(dataPoints, TimeUnit.SECONDS);
+        testScheduler.advanceTimeBy(100, TimeUnit.SECONDS);
         subscriber.assertValueCount(1);
         List<MantisServerSentEvent> events = subscriber.getOnNextEvents();
         assertEquals("0", events.get(0).getEventAsString());
@@ -192,7 +191,7 @@ public class SseWorkerConnectionTest {
         Counter droppedCounter = metrics.getCounter(DropOperator.Counters.dropped.toString());
         logger.info("next: {}", onNextCounter.value());
         logger.info("drop: {}", droppedCounter.value());
-        assertTrue(onNextCounter.value() >= bufferSize); // Should pull AT LEAST the buffer.
-        assertTrue(droppedCounter.value() <=  dataPoints - bufferSize); // We should not drop any of the buffer.
+        assertTrue(onNextCounter.value() >= bufferSize); // Should pull at least the buffer even though we requested 1.
+        assertTrue(droppedCounter.value() <= 80); // We should not drop any of the buffer.
     }
 }

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
@@ -192,7 +192,7 @@ public class SseWorkerConnectionTest {
         Counter droppedCounter = metrics.getCounter(DropOperator.Counters.dropped.toString());
         logger.info("next: {}", onNextCounter.value());
         logger.info("drop: {}", droppedCounter.value());
-        assertTrue(onNextCounter.value() >= bufferSize); // Should pull at least the buffer even though we requested 1.
+        assertTrue(onNextCounter.value() >= bufferSize); // Should request at least the buffer even though we requested 1.
         assertTrue(droppedCounter.value() <= totalEvents - bufferSize ); // We should not drop any of the buffer.
     }
 }


### PR DESCRIPTION
### Context

The `SseWorkerConnection` uses a `DropOperator` with a metric named suffixed with `withBuffer` set in the [SseWorkerConnectionFunction](https://github.com/Netflix/mantis/blob/master/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/SseWorkerConnectionFunction.java#L61) class. The class takes a `bufferSize` parameter but does nothing with it! I've had the illusion that we've been buffering here for darn near a decade!

This change is pretty straightforward implementation. `rebatchRequests` simply sends `n` requests into the `DropOperator` and continues to stay ahead of the requests made by the downstream by up to n. There is a batching implementation inside of the operator that RxJava uses to implement this.

Users could then set the buffer with the: `mantisClient.buffer.size` and `workerClient.buffer.size` properties.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
