### PR TITLE
Make executor state manager pluggable

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 /**
  * A component to manage the states of {@link TaskExecutorState} for a given {@link ResourceClusterActor}.
  */
-interface ExecutorStateManager {
+public interface ExecutorStateManager {
     /**
      * Store and track the given task executor's state inside this {@link ExecutorStateManager} if there is no existing
      * state already. Ignore the given state instance if there is already a state associated with the given ID.

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -154,7 +154,8 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         String jobClustersWithArtifactCachingEnabled,
         boolean isJobArtifactCachingEnabled,
         Map<String, String> schedulingAttributes,
-        FitnessCalculator fitnessCalculator
+        FitnessCalculator fitnessCalculator,
+        Optional<ExecutorStateManager> executorStateManager
     ) {
         return Props.create(
             ResourceClusterActor.class,
@@ -171,7 +172,8 @@ class ResourceClusterActor extends AbstractActorWithTimers {
             jobClustersWithArtifactCachingEnabled,
             isJobArtifactCachingEnabled,
             schedulingAttributes,
-            fitnessCalculator
+            fitnessCalculator,
+            executorStateManager
         ).withMailbox("akka.actor.metered-mailbox");
     }
 
@@ -189,7 +191,8 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         String jobClustersWithArtifactCachingEnabled,
         boolean isJobArtifactCachingEnabled,
         Map<String, String> schedulingAttributes,
-        FitnessCalculator fitnessCalculator) {
+        FitnessCalculator fitnessCalculator,
+        Optional<ExecutorStateManager> executorStateManager) {
         this.clusterID = clusterID;
         this.heartbeatTimeout = heartbeatTimeout;
         this.assignmentTimeout = assignmentTimeout;
@@ -206,8 +209,8 @@ class ResourceClusterActor extends AbstractActorWithTimers {
         this.maxJobArtifactsToCache = maxJobArtifactsToCache;
         this.jobClustersWithArtifactCachingEnabled = jobClustersWithArtifactCachingEnabled;
 
-        this.executorStateManager = new ExecutorStateManagerImpl(
-            schedulingAttributes, fitnessCalculator, this.schedulerLeaseExpirationDuration);
+        this.executorStateManager = executorStateManager.orElseGet(() -> new ExecutorStateManagerImpl(
+            schedulingAttributes, fitnessCalculator, this.schedulerLeaseExpirationDuration));
 
         this.metrics = new ResourceClusterActorMetrics();
     }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -54,6 +54,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Value;
@@ -183,7 +184,9 @@ class ResourceClustersManagerActor extends AbstractActor {
                     masterConfiguration.getJobClustersWithArtifactCachingEnabled(),
                     masterConfiguration.isJobArtifactCachingEnabled(),
                     masterConfiguration.getSchedulingConstraints(),
-                    masterConfiguration.getFitnessCalculator()),
+                    masterConfiguration.getFitnessCalculator(),
+                    Optional.of(masterConfiguration.getExecutorStateManager())
+                ),
                 "ResourceClusterActor-" + clusterID.getResourceID());
         log.info("Created resource cluster actor for {}", clusterID);
         return clusterActor;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -22,6 +22,7 @@ import io.mantisrx.server.core.CoreConfiguration;
 import io.mantisrx.server.core.IKeyValueStore;
 import io.mantisrx.shaded.com.google.common.base.Splitter;
 import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
+import io.mantisrx.master.resourcecluster.ExecutorStateManager;
 import java.time.Duration;
 import java.util.Map;
 import org.skife.config.Config;
@@ -162,6 +163,9 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Config("mantis.master.scheduler.fitnessCalculator.class")
     @Default("io.mantisrx.master.scheduler.CpuWeightedFitnessCalculator")
     FitnessCalculator getFitnessCalculator();
+
+    @Config("mantis.master.scheduler.executorstatemanager.class")
+    ExecutorStateManager getExecutorStateManager();
 
     default Duration getSchedulerIntervalBetweenRetries() {
         return Duration.ofMillis(getSchedulerIntervalBetweenRetriesInMs());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorClusterUsageAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorClusterUsageAkkaTest.java
@@ -177,7 +177,7 @@ public class ResourceClusterActorClusterUsageAkkaTest {
                 false,
                 ImmutableMap.of("jdk", "8"),
                 new CpuWeightedFitnessCalculator(),
-                null);
+                Optional.empty());
 
         resourceClusterActor = actorSystem.actorOf(props);
         resourceCluster =

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorClusterUsageAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorClusterUsageAkkaTest.java
@@ -176,7 +176,8 @@ public class ResourceClusterActorClusterUsageAkkaTest {
                 "",
                 false,
                 ImmutableMap.of("jdk", "8"),
-                new CpuWeightedFitnessCalculator());
+                new CpuWeightedFitnessCalculator(),
+                null);
 
         resourceClusterActor = actorSystem.actorOf(props);
         resourceCluster =

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -211,7 +211,8 @@ public class ResourceClusterActorTest {
                 "",
                 false,
                 ImmutableMap.of(),
-                new CpuWeightedFitnessCalculator());
+                new CpuWeightedFitnessCalculator(),
+                Optional.empty());
 
         resourceClusterActor = actorSystem.actorOf(props);
         resourceCluster =


### PR DESCRIPTION
### Context

Making the ExecutorStateManager pluggable so we can implement some custom scheduling logic 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
