### PR TITLE
Update JobSource to take in additional query params

### DIFF
--- a/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/core/AbstractJobSource.java
+++ b/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/core/AbstractJobSource.java
@@ -23,6 +23,7 @@ import io.mantisrx.common.MantisServerSentEvent;
 import io.mantisrx.runtime.parameter.SinkParameters;
 import io.mantisrx.runtime.source.Source;
 import java.io.UnsupportedEncodingException;
+import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,15 @@ public abstract class AbstractJobSource implements Source<MantisServerSentEvent>
                                                final Optional<String> subscriptionId,
                                                final boolean enableMetaMessages,
                                                boolean enableCompressedBinaryInput, final long metaMessageInterval) {
+        return this.getDefaultSinkParams(clientId, samplePerSec, criterion, subscriptionId, enableMetaMessages, enableCompressedBinaryInput, metaMessageInterval, null);
+    }
+
+    public SinkParameters getDefaultSinkParams(final String clientId,
+                                               final int samplePerSec,
+                                               final Optional<String> criterion,
+                                               final Optional<String> subscriptionId,
+                                               final boolean enableMetaMessages,
+                                               boolean enableCompressedBinaryInput, final long metaMessageInterval, Map<String, String> additionalParams) {
         SinkParameters.Builder defaultParamBuilder = new SinkParameters.Builder();
 
         try {
@@ -63,6 +73,11 @@ public abstract class AbstractJobSource implements Source<MantisServerSentEvent>
             }
             if (enableCompressedBinaryInput) {
                 defaultParamBuilder = defaultParamBuilder.withParameter(MantisSSEConstants.MANTIS_ENABLE_COMPRESSION, Boolean.toString(true));
+            }
+            if (additionalParams != null) {
+                for (Map.Entry<String, String> entry : additionalParams.entrySet()) {
+                    defaultParamBuilder.withParameter(entry.getKey(), entry.getValue());
+                }
             }
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e.getMessage());

--- a/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/core/AbstractSourceJobSource.java
+++ b/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/core/AbstractSourceJobSource.java
@@ -19,6 +19,7 @@ package io.mantisrx.connector.job.core;
 import io.mantisrx.client.MantisSSEJob;
 import io.mantisrx.client.SinkConnectionsStatus;
 import io.mantisrx.runtime.parameter.SinkParameters;
+import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +52,7 @@ public abstract class AbstractSourceJobSource extends AbstractJobSource {
         LOGGER.info("Connecting to source job " + sourceJobName + " obs " + sinkConnObs);
         boolean enableMetaMessages = false;
         boolean enableCompressedBinaryInput = false;
-        return connectToQueryBasedJob(MantisSourceJobConnectorFactory.getConnector(), criterion, sourceJobName, clientId, samplePerSec, enableMetaMessages, enableCompressedBinaryInput, sinkConnObs, Optional.<SinkParameters>empty());
+        return connectToQueryBasedJob(MantisSourceJobConnectorFactory.getConnector(), criterion, sourceJobName, clientId, samplePerSec, enableMetaMessages, enableCompressedBinaryInput, sinkConnObs, null, Optional.<SinkParameters>empty());
 
     }
 
