### PR TITLE
Fix cluster artifact update back compatibility

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
@@ -553,7 +553,11 @@ public class JobClusterManagerProto {
 
             this.clusterName = clusterName;
             this.artifactName = artifact;
-            this.jobJarUrl = jobJarUrl != null ? jobJarUrl : "http://" + artifact;
+            // [Note] in the legacy setup this artifact field is used to host the job jar url field (it maps to the
+            // json property "url".
+            this.jobJarUrl = jobJarUrl != null ?
+                jobJarUrl :
+                (artifact.startsWith("http://") ? artifact : "http://" + artifact);
             this.version = version;
             this.skipSubmit = skipSubmit;
             this.user = user;

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -790,6 +790,30 @@ public class JobClusterAkkaTest {
     }
 
     @Test
+    public void testJobClusterArtifactUpdateBackCompat() throws Exception {
+        String clusterName = "testJobClusterArtifactUpdateBackCompat";
+        UpdateJobClusterArtifactRequest req = new UpdateJobClusterArtifactRequest(
+            clusterName,
+            "http://path1/artifact1-1.zip",
+            null,
+            "1",
+            true,
+            "user");
+        assertEquals("http://path1/artifact1-1.zip", req.getArtifactName());
+        assertEquals("http://path1/artifact1-1.zip", req.getjobJarUrl());
+
+        UpdateJobClusterArtifactRequest req2 = new UpdateJobClusterArtifactRequest(
+            clusterName,
+            "artifact1-1.zip",
+            null,
+            "1",
+            true,
+            "user");
+        assertEquals("artifact1-1.zip", req2.getArtifactName());
+        assertEquals("http://artifact1-1.zip", req2.getjobJarUrl());
+    }
+
+    @Test
     public void testJobClusterArtifactUpdate() throws Exception  {
         TestKit probe = new TestKit(system);
         String clusterName = "testJobClusterArtifactUpdate";


### PR DESCRIPTION
### Context

The update artifact request's artifact field is mapped to the "url" request field. In #708 the extra "http://" prefix is added to the job jar url causing double prefix in the existing job config.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
