### PR TITLE
Increase schedule retries

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -168,7 +168,7 @@ public interface MasterConfiguration extends CoreConfiguration {
     }
 
     @Config("mantis.master.scheduler.max-retries")
-    @Default("10")
+    @Default("60")
     int getSchedulerMaxRetries();
 
     @Config("mantis.zookeeper.leader.election.path")


### PR DESCRIPTION
### Context

Increasing the default schedule retries config (since the initial scheduling on batch is consolidated to honor the backoff it should be safe now to use a larger retry max to reduce jobs stuck on no resource not retrying anymore).
The follow-up work here could be to extend this to retry forever (e.g. if no resource is available for this scheduling request, keep retrying with proper backoff delay), but given the risk, I will defer this change till we gather more confidence with the new behavior.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
