### PR TITLE
report error creating cron

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
@@ -795,6 +795,7 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
                     initReq.requestId, e instanceof SchedulerException?CLIENT_ERROR:SERVER_ERROR,
                     "Job Cluster " + jobClusterName + " could not be created due to cron initialization error" + e.getMessage(),
                     jobClusterName), getSelf());
+                return;
             }
             initRunningJobs(initReq, sender);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobClusterDefinitionImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/domain/JobClusterDefinitionImpl.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.server.master.domain;
 
+import com.netflix.fenzo.triggers.TriggerUtils;
 import io.mantisrx.common.Label;
 import io.mantisrx.master.jobcluster.LabelManager.SystemLabels;
 import io.mantisrx.master.jobcluster.job.JobState;
@@ -64,6 +65,8 @@ public class JobClusterDefinitionImpl implements IJobClusterDefinition {
     ) {
         Preconditions.checkNotNull(jobClusterConfigs);
         Preconditions.checkArgument(!jobClusterConfigs.isEmpty());
+        if (sla != null && sla.getCronSpec() != null)
+            TriggerUtils.validateCronExpression(sla.getCronSpec());
         this.owner = owner;
         this.name = name;
         this.sla = Optional.ofNullable(sla).orElse(new SLA(0, 0, null, CronPolicy.KEEP_EXISTING));

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -1568,54 +1568,15 @@ public class JobClusterAkkaTest {
 
     }
 
-    @Test
-    public void testInvalidCronSubmit() {
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidCronDefined() {
         TestKit probe = new TestKit(system);
-        String clusterName = "testInvalidCronSubmit";
+        String clusterName = "testInvalidCronDefined";
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         SLA sla = new SLA(1,1,"a b * * * * * * *",IJobClusterDefinition.CronPolicy.KEEP_NEW);
-        final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher, costsCalculator, 0));
-        jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
-        JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
-        assertEquals(CLIENT_ERROR, createResp.responseCode);
-    }
-
-    @Test
-    public void testInvalidCronSLAUpdate() throws Exception  {
-        TestKit probe = new TestKit(system);
-        String clusterName = "testJobClusterInvalidSLAUpdateIgnored";
-        MantisScheduler schedulerMock = mock(MantisScheduler.class);
-        MantisJobStore jobStoreMock = mock(MantisJobStore.class);
-
-        final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
-        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher, costsCalculator, 0));
-        jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
-        JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
-        assertEquals(SUCCESS, createResp.responseCode);
-
-        UpdateJobClusterSLARequest updateSlaReq = new UpdateJobClusterSLARequest(clusterName, 2, 1,"a b * * * * * * *",IJobClusterDefinition.CronPolicy.KEEP_NEW,false,"user" );
-        jobClusterActor.tell(updateSlaReq, probe.getRef());
-        UpdateJobClusterSLAResponse resp = probe.expectMsgClass(UpdateJobClusterSLAResponse.class);
-
-        assertEquals(CLIENT_ERROR, resp.responseCode);
-        assertEquals(jobClusterActor, probe.getLastSender());
-
-        jobClusterActor.tell(new GetJobClusterRequest(clusterName), probe.getRef());
-        GetJobClusterResponse resp3 = probe.expectMsgClass(GetJobClusterResponse.class);
-
-        assertEquals(SUCCESS, resp3.responseCode);
-        assertTrue(resp3.getJobCluster() != null);
-        System.out.println("Job cluster " + resp3.getJobCluster());
-        assertEquals(clusterName, resp3.getJobCluster().get().getName());
-        // No changes to original SLA
-        assertEquals(0, resp3.getJobCluster().get().getSla().getMin());
-        assertEquals(0, resp3.getJobCluster().get().getSla().getMax());
-
-        verify(jobStoreMock, times(1)).createJobCluster(any());
-        verify(jobStoreMock, times(0)).updateJobCluster(any());
+        final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla); //should throw IllegalArgumentException
     }
 
     @Test

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -1569,18 +1569,53 @@ public class JobClusterAkkaTest {
     }
 
     @Test
