### PR TITLE
Fix getDefaultSinkParams not returning additionalParams

### DIFF
--- a/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/core/AbstractJobSource.java
+++ b/mantis-connectors/mantis-connector-job-source/src/main/java/io/mantisrx/connector/job/core/AbstractJobSource.java
@@ -76,7 +76,7 @@ public abstract class AbstractJobSource implements Source<MantisServerSentEvent>
             }
             if (additionalParams != null) {
                 for (Map.Entry<String, String> entry : additionalParams.entrySet()) {
-                    defaultParamBuilder.withParameter(entry.getKey(), entry.getValue());
+                    defaultParamBuilder = defaultParamBuilder.withParameter(entry.getKey(), entry.getValue());
                 }
             }
         } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
### Context

Fix the bug introduced in https://github.com/Netflix/mantis/pull/748 where getDefaultSinkParams didn't update with additional params

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
