### PR TITLE
Fix clutch rps

### DIFF
--- a/mantis-rxcontrol/src/main/java/io/mantisrx/control/clutch/ExperimentalClutchConfigurator.java
+++ b/mantis-rxcontrol/src/main/java/io/mantisrx/control/clutch/ExperimentalClutchConfigurator.java
@@ -134,7 +134,7 @@ public class ExperimentalClutchConfigurator implements Observable.Transformer<Ev
     private static void logStatsSummary(DescriptiveStatistics stat, String prefix) {
         log.info("{} RPS Sketch Quantiles -- Min: {}, 25th: {}, 50th: {}, 75th: {}, 99th: {}, Max: {}",
                 prefix,
-                stat.getPercentile(0),
+                stat.getMin(),
                 stat.getPercentile(25),
                 stat.getPercentile(50),
                 stat.getPercentile(75),


### PR DESCRIPTION
### Context

`stat.getPercentile(0)` would cause this exception 
```
2024-12-02 21:05:45.787 ERROR 1171 --- [tionScheduler-1] i.m.s.w.j.JobAutoScaler                  : got onError in JobAutoScaler
org.apache.commons.math3.exception.OutOfRangeException: out of bounds quantile value: 0, must be in (0, 100]
        at org.apache.commons.math3.stat.descriptive.rank.Percentile.setQuantile(Percentile.java:398)
        at org.apache.commons.math3.stat.descriptive.DescriptiveStatistics.getPercentile(DescriptiveStatistics.java:442)
        at io.mantisrx.control.clutch.ExperimentalClutchConfigurator.logStatsSummary(ExperimentalClutchConfigurator.java:137)
        at io.mantisrx.control.clutch.ExperimentalClutchConfigurator.lambda$call$9(ExperimentalClutchConfigurator.java:114)
        at rx.internal.util.ActionObserver.onNext(ActionObserver.java:39)
        at rx.internal.operators.OnSubscribeDoOnEach$DoOnEachSubscriber.onNext(OnSubscribeDoOnEach.java:96)
        at rx.internal.operators.OnSubscribeDoOnEach$DoOnEachSubscriber.onNext(OnSubscribeDoOnEach.java:101)
        at rx.internal.operators.OperatorDistinctUntilChanged$1.onNext(OperatorDistinctUntilChanged.java:102)
        at rx.observers.SerializedObserver.onNext(SerializedObserver.java:91)
        at rx.observers.SerializedSubscriber.onNext(SerializedSubscriber.java:94)
        at rx.internal.operators.OnSubscribeConcatMap$ConcatMapSubscriber.innerNext(OnSubscribeConcatMap.java:182)
        at rx.internal.operators.OnSubscribeConcatMap$ConcatMapInnerSubscriber.onNext(OnSubscribeConcatMap.java:335)
        at rx.internal.operators.OnSubscribeDoOnEach$DoOnEachSubscriber.onNext(OnSubscribeDoOnEach.java:101)
        at rx.internal.operators.OnSubscribeMap$MapSubscriber.onNext(OnSubscribeMap.java:77)
        at rx.internal.operators.OperatorTake$1.onNext(OperatorTake.java:79)
        at rx.internal.operators.OnSubscribeTimerPeriodically$1.call(OnSubscribeTimerPeriodically.java:52)
        at rx.internal.schedulers.SchedulePeriodicHelper$1.call(SchedulePeriodicHelper.java:72)
        at rx.internal.schedulers.EventLoopsScheduler$EventLoopWorker$2.call(EventLoopsScheduler.java:189)
        at rx.internal.schedulers.ScheduledAction.run(ScheduledAction.java:55)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: rx.exceptions.OnErrorThrowable$OnNextValue: OnError while emitting onNext value: io.mantisrx.control.clutch.ClutchConfiguration.class
        at rx.exceptions.OnErrorThrowable.addValueAsLastCause(OnErrorThrowable.java:118)
        at rx.exceptions.Exceptions.throwOrReport(Exceptions.java:188)
        at rx.internal.operators.OnSubscribeDoOnEach$DoOnEachSubscriber.onNext(OnSubscribeDoOnEach.java:98)
        ... 19 more
```

Looks like a new version of the `Percentile` class doesn't allow fetching 0 percentile anymore. Allowed values `0 < p ≤ 100`. 

Fixed by replacing it with `getMin()`

### Tests

Tested in a staging shared mre job and the scaler doesn't fail there anymore.