### PR TITLE
Fix sse connection infinite retry failure

### DIFF
--- a/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/MantisHttpClientImpl.java
+++ b/mantis-server/mantis-server-worker-client/src/main/java/io/mantisrx/server/worker/client/MantisHttpClientImpl.java
@@ -96,15 +96,28 @@ public class MantisHttpClientImpl<I, O> extends HttpClientImpl<I, O> {
     protected void closeConn() {
         synchronized (connectionTracker) {
             isClosed.set(true);
-            for (Channel value : this.connectionTracker) {
-                Channel channel = value;
-                log.info("Closing connection: {}. Status at close: isActive: {}, isOpen: {}, isWritable: {}",
-                    channel.toString(), channel.isActive(), channel.isOpen(), channel.isWritable());
-                channel.close();
-                numConnectionsTracked.decrement();
-            }
-            this.connectionTracker.clear();
+            resetConnInternalUnsafe();
         }
+    }
+
+    protected void resetConn() {
+        synchronized (connectionTracker) {
+            resetConnInternalUnsafe();
+        }
+    }
+
+    /**
+     * Not thread safe, must be called with explicit lock.
+     */
+    private void resetConnInternalUnsafe() {
+        for (Channel value : this.connectionTracker) {
+            Channel channel = value;
+            log.info("Closing connection: {}. Status at close: isActive: {}, isOpen: {}, isWritable: {}",
+                channel.toString(), channel.isActive(), channel.isOpen(), channel.isWritable());
+            channel.close();
+            numConnectionsTracked.decrement();
+        }
+        this.connectionTracker.clear();
     }
 
     protected int connectionTrackerSize() {

--- a/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
+++ b/mantis-server/mantis-server-worker-client/src/test/java/io/mantisrx/server/worker/client/SseWorkerConnectionTest.java
@@ -138,6 +138,19 @@ public class SseWorkerConnectionTest {
         logger.info("Connection tracker size: {}", client.connectionTrackerSize());
         assertEquals(1, client.connectionTrackerSize());
 
+        client.resetConn();
+
+        logger.info("Connection tracker size: {}", client.connectionTrackerSize());
+        assertEquals(0, client.connectionTrackerSize());
+
+        // Test can still add more channels after the client gets reset.
+        client.trackConnection(dummyChannel);
+        logger.info("Connection tracker size: {}", client.connectionTrackerSize());
+        assertEquals(1, client.connectionTrackerSize());
+
+        client.trackConnection(dummyChannel);
+        logger.info("Connection tracker size: {}", client.connectionTrackerSize());
+        assertEquals(2, client.connectionTrackerSize());
         client.closeConn();
 
         logger.info("Connection tracker size: {}", client.connectionTrackerSize());


### PR DESCRIPTION
### Context

We noticed that when the SSE connection triggered "doOnError", the SSE HTTP client was closed internally (via resetConn) but the following "retryWhen" operation started an infinite retry action on the closed HTTP Client (and every retry failed right away since the client is not going to start the actual connection).

Solution:
Refactor to split reset and close operations on the SSE client so that the "doOnErro" within the retry loop will only reset instead of closing the client. Added an outer "doOnError" to make sure the client gets closed once the retry loop is broken.


### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
