### PR TITLE
Replace slotId tag with clientId in PushServer

### DIFF
--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
@@ -245,11 +245,11 @@ public abstract class PushServer<T, R> {
             groupId = id;
         }
 
-        final BasicTag slotIdTag = new BasicTag("slotId", slotId);
+        final BasicTag clientIdTag = new BasicTag(CLIENT_ID_TAG_NAME, Optional.ofNullable(groupId).orElse("none"));
 
         SerializedSubject<List<byte[]>, List<byte[]>> subject
             = new SerializedSubject<>(PublishSubject.<List<byte[]>>create());
-        Observable<List<byte[]>> observable = subject.lift(new DropOperator<>("batch_writes", slotIdTag));
+        Observable<List<byte[]>> observable = subject.lift(new DropOperator<>("batch_writes", clientIdTag));
 
         if (applySampling) {
             observable =
@@ -266,7 +266,6 @@ public abstract class PushServer<T, R> {
                     );
         }
 
-        final BasicTag clientIdTag = new BasicTag(CLIENT_ID_TAG_NAME, Optional.ofNullable(groupId).orElse("none"));
         Metrics writableMetrics = new Metrics.Builder()
             .id("PushServer", clientIdTag)
             .addCounter("channelWritable")


### PR DESCRIPTION
### Context

In pushServer the slotId tag's cardinality is too big and costly and we can achieve similar granularity using a combination of clientId + infra tags.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
