### PR TITLE
Fix custom rule error handling

### DIFF
--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/rules/CustomRuleActor.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/jobmaster/rules/CustomRuleActor.java
@@ -121,9 +121,8 @@ public class CustomRuleActor extends AbstractActor {
             if (result.isSuccess()) {
                 log.info("Custom trigger started successfully");
             } else {
-                log.error("failed to run custom rule: {}, restart rule actor",
+                log.error("failed to run custom rule: {}",
                     this.rule, result.failed().get());
-                throw new RuntimeException("CustomTrigger run failed, restart rule actor", result.failed().get());
             }
             return null;
         }, getContext().dispatcher());


### PR DESCRIPTION
### Context

* Remove not used runtime exception.
* UT to validate error behavior: run failure from custom trigger should NOT trigger rule actor restart to avoid short-circuit.


### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
