### PR TITLE
Upgrade to actions-cache v4

### DIFF
--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -25,14 +25,14 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
           restore-keys: |
             - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: ~/.gradle/wrapper

--- a/.github/workflows/nebula-ci.yml
+++ b/.github/workflows/nebula-ci.yml
@@ -25,14 +25,16 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v4
+      - name: Gradle Cache
+        uses: actions/cache@v4
         id: gradle-cache
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle/dependency-locks/*.lockfile') }}
           restore-keys: |
             - ${{ runner.os }}-gradle-
-      - uses: actions/cache@v4
+      - name: Gradle Wrapper Cache
+        uses: actions/cache@v4
         id: gradle-wrapper-cache
         with:
           path: ~/.gradle/wrapper

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -92,7 +92,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -77,6 +77,7 @@ docker {
     }
 
     dockerCreateDockerfile {
+        instruction 'USER root'
         instruction 'RUN apt-get update && apt-get install -y curl'
 
         // instructions to install all the necessary dependencies

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -77,8 +77,7 @@ docker {
     }
 
     dockerCreateDockerfile {
-        instruction 'RUN which apt-get'
-        instruction 'RUN apt-get clean && apt-get update && apt-get install -y curl'
+        instruction 'RUN apt-get update && apt-get install -y curl'
 
         // instructions to install all the necessary dependencies
         instruction 'WORKDIR /apps/mantis/mantis-control-plane-server'

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -77,8 +77,8 @@ docker {
     }
 
     dockerCreateDockerfile {
-        instruction 'USER root'
-        instruction 'RUN apt-get update && apt-get install -y curl'
+        instruction 'RUN which apt-get'
+        instruction 'RUN apt-get clean && apt-get update && apt-get install -y curl'
 
         // instructions to install all the necessary dependencies
         instruction 'WORKDIR /apps/mantis/mantis-control-plane-server'

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -77,7 +77,7 @@ docker {
     }
 
     dockerCreateDockerfile {
-        instruction 'RUN apt-get clean && apt-get update && apt-get install -y curl'
+        instruction 'RUN apt-get clean && apt-get update && apt-get install -y curl=7.80.0-1ubuntu1.2'
 
         // instructions to install all the necessary dependencies
         instruction 'WORKDIR /apps/mantis/mantis-control-plane-server'

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -77,7 +77,7 @@ docker {
     }
 
     dockerCreateDockerfile {
-        instruction 'RUN apt-get clean && apt-get update && apt-get install -y curl=7.80.0-1ubuntu1.2'
+        instruction 'RUN apt-get clean && apt-get update && apt-get install -y curl'
 
         // instructions to install all the necessary dependencies
         instruction 'WORKDIR /apps/mantis/mantis-control-plane-server'

--- a/mantis-control-plane/mantis-control-plane-server/build.gradle
+++ b/mantis-control-plane/mantis-control-plane-server/build.gradle
@@ -77,7 +77,7 @@ docker {
     }
 
     dockerCreateDockerfile {
-        instruction 'RUN apt-get update && apt-get install -y curl'
+        instruction 'RUN apt-get clean && apt-get update && apt-get install -y curl'
 
         // instructions to install all the necessary dependencies
         instruction 'WORKDIR /apps/mantis/mantis-control-plane-server'


### PR DESCRIPTION
### Context
Actions Cache v1 and v2 are being [deprecated](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) March 01, 2025.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
