### PR TITLE
Change leader lookup log level from info to debug

### DIFF
--- a/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitorSingleton.java
+++ b/mantis-control-plane/mantis-control-plane-dynamodb/src/main/java/io/mantisrx/extensions/dynamodb/DynamoDBMasterMonitorSingleton.java
@@ -157,7 +157,7 @@ class DynamoDBMasterMonitorSingleton {
 
     @SuppressWarnings("FutureReturnValueIgnored")
     private void getCurrentLeader() {
-        logger.info("attempting leader lookup");
+        logger.debug("attempting leader lookup");
         this.getCurrentLeaderCounter.increment();
         final Optional<LockItem> optionalLock = lockClient.getLock(partitionKey, Optional.empty());
         final MasterDescription nextDescription;


### PR DESCRIPTION
### Context

The leader lookup logs are spamming the logs, change it from info level to debug 

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
