### PR TITLE
Ensure worker failed before first heartbeat gets resubmission

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/worker/IMantisWorkerMetadata.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/worker/IMantisWorkerMetadata.java
@@ -186,6 +186,12 @@ public interface IMantisWorkerMetadata {
     long getLaunchedAt();
 
     /**
+     * Whether this worker has entered launched state.
+     * @return true if launched.
+     */
+    boolean hasLaunched();
+
+    /**
      * The timestamp at which this worker started initialization.
      * @return
      */

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/worker/MantisWorkerMetadataImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/worker/MantisWorkerMetadataImpl.java
@@ -323,6 +323,10 @@ public class MantisWorkerMetadataImpl implements IMantisWorkerMetadata {
         return launchedAt;
     }
 
+    public boolean hasLaunched() {
+        return launchedAt > 0;
+    }
+
 
     public long getStartingAt() {
         return startingAt;


### PR DESCRIPTION
### Context

Problem:
The missing heartbeat logic relies on the last HB timestamp to determine whether it should be re-submitted by the job actor or the scheduler. This creates a problem for workers failed right after getting scheduled but before it's able to emit the first heartbeat message. This problem gets amplified when we have higher transient worker startup failures due to other issues.

Solution:
Instead of last heartbeat, use the launched event status to decide whether the job actor should start taking over the job resubmission from the scheduler.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
