### PR TITLE
DynamoDBMasterMonitor: Add option to disable shutdown hook.

### DIFF
--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBConfig.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBConfig.java
@@ -68,7 +68,7 @@ public interface DynamoDBConfig {
     @Default("false")
     boolean getDynamoDBUseLocal();
 
-    @Config("mantis.ext.dynamodb.disableMonitorShutdown")
-    @Default("false")
-    boolean getDisableMonitorShutdown();
+    @Config("mantis.ext.dynamodb.enableShutdownHook")
+    @Default("true")
+    boolean getEnableShutdownHook();
 }

--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBConfig.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBConfig.java
@@ -67,4 +67,8 @@ public interface DynamoDBConfig {
     @Config("mantis.ext.dynamodb.useLocal")
     @Default("false")
     boolean getDynamoDBUseLocal();
+
+    @Config("mantis.ext.dynamodb.disableMonitorShutdown")
+    @Default("false")
+    boolean getDisableMonitorShutdown();
 }

--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitorSingleton.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitorSingleton.java
@@ -75,6 +75,9 @@ class DynamoDBMasterMonitorSingleton {
     public static synchronized DynamoDBMasterMonitorSingleton getInstance() {
         if (instance == null) {
             instance = new DynamoDBMasterMonitorSingleton();
+
+            // We allow agents to disable the shutdown hook as avoid losing contact with the master prematurely.
+            // Master should keep this because it releases the leader lock.
             if (!DynamoDBClientSingleton.getDynamoDBConf().getDisableMonitorShutdown()) {
                 Runtime.getRuntime()
                     .addShutdownHook(new Thread(instance::shutdown, "dynamodb-monitor-shutdown-" + instance.hashCode()));

--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitorSingleton.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitorSingleton.java
@@ -78,7 +78,7 @@ class DynamoDBMasterMonitorSingleton {
 
             // We allow agents to disable the shutdown hook as avoid losing contact with the master prematurely.
             // Master should keep this because it releases the leader lock.
-            if (!DynamoDBClientSingleton.getDynamoDBConf().getDisableMonitorShutdown()) {
+            if (DynamoDBClientSingleton.getDynamoDBConf().getEnableShutdownHook()) {
                 Runtime.getRuntime()
                     .addShutdownHook(new Thread(instance::shutdown, "dynamodb-monitor-shutdown-" + instance.hashCode()));
             }


### PR DESCRIPTION
### Context

The `DynamoDBMasterMonitor` presently ensures a clean shutdown when the JVM shutdown hook is called. This works well for Master instances as it will release the lock on the leader election. However in when running on the agent this has the downside of sometimes shutting down before other threads that require master communication. The result is workers that stay stuck until a `180s` heartbeat timeout. Furthermore closing the lock client has no benefit for the agents -- they don't lock it.

This would enable us to configure agents to let this thread keep running. It is configured as a daemon thread so it will not prevent the JVM from shutting down.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
