### PR TITLE
Resubmit Worker Allocations

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -363,6 +363,10 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("3")
     int getSlaMaxHeadroomForAccepted();
 
+    @Config("mantis.scheduler.handlesAllocationRetries")
+    @Default("true")
+    boolean getSchedulerHandlesAllocationRetries();
+
     default Duration getHeartbeatInterval() {
         return Duration.ofMillis(getHeartbeatIntervalInMs());
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisScheduler.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisScheduler.java
@@ -76,4 +76,11 @@ public interface MantisScheduler {
      */
     void initializeRunningWorker(final ScheduleRequest scheduleRequest, final String hostname, final String hostID);
 
+    /**
+     * This should return true if the underlying scheduler handles retrying worker allocations.
+     *
+     * @return If there are not enough resources to schedule the worker and the scheduler automatically retries until
+     * the worker is assigned, then return true; otherwise, return false.
+     */
+    boolean schedulerHandlesAllocationRetries();
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisSchedulerFactoryImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/MantisSchedulerFactoryImpl.java
@@ -63,7 +63,8 @@ public class MantisSchedulerFactoryImpl implements MantisSchedulerFactory {
                                 executeStageRequestFactory,
                                 jobMessageRouter,
                                 metricsRegistry),
-                            "scheduler-for-" + cid.getResourceID()));
+                            "scheduler-for-" + cid.getResourceID()),
+                            masterConfiguration.getSchedulerHandlesAllocationRetries());
                     });
         } else {
             log.error("Scheduler gets unexpected null clusterID");

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareScheduler.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/scheduler/ResourceClusterAwareScheduler.java
@@ -32,6 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 public class ResourceClusterAwareScheduler implements MantisScheduler {
 
     private final ActorRef schedulerActor;
+    private final boolean handlesAllocationRetries;
 
     @Override
     public void scheduleWorkers(BatchScheduleRequest scheduleRequest) {
@@ -66,5 +67,10 @@ public class ResourceClusterAwareScheduler implements MantisScheduler {
         schedulerActor.tell(
             new InitializeRunningWorkerRequestEvent(scheduleRequest, TaskExecutorID.of(hostID)),
             null);
+    }
+
+    @Override
+    public boolean schedulerHandlesAllocationRetries() {
+        return handlesAllocationRetries;
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestMigrationTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestMigrationTests.java
@@ -209,6 +209,11 @@ public class JobTestMigrationTests {
             // TODO Auto-generated method stub
 
         }
+
+        @Override
+        public boolean schedulerHandlesAllocationRetries(){
+            return false;
+        }
     }
 
     public static void main(String[] args) {

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/scheduler/FakeMantisScheduler.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/scheduler/FakeMantisScheduler.java
@@ -64,4 +64,9 @@ public class FakeMantisScheduler implements MantisScheduler {
     public void initializeRunningWorker(final ScheduleRequest scheduleRequest, final String hostname, final String hostID) {
         // no-op
     }
+
+    @Override
+    public boolean schedulerHandlesAllocationRetries() {
+        return false;
+    }
 }


### PR DESCRIPTION
A recent change removed worker resubmits when workers are stuck in accepted: https://github.com/Netflix/mantis/pull/719

Our underlying scheduler will not retry the allocations, so we need a way to conditionally enable the ability to resubmit.

### Context

I did not see unit tests for the functionality that was removed.  I'd be happy to add them, but would like to get this merged first, since we had to pin master to a different version than the agents to avoid stuck workers.

### Checklist

- [X] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [X] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
