### PR TITLE
re-enable disabled node on expiry

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -518,6 +518,13 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             if (activeDisableTaskExecutorsByAttributesRequests.remove(request.getRequest()) || (request.getRequest().getTaskExecutorID().isPresent() && disabledTaskExecutors.remove(request.getRequest().getTaskExecutorID().get()))) {
                 mantisJobStore.deleteExpiredDisableTaskExecutorsRequest(request.getRequest());
             }
+
+            // also re-enable the node if the state is still valid.
+            if (request.getRequest().getTaskExecutorID().isPresent()) {
+                final TaskExecutorState state = this.executorStateManager.get(
+                    request.getRequest().getTaskExecutorID().get());
+                state.onNodeEnabled();
+            }
         } catch (Exception e) {
             log.error("Failed to delete expired {}", request.getRequest());
         }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
@@ -170,6 +170,15 @@ class TaskExecutorState {
         }
     }
 
+    boolean onNodeEnabled() {
+        if (this.disabled) {
+            this.disabled = false;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     boolean onHeartbeat(TaskExecutorHeartbeat heartbeat)
         throws IllegalStateException, TaskExecutorTaskCancelledException {
         if (!isRegistered()) {


### PR DESCRIPTION
### Context

If a node marked as disabled was never destroyed by the host cluster and maintained heartbeats (thus, its executor state remained valid in memory), it would remain disabled until the next leader's re-election.

Fix:
On disable node expiration, ensure the internal state (if still valid) is reset to be not disabled.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
