### PR TITLE
Fix worker no heartbeat race condition

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -1943,18 +1943,18 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                                 acceptedAt);
                         }
                     } else {
+                        // no heartbeat or heartbeat too old
                         if (!workerMeta.getLastHeartbeatAt().isPresent() || Duration.between(workerMeta.getLastHeartbeatAt().get(), currentTime).getSeconds()
                             > missedHeartBeatToleranceSecs) {
-                            // no heartbeat or heartbeat too old
                             this.numWorkerMissingHeartbeat.increment();
 
                             if (!workerMeta.getLastHeartbeatAt().isPresent()) {
-                                LOGGER.info("Job {}, Worker {} hasn't received heartbeat, threshold {} exceeded",
+                                LOGGER.warn("Job {}, Worker {} hasn't received heartbeat, threshold {} exceeded",
                                     this.jobMgr.getJobId(),
                                     workerMeta.getWorkerId(),
                                     missedHeartBeatToleranceSecs);
                             } else {
-                                LOGGER.info("Job {}, Worker {} Duration between last heartbeat and now {} "
+                                LOGGER.warn("Job {}, Worker {} Duration between last heartbeat and now {} "
                                         + "missed heart beat threshold {} exceeded",
                                     this.jobMgr.getJobId(),
                                     workerMeta.getWorkerId(),

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -1943,15 +1943,25 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                                 acceptedAt);
                         }
                     } else {
-                        if (Duration.between(workerMeta.getLastHeartbeatAt().get(), currentTime).getSeconds()
+                        if (!workerMeta.getLastHeartbeatAt().isPresent() || Duration.between(workerMeta.getLastHeartbeatAt().get(), currentTime).getSeconds()
                             > missedHeartBeatToleranceSecs) {
-                            // heartbeat too old
+                            // no heartbeat or heartbeat too old
                             this.numWorkerMissingHeartbeat.increment();
-                            LOGGER.info("Job {}, Worker {} Duration between last heartbeat and now {} "
-                                    + "missed heart beat threshold {} exceeded", this.jobMgr.getJobId(),
-                                workerMeta.getWorkerId(), Duration.between(
-                                    workerMeta.getLastHeartbeatAt().get(),
-                                    currentTime).getSeconds(), missedHeartBeatToleranceSecs);
+
+                            if (!workerMeta.getLastHeartbeatAt().isPresent()) {
+                                LOGGER.info("Job {}, Worker {} hasn't received heartbeat, threshold {} exceeded",
+                                    this.jobMgr.getJobId(),
+                                    workerMeta.getWorkerId(),
+                                    missedHeartBeatToleranceSecs);
+                            } else {
+                                LOGGER.info("Job {}, Worker {} Duration between last heartbeat and now {} "
+                                        + "missed heart beat threshold {} exceeded",
+                                    this.jobMgr.getJobId(),
+                                    workerMeta.getWorkerId(),
+                                    Duration.between(
+                                        workerMeta.getLastHeartbeatAt().get(),
+                                        currentTime).getSeconds(), missedHeartBeatToleranceSecs);
+                            }
 
                             if (ConfigurationProvider.getConfig().isHeartbeatTerminationEnabled()) {
                                 eventPublisher.publishStatusEvent(new LifecycleEventsProto.WorkerStatusEvent(WARN,


### PR DESCRIPTION
### Context

A race condition was introduced from #731 when a heartbeat check happened between launch event and first heartbeat and can trigger NPE on the actor. 
Refactored the condition check on the case above + improve UTs to cover the related states.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
