### PR TITLE
update log level from into to debug for two big log lines

### DIFF
--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/ConnectionManager.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/ConnectionManager.java
@@ -127,7 +127,7 @@ public class ConnectionManager<T> {
                 }
             }
             current.addConnection(connection);
-            logger.info("Connection added to group: " + groupId + ", connection: " + connection + ", group: " + current);
+            logger.debug("Connection added to group: " + groupId + ", connection: " + connection + ", group: " + current);
         } finally {
             connectionState.unlock();
         }
@@ -146,7 +146,7 @@ public class ConnectionManager<T> {
             ConnectionGroup<T> current = managedConnections.get(groupId);
             if (current != null) {
                 current.removeConnection(connection);
-                logger.info("Connection removed from group: " + groupId + ", connection: " + connection + ", group: " + current);
+                logger.debug("Connection removed from group: " + groupId + ", connection: " + connection + ", group: " + current);
                 if (current.isEmpty()) {
                     logger.info("Removing group: " + groupId + ", zero connections");
                     // deregister metrics


### PR DESCRIPTION
### Context

As title, changing two very long log lines' level from `info` to `debug`

### Checklist

- [x] `./gradlew build` compiles code correctly
- [x] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [x] Extended README or added javadocs where applicable