@@ -72,13 +73,21 @@ public abstract class AbstractSourceJobSource extends AbstractJobSource {
     public MantisSSEJob getSourceJob(String sourceJobName, String criterion, String clientId,
                                      int samplePerSec, boolean enableMetaMessages, boolean enableCompressedBinaryInput, Observer<SinkConnectionsStatus> sinkConnObs, Optional<SinkParameters> sinkParamsO) {
         LOGGER.info("Connecting to source job " + sourceJobName + " obs " + sinkConnObs);
-        return connectToQueryBasedJob(MantisSourceJobConnectorFactory.getConnector(), criterion, sourceJobName, clientId, samplePerSec, enableMetaMessages, enableCompressedBinaryInput, sinkConnObs, sinkParamsO);
+        return connectToQueryBasedJob(MantisSourceJobConnectorFactory.getConnector(), criterion, sourceJobName, clientId, samplePerSec, enableMetaMessages, enableCompressedBinaryInput, sinkConnObs, null, sinkParamsO);
+
+    }
+
+    public MantisSSEJob getSourceJob(String sourceJobName, String criterion, String clientId,
+                                     int samplePerSec, boolean enableMetaMessages, boolean enableCompressedBinaryInput, Observer<SinkConnectionsStatus> sinkConnObs, Map<String, String> additionalParams, Optional<SinkParameters> sinkParamsO) {
+        LOGGER.info("Connecting to source job " + sourceJobName + " obs " + sinkConnObs);
+        return connectToQueryBasedJob(MantisSourceJobConnectorFactory.getConnector(), criterion, sourceJobName, clientId, samplePerSec, enableMetaMessages, enableCompressedBinaryInput, sinkConnObs, additionalParams, sinkParamsO);
 
     }
 
     private MantisSSEJob connectToQueryBasedJob(MantisSourceJobConnector connector, String criterion,
                                                 String jobName, String clientId, int samplePerSec, boolean enableMetaMessages, boolean enableCompressedBinaryInput,
                                                 Observer<SinkConnectionsStatus> sinkConnObs,
+                                                Map<String, String> additionalParams,
                                                 Optional<SinkParameters> sinkParamsO) {
         LOGGER.info("Connecting to " + jobName);
         if (criterion == null || criterion.isEmpty()) {
@@ -86,7 +95,7 @@ public abstract class AbstractSourceJobSource extends AbstractJobSource {
         }
         String subId = Integer.toString(criterion.hashCode());
         SinkParameters defaultParams = getDefaultSinkParams(clientId, samplePerSec,
-                Optional.of(criterion), Optional.of(subId), enableMetaMessages, enableCompressedBinaryInput, 500);
+                Optional.of(criterion), Optional.of(subId), enableMetaMessages, enableCompressedBinaryInput, 500, additionalParams);
 
         return connector.connectToJob(jobName, sinkParamsO.orElse(defaultParams), sinkConnObs);
     }

--- a/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/source/JobSource.java
+++ b/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/source/JobSource.java
@@ -17,6 +17,7 @@
 package io.mantisrx.connector.job.source;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mantisrx.common.utils.Closeables;
@@ -39,11 +40,8 @@ import io.mantisrx.shaded.com.google.common.collect.Lists;
 import io.vavr.Tuple;
 import io.vavr.Tuple2;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -111,8 +109,9 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
                 clientId = clientId + "_" + workerNo;
             }
             boolean enableCompressedBinary = targetInfo.enableCompressedBinary;
+            Map<String, String> additionalParams = targetInfo.additionalParams;
 
-            job = getSourceJob(sourceJobName, criterion, clientId, samplePerSec, enableMetaMessages, enableCompressedBinary, obs, Optional.<SinkParameters>empty());
+            job = getSourceJob(sourceJobName, criterion, clientId, samplePerSec, enableMetaMessages, enableCompressedBinary, obs, additionalParams, Optional.<SinkParameters>empty());
             jobs.add(job);
 
             if (sourceObs == null) {
@@ -155,6 +154,7 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
         public boolean enableMetaMessages;
         public boolean enableCompressedBinary;
         public String clientId;
+        public Map<String, String> additionalParams;
 
         public TargetInfo(String jobName,
                           String criterion,
@@ -163,6 +163,17 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
                           boolean isBroadcastMode,
                           boolean enableMetaMessages,
                           boolean enableCompressedBinary) {
+            this(jobName, criterion, clientId, samplePerSec, isBroadcastMode, enableMetaMessages, enableCompressedBinary, null);
+        }
+
+        public TargetInfo(String jobName,
+                          String criterion,
+                          String clientId,
+                          int samplePerSec,
+                          boolean isBroadcastMode,
+                          boolean enableMetaMessages,
+                          boolean enableCompressedBinary,
+                          Map<String, String> additionalParams) {
             this.sourceJobName = jobName;
             this.criterion = criterion;
             this.clientId = clientId;
@@ -170,6 +181,7 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
             this.isBroadcastMode = isBroadcastMode;
             this.enableMetaMessages = enableMetaMessages;
             this.enableCompressedBinary = enableCompressedBinary;
+            this.additionalParams = additionalParams;
         }
     }
 
