### PR TITLE
[WIP] DynamoDB client session monitor

### DIFF
--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBLeaderElector.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBLeaderElector.java
@@ -131,6 +131,8 @@ public class DynamoDBLeaderElector extends BaseService {
                                     .withReplaceData(true)
                                     .withAcquireReleasedLocksConsistently(true)
                                     .withData(ByteBuffer.wrap(jsonMapper.writeValueAsBytes(me)))
+                                    // @todo(andresgalindo) this should come from config
+                                    .withSessionMonitor(5000L, Optional.of(leadershipManager::stopBeingLeader))
                                     .build());
             if (optionalLock.isPresent()) {
                 leaderLock = optionalLock.get();


### PR DESCRIPTION
### Context

Setting session monitor so we can give up leadership if master loses lock for reasons other than a restart

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