-    public void testUnsupportedCronSubmit() {
+    public void testInvalidCronSubmit() {
         TestKit probe = new TestKit(system);
-        String clusterName = "testUnsupportedCronSubmit";
+        String clusterName = "testInvalidCronSubmit";
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
-        SLA sla = new SLA(1,1,"0 18 * * *",IJobClusterDefinition.CronPolicy.KEEP_NEW);
+        SLA sla = new SLA(1,1,"a b * * * * * * *",IJobClusterDefinition.CronPolicy.KEEP_NEW);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla);
         ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher, costsCalculator, 0));
         jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
         JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
         assertEquals(CLIENT_ERROR, createResp.responseCode);
+    }
+
+    @Test
+    public void testInvalidCronSLAUpdate() throws Exception  {
+        TestKit probe = new TestKit(system);
+        String clusterName = "testJobClusterInvalidSLAUpdateIgnored";
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+        final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher, costsCalculator, 0));
+        jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
+        JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
+        assertEquals(SUCCESS, createResp.responseCode);
+
+        UpdateJobClusterSLARequest updateSlaReq = new UpdateJobClusterSLARequest(clusterName, 2, 1,"a b * * * * * * *",IJobClusterDefinition.CronPolicy.KEEP_NEW,false,"user" );
+        jobClusterActor.tell(updateSlaReq, probe.getRef());
+        UpdateJobClusterSLAResponse resp = probe.expectMsgClass(UpdateJobClusterSLAResponse.class);
+
+        assertEquals(CLIENT_ERROR, resp.responseCode);
+        assertEquals(jobClusterActor, probe.getLastSender());
+
+        jobClusterActor.tell(new GetJobClusterRequest(clusterName), probe.getRef());
+        GetJobClusterResponse resp3 = probe.expectMsgClass(GetJobClusterResponse.class);
+
+        assertEquals(SUCCESS, resp3.responseCode);
+        assertTrue(resp3.getJobCluster() != null);
+        System.out.println("Job cluster " + resp3.getJobCluster());
+        assertEquals(clusterName, resp3.getJobCluster().get().getName());
+        // No changes to original SLA
+        assertEquals(0, resp3.getJobCluster().get().getSla().getMin());
+        assertEquals(0, resp3.getJobCluster().get().getSla().getMax());
+
+        verify(jobStoreMock, times(1)).createJobCluster(any());
+        verify(jobStoreMock, times(0)).updateJobCluster(any());
     }
 
     @Test

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -1569,6 +1569,21 @@ public class JobClusterAkkaTest {
     }
 
     @Test