@@ -216,6 +228,21 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
                 enableCompressedBinary = true;
             }
 
+            // Extract additionalParams
+            Map<String, String> additionalParams = new HashMap<>();
+            for (Map.Entry<String, JsonElement> entry : srcObj.entrySet()) {
+                String key = entry.getKey();
+                if (!key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_NAME_PARAM) &&
+                    !key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_CRITERION) &&
+                    !key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_CLIENT_ID) &&
+                    !key.equals(MantisSSEConstants.SAMPLE) &&
+                    !key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_IS_BROADCAST_MODE) &&
+                    !key.equals(MantisSSEConstants.ENABLE_META_MESSAGES) &&
+                    !key.equals(MantisSSEConstants.MANTIS_ENABLE_COMPRESSION)) {
+                    additionalParams.put(key, entry.getValue().getAsString());
+                }
+            }
+
             TargetInfo ti = new TargetInfo(
                     sName,
                     criterion,
@@ -223,7 +250,8 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
                     sample,
                     isBroadCastMode,
                     enableMetaMessages,
-                    enableCompressedBinary);
+                    enableCompressedBinary,
+                    additionalParams);
             targetList.add(ti);
             LOGGER.info("sname: " + sName + " criterion: " + criterion + " isBroadcastMode " + isBroadCastMode);
         }
@@ -244,6 +272,7 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
         private boolean isBroadcastMode = false;
         private boolean enableMetaMessages = false;
         private boolean enableCompressedBinary = false;
+        private Map<String, String> additionalParams = new HashMap<>();
 
         public TargetInfoBuilder() {
         }
@@ -284,6 +313,11 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
             return this;
         }
 
+        public TargetInfoBuilder withAdditionalParams(Map<String, String> additionalParams) {
+            this.additionalParams = additionalParams;
+            return this;
+        }
+
         public TargetInfo build() {
             return new TargetInfo(
                     sourceJobName,
@@ -292,7 +326,8 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
                     samplePerSec,
                     isBroadcastMode,
                     enableMetaMessages,
-                    enableCompressedBinary);
+                    enableCompressedBinary,
+                    additionalParams);
         }
     }
 

--- a/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/source/JobSource.java
+++ b/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/source/JobSource.java
@@ -232,15 +232,16 @@ public class JobSource extends AbstractSourceJobSource implements Source<MantisS
             Map<String, String> additionalParams = new HashMap<>();
             for (Map.Entry<String, JsonElement> entry : srcObj.entrySet()) {
                 String key = entry.getKey();
-                if (!key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_NAME_PARAM) &&
-                    !key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_CRITERION) &&
-                    !key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_CLIENT_ID) &&
-                    !key.equals(MantisSSEConstants.SAMPLE) &&
-                    !key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_IS_BROADCAST_MODE) &&
-                    !key.equals(MantisSSEConstants.ENABLE_META_MESSAGES) &&
-                    !key.equals(MantisSSEConstants.MANTIS_ENABLE_COMPRESSION)) {
-                    additionalParams.put(key, entry.getValue().getAsString());
+                if (key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_NAME_PARAM) ||
+                    key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_CRITERION) ||
+                    key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_CLIENT_ID) ||
+                    key.equals(MantisSSEConstants.SAMPLE) ||
+                    key.equals(MantisSourceJobConnector.MANTIS_SOURCEJOB_IS_BROADCAST_MODE) ||
+                    key.equals(MantisSSEConstants.ENABLE_META_MESSAGES) ||
+                    key.equals(MantisSSEConstants.MANTIS_ENABLE_COMPRESSION)) {
+                    LOGGER.warn("Overwriting key " + key + " in additionalParams");
                 }
