### PR TITLE
Enable v2 scaler by default

### DIFF
--- a/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/WorkerExecutionOperationsNetworkStage.java
+++ b/mantis-runtime-executor/src/main/java/io/mantisrx/server/worker/WorkerExecutionOperationsNetworkStage.java
@@ -411,7 +411,7 @@ public class WorkerExecutionOperationsNetworkStage implements WorkerExecutionOpe
                 JobAutoscalerManager jobAutoscalerManager = getJobAutoscalerManagerInstance(serviceLocator);
 
                 // switch to v2 scaler control only when parameter is set to true for now
-                final Boolean useV2ScalerService = (Boolean) parameters.get(JOB_AUTOSCALE_V2_ENABLED_PARAM, false);
+                final Boolean useV2ScalerService = (Boolean) parameters.get(JOB_AUTOSCALE_V2_ENABLED_PARAM, true);
                 if (useV2ScalerService) {
                     logger.info("[V2 AUTO-SCALER ENABLED] Using V2 JobAutoScalerService: JobMasterServiceV2");
                     Service jobMasterServiceV2 = new JobMasterServiceV2(

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/ParameterUtils.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/parameter/ParameterUtils.java
@@ -214,7 +214,7 @@ public class ParameterUtils {
         ParameterDefinition<Boolean> autoscaleV2Enabled = new BooleanParameter()
             .name(JOB_AUTOSCALE_V2_ENABLED_PARAM)
             .validator(Validators.alwaysPass())
-            .defaultValue(false)
+            .defaultValue(true)
             .description("Enable v2 job master service.")
             .build();
         systemParams.put(autoscaleV2Enabled.getName(), autoscaleV2Enabled);


### PR DESCRIPTION
### Context

Note: V2 scaler for dynamic scaler rule support is fully back-compatible with v1 scaler so no change is expected on existing jobs.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
