### PR TITLE
Fixing class visibility

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
@@ -66,7 +66,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.math3.util.Precision;
 
 @Slf4j
-class ExecutorStateManagerImpl implements ExecutorStateManager {
+public class ExecutorStateManagerImpl implements ExecutorStateManager {
     private final Map<TaskExecutorID, TaskExecutorState> taskExecutorStateMap = new HashMap<>();
     Cache<String, JobRequirements> pendingJobRequests = CacheBuilder.newBuilder()
         .maximumSize(1000)

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClusterActor.java
@@ -97,7 +97,7 @@ import org.apache.flink.runtime.rpc.RpcService;
  */
 @ToString(of = {"clusterID"})
 @Slf4j
-class ResourceClusterActor extends AbstractActorWithTimers {
+public class ResourceClusterActor extends AbstractActorWithTimers {
     /**
      * For ResourceClusterActor instances, we need to ensure they are always running after encountering error so that
      * TaskExecutors can still remain connected. If there is a fatal error that needs to be escalated to terminate the


### PR DESCRIPTION
### Context

When implementing the scheduling hook I made some inner classes public but not the encapsulating class so I cannot access it https://github.com/Netflix/mantis/pull/753

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
