### PR TITLE
Fix https jar url in update artifact request

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/proto/JobClusterManagerProto.java
@@ -557,7 +557,7 @@ public class JobClusterManagerProto {
             // json property "url".
             this.jobJarUrl = jobJarUrl != null ?
                 jobJarUrl :
-                (artifact.startsWith("http://") ? artifact : "http://" + artifact);
+                (artifact.startsWith("http://") || artifact.startsWith("https://") ? artifact : "http://" + artifact);
             this.version = version;
             this.skipSubmit = skipSubmit;
             this.user = user;

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -811,6 +811,16 @@ public class JobClusterAkkaTest {
             "user");
         assertEquals("artifact1-1.zip", req2.getArtifactName());
         assertEquals("http://artifact1-1.zip", req2.getjobJarUrl());
+
+        UpdateJobClusterArtifactRequest req3 = new UpdateJobClusterArtifactRequest(
+            clusterName,
+            "https://path1/artifact1-1.zip",
+            null,
+            "1",
+            true,
+            "user");
+        assertEquals("https://path1/artifact1-1.zip", req3.getArtifactName());
+        assertEquals("https://path1/artifact1-1.zip", req3.getjobJarUrl());
     }
 
     @Test


### PR DESCRIPTION
### Context

Needs to handle both https and http url in the back compatibility change for legacy jar artifact url.
 
### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