+                additionalParams.put(key, entry.getValue().getAsString());
             }
 
             TargetInfo ti = new TargetInfo(

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/SourceJobParameters.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/SourceJobParameters.java
@@ -32,6 +32,7 @@ public class SourceJobParameters {
     public static final String MANTIS_SOURCEJOB_CRITERION = "criterion";
     public static final String MANTIS_SOURCEJOB_CLIENT_ID = "clientId";
     public static final String MANTIS_SOURCEJOB_IS_BROADCAST_MODE = "isBroadcastMode";
+    public static final String MANTIS_SOURCEJOB_ADDITIONAL_PARAMS = "additionalParams";
     private static final Logger log = LoggerFactory.getLogger(SourceJobParameters.class);
     private static final ObjectMapper mapper = new ObjectMapper();
 
@@ -68,6 +69,7 @@ public class SourceJobParameters {
         @JsonProperty(MantisSSEConstants.ENABLE_META_MESSAGES) public boolean enableMetaMessages;
         @JsonProperty(MantisSSEConstants.MANTIS_ENABLE_COMPRESSION) public boolean enableCompressedBinary;
         @JsonProperty(MantisSSEConstants.MANTIS_COMPRESSION_DELIMITER) public String delimiter;
+        @JsonProperty(MANTIS_SOURCEJOB_ADDITIONAL_PARAMS) public Map<String, String> additionalParams;
 
         public TargetInfo(String jobName,
                           String criterion,
@@ -77,6 +79,18 @@ public class SourceJobParameters {
                           boolean enableMetaMessages,
                           boolean enableCompressedBinary,
                           String delimiter) {
+            this(jobName, criterion, clientId, samplePerSec, isBroadcastMode, enableMetaMessages, enableCompressedBinary, delimiter, null);
+        }
+
+        public TargetInfo(String jobName,
+                          String criterion,
+                          String clientId,
+                          int samplePerSec,
+                          boolean isBroadcastMode,
+                          boolean enableMetaMessages,
+                          boolean enableCompressedBinary,
+                          String delimiter,
+                          Map<String, String> additionalParams) {
             this.sourceJobName = jobName;
             this.criterion = criterion;
             this.clientId = clientId;
@@ -85,6 +99,7 @@ public class SourceJobParameters {
             this.enableMetaMessages = enableMetaMessages;
             this.enableCompressedBinary = enableCompressedBinary;
             this.delimiter = delimiter;
+            this.additionalParams = additionalParams;
         }
 
         public TargetInfo() {
@@ -102,12 +117,13 @@ public class SourceJobParameters {
                     Objects.equals(isBroadcastMode, that.isBroadcastMode) &&
                     Objects.equals(enableMetaMessages, that.enableMetaMessages) &&
                     Objects.equals(enableCompressedBinary, that.enableCompressedBinary) &&
-                    Objects.equals(delimiter, that.delimiter);
+                    Objects.equals(delimiter, that.delimiter) &&
+                    Objects.equals(additionalParams, that.additionalParams);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(sourceJobName, criterion, clientId, samplePerSec, isBroadcastMode, enableMetaMessages, enableCompressedBinary, delimiter);
+            return Objects.hash(sourceJobName, criterion, clientId, samplePerSec, isBroadcastMode, enableMetaMessages, enableCompressedBinary, delimiter, additionalParams);
         }
 
         @Override
@@ -121,6 +137,7 @@ public class SourceJobParameters {
                     "enableMetaMessages=" + enableMetaMessages + "," +
                     "enableCompressedBinary=" + enableCompressedBinary + "," +
                     "delimiter=" + delimiter + "," +
+                    "additionalParams=" + additionalParams +
                     "}";
         }
     }
@@ -135,6 +152,7 @@ public class SourceJobParameters {
         private boolean enableMetaMessages = false;
         private boolean enableCompressedBinary = false;
         private String delimiter = null;
+        private Map<String, String> additionalParams;
 
         public TargetInfoBuilder() {
         }
@@ -180,6 +198,11 @@ public class SourceJobParameters {
             return this;
         }
 
+        public TargetInfoBuilder withAdditionalParams(Map<String, String> additionalParams) {
+            this.additionalParams = additionalParams;
+            return this;
+        }
+
         public TargetInfo build() {
             return new TargetInfo(
                     sourceJobName,
@@ -189,7 +212,8 @@ public class SourceJobParameters {
                     isBroadcastMode,
                     enableMetaMessages,
                     enableCompressedBinary,
-                    delimiter);
+                    delimiter,
+                    additionalParams);
         }
     }
 


### PR DESCRIPTION
### Context

a followup on https://github.com/Netflix/mantis/pull/747
allow users to pass in additional query params like availabilityZone={availabilityZone} to JobSource 

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