+    public void testUnsupportedCronSubmit() {
+        TestKit probe = new TestKit(system);
+        String clusterName = "testUnsupportedCronSubmit";
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+        SLA sla = new SLA(1,1,"0 18 * * *",IJobClusterDefinition.CronPolicy.KEEP_NEW);
+        final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla);
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher, costsCalculator, 0));
+        jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
+        JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
+        assertEquals(CLIENT_ERROR, createResp.responseCode);
+    }
+
+    @Test
     public void testJobSubmitWithUnique() {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobSubmitWithUnique";

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -1571,12 +1571,47 @@ public class JobClusterAkkaTest {
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidCronDefined() {
         TestKit probe = new TestKit(system);
-        String clusterName = "testInvalidCronDefined";
+        String clusterName = "testInvalidCronSubmit";
         MantisScheduler schedulerMock = mock(MantisScheduler.class);
         MantisJobStore jobStoreMock = mock(MantisJobStore.class);
 
         SLA sla = new SLA(1,1,"a b * * * * * * *",IJobClusterDefinition.CronPolicy.KEEP_NEW);
         final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName, Lists.newArrayList(),sla); //should throw IllegalArgumentException
+    }
+
+    @Test
+    public void testInvalidCronSLAUpdate() throws Exception  {
+        TestKit probe = new TestKit(system);
+        String clusterName = "testJobClusterInvalidSLAUpdateIgnored";
+        MantisScheduler schedulerMock = mock(MantisScheduler.class);
+        MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+        final JobClusterDefinitionImpl fakeJobCluster = createFakeJobClusterDefn(clusterName);
+        ActorRef jobClusterActor = system.actorOf(props(clusterName, jobStoreMock, jobDfn -> schedulerMock, eventPublisher, costsCalculator, 0));
+        jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(fakeJobCluster, user, probe.getRef()), probe.getRef());
+        JobClusterProto.InitializeJobClusterResponse createResp = probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
+        assertEquals(SUCCESS, createResp.responseCode);
+
+        UpdateJobClusterSLARequest updateSlaReq = new UpdateJobClusterSLARequest(clusterName, 2, 1,"a b * * * * * * *",IJobClusterDefinition.CronPolicy.KEEP_NEW,false,"user" );
+        jobClusterActor.tell(updateSlaReq, probe.getRef());
+        UpdateJobClusterSLAResponse resp = probe.expectMsgClass(UpdateJobClusterSLAResponse.class);
+
+        assertEquals(CLIENT_ERROR, resp.responseCode);
+        assertEquals(jobClusterActor, probe.getLastSender());
+
+        jobClusterActor.tell(new GetJobClusterRequest(clusterName), probe.getRef());
+        GetJobClusterResponse resp3 = probe.expectMsgClass(GetJobClusterResponse.class);
+
+        assertEquals(SUCCESS, resp3.responseCode);
+        assertTrue(resp3.getJobCluster() != null);
+        System.out.println("Job cluster " + resp3.getJobCluster());
+        assertEquals(clusterName, resp3.getJobCluster().get().getName());
+        // No changes to original SLA
+        assertEquals(0, resp3.getJobCluster().get().getSla().getMin());
+        assertEquals(0, resp3.getJobCluster().get().getSla().getMax());
+
+        verify(jobStoreMock, times(1)).createJobCluster(any());
+        verify(jobStoreMock, times(0)).updateJobCluster(any());
     }
 
     @Test

--- a/mantis-testcontainers/src/test/java/TestContainerHelloWorld.java
+++ b/mantis-testcontainers/src/test/java/TestContainerHelloWorld.java
@@ -211,7 +211,7 @@ public class TestContainerHelloWorld {
             agentId0,
             agent0,
             5,
-            Duration.ofSeconds(3).toMillis())) {
+            Duration.ofSeconds(10).toMillis())) {
             fail("Failed to register agent: " + agent0.getContainerId());
         }
 
@@ -221,7 +221,7 @@ public class TestContainerHelloWorld {
             controlPlaneHost,
             controlPlanePort,
             10,
-            Duration.ofSeconds(2).toMillis())) {
+            Duration.ofSeconds(10).toMillis())) {
             fail("Failed to start job worker.");
         }
 
@@ -264,7 +264,7 @@ public class TestContainerHelloWorld {
             agentId0,
             agent0,
             5,
-            Duration.ofSeconds(3).toMillis())) {
+            Duration.ofSeconds(10).toMillis())) {
             fail("Failed to register agent: " + agent0.getContainerId());
         }
 
@@ -274,7 +274,7 @@ public class TestContainerHelloWorld {
             controlPlaneHost,
             controlPlanePort,
             5,
-            Duration.ofSeconds(2).toMillis())) {
+            Duration.ofSeconds(10).toMillis())) {
             fail("Failed to start job worker.");
         }
 


### PR DESCRIPTION
### Context

Currently, initializing a job cluster with an incorrect cron schedule that cannot be parsed by Quartz silently errors with a warning log. We should return a response instead

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
