### PR TITLE
Fix scheduler double booking task executors

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -174,6 +174,7 @@ class ResourceClustersManagerActor extends AbstractActor {
                     Duration.ofMillis(masterConfiguration.getHeartbeatIntervalInMs()),
                     Duration.ofMillis(masterConfiguration.getAssignmentIntervalInMs()),
                     Duration.ofMillis(masterConfiguration.getAssignmentIntervalInMs()),
+                    Duration.ofMillis(masterConfiguration.getSchedulerLeaseExpirationDurationInMs()),
                     clock,
                     rpcService,
                     mantisJobStore,

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
@@ -288,7 +288,8 @@ class TaskExecutorState {
         return Duration.between(this.lastSchedulerLeased, this.clock.instant());
     }
 
-    void updateLastSchedulerLeased() {
+    void updateLastSchedulerLeased()
+    {
         this.lastSchedulerLeased = this.clock.instant();
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/TaskExecutorState.java
@@ -32,6 +32,7 @@ import io.mantisrx.server.master.scheduler.JobMessageRouter;
 import io.mantisrx.server.master.scheduler.WorkerOnDisabledVM;
 import io.mantisrx.server.worker.TaskExecutorGateway;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -62,6 +63,9 @@ class TaskExecutorState {
 
     // last interaction initiated by the task executor
     private Instant lastActivity;
+
+    // last interaction time when this instance was leased by the scheduler in findBestFit.
+    private Instant lastSchedulerLeased;
     private final Clock clock;
     private final RpcService rpcService;
     private final JobMessageRouter jobMessageRouter;
@@ -78,6 +82,7 @@ class TaskExecutorState {
             null,
             false,
             clock.instant(),
+            Instant.MIN,
             clock,
             rpcService,
             jobMessageRouter,
@@ -276,6 +281,15 @@ class TaskExecutorState {
     // that are caused from within the server do not cause an uptick.
     Instant getLastActivity() {
         return this.lastActivity;
+    }
+
+    Duration getLastSchedulerLeasedDuration()
+    {
+        return Duration.between(this.lastSchedulerLeased, this.clock.instant());
+    }
+
+    void updateLastSchedulerLeased() {
+        this.lastSchedulerLeased = this.clock.instant();
     }
 
     TaskExecutorRegistration getRegistration() {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -329,6 +329,10 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("60000") // 1 minute
     int getAssignmentIntervalInMs();
 
+    @Config("mantis.agent.assignment.scheduler.lease.ms")
+    @Default("100")
+    int getSchedulerLeaseExpirationDurationInMs();
+
     @Config("mantis.job.costsCalculator.class")
     @Default("io.mantisrx.master.jobcluster.job.NoopCostsCalculator")
     CostsCalculator getJobCostsCalculator();

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorClusterUsageAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorClusterUsageAkkaTest.java
@@ -72,6 +72,7 @@ public class ResourceClusterActorClusterUsageAkkaTest {
     private static final ClusterID CLUSTER_ID = ClusterID.of("clusterId");
     private static final Duration heartbeatTimeout = Duration.ofSeconds(10);
     private static final Duration checkForDisabledExecutorsInterval = Duration.ofSeconds(10);
+    private static final Duration schedulerLeaseExpirationDuration = Duration.ofMillis(100);
     private static final Duration assignmentTimeout = Duration.ofSeconds(1);
     private static final String HOST_NAME = "hostname";
     private static final WorkerPorts WORKER_PORTS = new WorkerPorts(1, 2, 3, 4, 5);
@@ -166,6 +167,7 @@ public class ResourceClusterActorClusterUsageAkkaTest {
                 heartbeatTimeout,
                 assignmentTimeout,
                 checkForDisabledExecutorsInterval,
+                schedulerLeaseExpirationDuration,
                 Clock.systemDefaultZone(),
                 rpcService,
                 mantisJobStore,

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -102,6 +102,7 @@ public class ResourceClusterActorTest {
     private static final ClusterID CLUSTER_ID = ClusterID.of("clusterId");
     private static final Duration heartbeatTimeout = Duration.ofSeconds(10);
     private static final Duration checkForDisabledExecutorsInterval = Duration.ofSeconds(10);
+    private static final Duration schedulerLeaseExpirationDuration = Duration.ofMillis(100);
     private static final Duration assignmentTimeout = Duration.ofSeconds(1);
     private static final String HOST_NAME = "hostname";
 
@@ -201,6 +202,7 @@ public class ResourceClusterActorTest {
                 heartbeatTimeout,
                 assignmentTimeout,
                 checkForDisabledExecutorsInterval,
+                schedulerLeaseExpirationDuration,
                 Clock.systemDefaultZone(),
                 rpcService,
                 mantisJobStore,


### PR DESCRIPTION
### Context

Problem:
When a TE is returned from here to be used for scheduling, its state remain active until the scheduler trigger another message to update (lock) the state. However when large number of the requests are active at the same time on same sku, the gap between here and the message to lock the state can be large so another schedule request message can be in between and got the same set of TEs. 

Solution:
To avoid this, a lease is added to each TE state (based on last scheduled usage timestamp) to temporarily lock the TE to be used again. Since this is only lock between actor messages and lease duration can be short.

* Also fixed a NPE from the node state update call.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
