### PR TITLE
Fix Incorrect Cluster Size Update in ExperimentalControlLoop When Scaling Down is Disabled

### DIFF
--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobAutoScaler.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/JobAutoScaler.java
@@ -398,13 +398,13 @@ public class JobAutoScaler {
         return desiredWorkers;
       }
 
-      public void scaleDownStage(final int numCurrentWorkers, final int desiredWorkers, final String reason) {
+      public boolean scaleDownStage(final int numCurrentWorkers, final int desiredWorkers, final String reason) {
         logger.info("scaleDownStage decrementing number of workers from {} to {}", numCurrentWorkers, desiredWorkers);
         cancelOutstandingScalingRequest();
         final StageScalingPolicy scalingPolicy = stageSchedulingInfo.getScalingPolicy();
         if (scalingPolicy != null && scalingPolicy.isAllowAutoScaleManager() && !jobAutoscalerManager.isScaleDownEnabled()) {
             logger.warn("Scaledown is disabled for all autoscaling strategy. For stage {} of job {}", stage, jobId);
-            return;
+            return false;
         }
         final Subscription subscription = masterClientApi.scaleJobStage(jobId, stage, desiredWorkers, reason)
           .retryWhen(retryLogic)
@@ -414,6 +414,7 @@ public class JobAutoScaler {
           })
         .subscribe();
         setOutstandingScalingRequest(subscription);
+        return true;
       }
 
       public int getStage() {

--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/control/actuators/ClutchMantisStageActuator.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/control/actuators/ClutchMantisStageActuator.java
@@ -38,7 +38,9 @@ public class ClutchMantisStageActuator implements Observable.Transformer<Tuple3<
 
         String reason = tup._1;
         if (desiredNumWorkers < tup._3) {
-            scaler.scaleDownStage(tup._3, desiredNumWorkers, reason);
+            if (!scaler.scaleDownStage(tup._3, desiredNumWorkers, reason)) {
+                return tup._3 * 1.0;
+            }
         } else if (desiredNumWorkers > tup._3) {
             scaler.scaleUpStage(tup._3, desiredNumWorkers, reason);
         } else {

--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/control/actuators/ClutchMantisStageActuator.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/control/actuators/ClutchMantisStageActuator.java
@@ -38,6 +38,7 @@ public class ClutchMantisStageActuator implements Observable.Transformer<Tuple3<
 
         String reason = tup._1;
         if (desiredNumWorkers < tup._3) {
+            // If scale down is disabled, return current value
             if (!scaler.scaleDownStage(tup._3, desiredNumWorkers, reason)) {
                 return tup._3 * 1.0;
             }

--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/control/actuators/MantisStageActuator.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/control/actuators/MantisStageActuator.java
@@ -43,7 +43,9 @@ public class MantisStageActuator extends IActuator {
 
         String reason = "Clutch determined " + desiredNumWorkers + " instance(s) for target resource usage.";
         if (desiredNumWorkers < this.lastValue) {
-            scaler.scaleDownStage(lastValue.intValue(), desiredNumWorkers.intValue(), reason);
+            if (!scaler.scaleDownStage(lastValue.intValue(), desiredNumWorkers.intValue(), reason)) {
+                return this.lastValue * 1.0;
+            }
             this.lastValue = desiredNumWorkers;
         } else if (desiredNumWorkers > this.lastValue) {
             scaler.scaleUpStage(lastValue.intValue(), desiredNumWorkers.intValue(), reason);

--- a/mantis-rxcontrol/src/test/java/io/mantisrx/control/clutch/ExperimentalControlLoopTest.java
+++ b/mantis-rxcontrol/src/test/java/io/mantisrx/control/clutch/ExperimentalControlLoopTest.java
@@ -24,6 +24,8 @@ import io.vavr.Tuple;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.junit.Test;
 import rx.Observable;
 import rx.subjects.PublishSubject;
@@ -202,9 +204,70 @@ public class ExperimentalControlLoopTest {
         assertEquals(116.1, actuator.lastValue, 1e-10);
     }
 
+    @Test
+    public void shouldHandleScalingDisabledAndEnabled() throws Exception {
+        ClutchConfiguration config = ClutchConfiguration.builder()
+            .metric(Clutch.Metric.RPS)
+            .setPoint(100.0)
+            .kp(1.0)
+            .ki(0)
+            .kd(0)
+            .minSize(1)
+            .maxSize(1000)
+            .rope(Tuple.of(0.0, 0.0))
+            .cooldownInterval(0)
+            .cooldownUnits(TimeUnit.SECONDS)
+            .build();
+
+        // Test with scaling enabled
+        TestActuator actuatorScalingEnabled = new TestActuator(100);
+        actuatorScalingEnabled.setScalingDisabled(false); // Simulate scaling being enabled
+        CountDownLatch latchScalingEnabled = actuatorScalingEnabled.createLatch();
+
+        AtomicLong currentSizeScalingEnabled = new AtomicLong(100);
+        ExperimentalControlLoop controlLoopScalingEnabled = new ExperimentalControlLoop(config, actuatorScalingEnabled, currentSizeScalingEnabled,
+            new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
+            new ExperimentalControlLoop.DefaultRpsMetricComputer(),
+            new ExperimentalControlLoop.DefaultScaleComputer());
+
+        PublishSubject<Event> publisherScalingEnabled = PublishSubject.create();
+        controlLoopScalingEnabled.call(publisherScalingEnabled).subscribe();
+
+        controlLoopScalingEnabled.setCooldownMillis(0);
+        publisherScalingEnabled.onNext(new Event(Clutch.Metric.RPS, 90));
+        latchScalingEnabled.await();
+        assertEquals(90, currentSizeScalingEnabled.get()); // Verify that current size has changed
+
+        // Test with scaling disabled
+        TestActuator actuatorScalingDisabled = new TestActuator(100);
+        actuatorScalingDisabled.setScalingDisabled(true); // Simulate scaling being disabled
+        CountDownLatch latchScalingDisabled = actuatorScalingDisabled.createLatch();
+
+        AtomicLong currentSizeScalingDisabled = new AtomicLong(100);
+        ExperimentalControlLoop controlLoopScalingDisabled = new ExperimentalControlLoop(config, actuatorScalingDisabled, currentSizeScalingDisabled,
+            new AtomicDouble(1.0), Observable.timer(10, TimeUnit.MINUTES), Observable.just(100),
+            new ExperimentalControlLoop.DefaultRpsMetricComputer(),
+            new ExperimentalControlLoop.DefaultScaleComputer());
+
+        PublishSubject<Event> publisherScalingDisabled = PublishSubject.create();
+        controlLoopScalingDisabled.call(publisherScalingDisabled).subscribe();
+
+        controlLoopScalingDisabled.setCooldownMillis(0);
+        publisherScalingDisabled.onNext(new Event(Clutch.Metric.RPS, 90));
+        latchScalingDisabled.await();
+        assertEquals(100, currentSizeScalingDisabled.get()); // Verify that current size has not changed
+    }
+
+    @NoArgsConstructor
     public static class TestActuator extends IActuator {
         private double lastValue;
         private CountDownLatch latch;
+        @Setter
+        private boolean scalingDisabled = false; // Flag to simulate scaling is being disabled
+
+        TestActuator(double initialValue) {
+            this.lastValue = initialValue;
+        }
 
         public CountDownLatch createLatch() {
             this.latch = new CountDownLatch(1);
@@ -213,6 +276,11 @@ public class ExperimentalControlLoopTest {
 
         @Override
         protected Double processStep(Double value) {
+            if (scalingDisabled) {
+                latch.countDown();
+                System.out.println("lastValue " + lastValue);
+                return lastValue; // Return the original value if scaling is disabled
+            }
             this.lastValue = value;
             latch.countDown();
             return value;


### PR DESCRIPTION
## Context

### Background

While monitoring the autoscaling behavior of our clusters, I observed an unexpected scale-down event in the shared MRE source ~3 AM PST, despite having scaling down disabled (new feature introduced for the next live event). This anomaly was not present in the PlayAPI source, which behaved correctly under the same conditions.

### Issue

Upon investigation, I discovered that the `ExperimentalControlLoop` class, used by the Clutch RPS scaling policy, was incorrectly updating the `currentSize` to the `desiredSize` even when the actuator did not perform a scale-down due to scaling being disabled. This led to a discrepancy between the `currentSize` and the actual cluster size, causing future scaling decisions to be based on incorrect data.

### Impact

This behavior resulted in a critical issue where, upon scaling up, the system could mistakenly reduce the cluster size. For example, with scaling down disabled:

* The currentSize was reduced from 100 to 50, while the actual size remained 100.
* When traffic increased, the scaler decided to "scale up" to 60, which effectively reduced the cluster from 100 to 60 nodes—a scale-down operation.

## Solution

The fix ensures that the currentSize is not updated when the actuator is unable to perform a scale-down due to scaling being disabled. This maintains the integrity of the cluster size data, preventing erroneous scaling operations.

## Testing 

* Added unit tests to simulate scenarios where scaling down is disabled, verifying that the currentSize remains unchanged.
* Confirmed that the system behaves correctly when scaling is enabled, with appropriate updates to the currentSize.
* TODO: apply this change to SharedMRE and test again in production





