### PR TITLE
Handle overloaded agent's heartbeat timeout

### DIFF
--- a/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CoreConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-core/src/main/java/io/mantisrx/server/core/CoreConfiguration.java
@@ -67,15 +67,15 @@ public interface CoreConfiguration {
     int getAsyncHttpClientMaxConnectionsPerHost();
 
     @Config("mantis.asyncHttpClient.connectionTimeoutMs")
-    @Default("10000")
+    @Default("90000")
     int getAsyncHttpClientConnectionTimeoutMs();
 
     @Config("mantis.asyncHttpClient.requestTimeoutMs")
-    @Default("10000")
+    @Default("90000")
     int getAsyncHttpClientRequestTimeoutMs();
 
     @Config("mantis.asyncHttpClient.readTimeoutMs")
-    @Default("10000")
+    @Default("90000")
     int getAsyncHttpClientReadTimeoutMs();
 
     @Config("mantis.asyncHttpClient.followRedirect")

--- a/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
+++ b/mantis-runtime-loader/src/main/java/io/mantisrx/runtime/loader/config/WorkerConfiguration.java
@@ -85,7 +85,7 @@ public interface WorkerConfiguration extends CoreConfiguration {
     int getTolerableConsecutiveHeartbeatFailures();
 
     @Config("mantis.taskexecutor.heartbeats.timeout.ms")
-    @Default("5000")
+    @Default("90000")
     int heartbeatTimeoutMs();
 
     @Config("mantis.taskexecutor.heartbeats.retry.initial-delay.ms")


### PR DESCRIPTION
### Context

We found a case where agents with shutdown workers got leaked:
* A job with multiple workers is being shut down.
* Some workers receive the shutdown signals and terminate the running workers. However, some workers fail to receive the signals (timeout, etc.) and continue to be alive. Now, all upstream traffic is re-distributed to these workers, and they become very busy (peaked CPU/network usage).
* Retried kill signals cannot reach these workers while the worker's host agent's heartbeat message to the control plane timed out, causing them to be leaked.

Improvements:
* increase heartbeat connection client's thread priority
* increase heartbeat connection timeout settings.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
