### PR TITLE
Move common code to utils and cleanup

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/runtime/MantisJobDefinition.java
+++ b/mantis-common/src/main/java/io/mantisrx/runtime/MantisJobDefinition.java
@@ -144,6 +144,8 @@ public class MantisJobDefinition {
                 throw new InvalidJobException("disk must be >=0, not " + machineDefinition.getDiskMB());
             if (machineDefinition.getNumPorts() < 0)
                 throw new InvalidJobException("numPorts must be >=0, not " + machineDefinition.getNumPorts());
+            if (machineDefinition.getNumPorts() > 1)
+                throw new InvalidJobException("custom port configuration is not currently supported.");
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/utils/JobRouteUtils.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/utils/JobRouteUtils.java
@@ -22,14 +22,20 @@ import static io.mantisrx.master.api.akka.route.utils.QueryParamUtils.paramValue
 import static io.mantisrx.master.api.akka.route.utils.QueryParamUtils.paramValuesAsInt;
 import static io.mantisrx.master.api.akka.route.utils.QueryParamUtils.paramValuesAsMetaState;
 
+import akka.japi.Pair;
 import io.mantisrx.master.jobcluster.job.JobState;
 import io.mantisrx.master.jobcluster.job.worker.WorkerHeartbeat;
 import io.mantisrx.master.jobcluster.job.worker.WorkerState;
 import io.mantisrx.master.jobcluster.job.worker.WorkerStatus;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
+import io.mantisrx.runtime.MantisJobDefinition;
+import io.mantisrx.runtime.descriptor.SchedulingInfo;
+import io.mantisrx.runtime.descriptor.StageScalingPolicy;
+import io.mantisrx.runtime.descriptor.StageSchedulingInfo;
 import io.mantisrx.server.core.PostJobStatusRequest;
 import io.mantisrx.server.core.Status;
 import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.domain.JobId;
 import io.mantisrx.server.master.scheduler.WorkerEvent;
 import java.util.List;
@@ -118,4 +124,117 @@ public class JobRouteUtils {
         return new JobClusterManagerProto.ListJobIdsRequest(limit, jobState, activeOnly, regex, labelsQuery, labelsOperand, jobId);
     }
 
+    /**
+     * @return true to indicate valid, false otherwise. The String holds the error message when the request is invalid
+     */
+    public static Pair<Boolean, String> validateSubmitJobRequest(MantisJobDefinition mjd, Optional<String> clusterNameInResource) {
+        if (null == mjd) {
+            logger.error("rejecting job submit request, job definition is malformed {}", mjd);
+            return Pair.apply(false, "Malformed job definition.");
+        }
+
+        // must include job cluster name
+        if (mjd.getName() == null || mjd.getName().length() == 0) {
+            logger.info("rejecting job submit request, must include name {}", mjd);
+            return Pair.apply(false, "Job definition must include name");
+        }
+
+        // validate specified job cluster name matches with what specified in REST resource endpoint
+        if (clusterNameInResource.isPresent()) {
+            if (!clusterNameInResource.get().equals(mjd.getName())) {
+                String msg = String.format("Cluster name specified in request payload [%s] " +
+                        "does not match with what specified in resource endpoint [%s]",
+                    mjd.getName(), clusterNameInResource.get());
+                logger.info("rejecting job submit request, {} {}", msg, mjd);
+                return Pair.apply(false, msg);
+            }
+        }
+
+        // validate scheduling info
+        SchedulingInfo schedulingInfo = mjd.getSchedulingInfo();
+        if (schedulingInfo != null) {
+            Map<Integer, StageSchedulingInfo> stages = schedulingInfo.getStages();
+            if (stages != null) {
+                for (StageSchedulingInfo stageSchedInfo : stages.values()) {
+                    double cpuCores = stageSchedInfo.getMachineDefinition().getCpuCores();
+                    int maxCpuCores = ConfigurationProvider.getConfig()
+                        .getWorkerMachineDefinitionMaxCpuCores();
+                    if (cpuCores > maxCpuCores) {
+                        logger.info(
+                            "rejecting job submit request, requested CPU {} > max for {} (user: {}) (stage: {})",
+                            cpuCores,
+                            mjd.getName(),
+                            mjd.getUser(),
+                            stages);
+                        return Pair.apply(
+                            false,
+                            "requested CPU cannot be more than max CPU per worker " +
+                                maxCpuCores);
+                    }
+                    double memoryMB = stageSchedInfo.getMachineDefinition().getMemoryMB();
+                    int maxMemoryMB = ConfigurationProvider.getConfig()
+                        .getWorkerMachineDefinitionMaxMemoryMB();
+                    if (memoryMB > maxMemoryMB) {
+                        logger.info(
+                            "rejecting job submit request, requested memory {} > max for {} (user: {}) (stage: {})",
+                            memoryMB,
+                            mjd.getName(),
+                            mjd.getUser(),
+                            stages);
+                        return Pair.apply(
+                            false,
+                            "requested memory cannot be more than max memoryMB per worker " +
+                                maxMemoryMB);
+                    }
+                    double networkMbps = stageSchedInfo.getMachineDefinition().getNetworkMbps();
+                    int maxNetworkMbps = ConfigurationProvider.getConfig()
+                        .getWorkerMachineDefinitionMaxNetworkMbps();
+                    if (networkMbps > maxNetworkMbps) {
+                        logger.info(
+                            "rejecting job submit request, requested network {} > max for {} (user: {}) (stage: {})",
+                            networkMbps,
+                            mjd.getName(),
+                            mjd.getUser(),
+                            stages);
+                        return Pair.apply(
+                            false,
+                            "requested network cannot be more than max networkMbps per worker " +
+                                maxNetworkMbps);
+                    }
+                    int numberOfInstances = stageSchedInfo.getNumberOfInstances();
+                    int maxWorkersPerStage = ConfigurationProvider.getConfig()
+                        .getMaxWorkersPerStage();
+                    if (numberOfInstances > maxWorkersPerStage) {
+                        logger.info(
+                            "rejecting job submit request, requested num instances {} > max for {} (user: {}) (stage: {})",
+                            numberOfInstances,
+                            mjd.getName(),
+                            mjd.getUser(),
+                            stages);
+                        return Pair.apply(
+                            false,
+                            "requested number of instances per stage cannot be more than " +
+                                maxWorkersPerStage);
+                    }
+
+                    StageScalingPolicy scalingPolicy = stageSchedInfo.getScalingPolicy();
+                    if (scalingPolicy != null) {
+                        if (scalingPolicy.getMax() > maxWorkersPerStage) {
+                            logger.info(
+                                "rejecting job submit request, requested num instances in scaling policy {} > max for {} (user: {}) (stage: {})",
+                                numberOfInstances,
+                                mjd.getName(),
+                                mjd.getUser(),
+                                stages);
+                            return Pair.apply(
+                                false,
+                                "requested number of instances per stage in scaling policy cannot be more than " +
+                                    maxWorkersPerStage);
+                        }
+                    }
+                }
+            }
+        }
+        return Pair.apply(true, "");
+    }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
@@ -33,13 +33,11 @@ import io.mantisrx.master.api.akka.route.Jackson;
 import io.mantisrx.master.api.akka.route.handlers.JobClusterRouteHandler;
 import io.mantisrx.master.api.akka.route.handlers.JobRouteHandler;
 import io.mantisrx.master.api.akka.route.proto.JobClusterProtoAdapter;
+import io.mantisrx.master.api.akka.route.utils.JobRouteUtils;
 import io.mantisrx.master.jobcluster.job.MantisJobMetadataView;
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.runtime.MantisJobDefinition;
-import io.mantisrx.runtime.descriptor.SchedulingInfo;
-import io.mantisrx.runtime.descriptor.StageScalingPolicy;
-import io.mantisrx.runtime.descriptor.StageSchedulingInfo;
 import io.mantisrx.server.core.PostJobStatusRequest;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.config.MasterConfiguration;
@@ -49,7 +47,6 @@ import io.mantisrx.server.master.http.api.CompactJobInfo;
 import io.mantisrx.server.master.store.MantisWorkerMetadataWritable;
 import io.mantisrx.shaded.com.google.common.base.Strings;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -290,7 +287,7 @@ public class JobsRoute extends BaseRoute {
 
                         // validate request
                         submitJobRequest.validate(true);
-                        Pair<Boolean, String> validationResult = validateSubmitJobRequest(
+                        Pair<Boolean, String> validationResult = JobRouteUtils.validateSubmitJobRequest(
                                 submitJobRequest,
                                 clusterName);
                         if (!validationResult.first()) {
@@ -613,121 +610,4 @@ public class JobsRoute extends BaseRoute {
                     );
                 });
     }
-
-    /**
-     * @return true to indicate valid, false otherwise. The String holds the error message when the request is invalid
-     */
-    private Pair<Boolean, String> validateSubmitJobRequest(
-            MantisJobDefinition mjd,
-            Optional<String> clusterNameInResource) {
-        if (null == mjd) {
-            logger.error("rejecting job submit request, job definition is malformed {}", mjd);
-            return Pair.apply(false, "Malformed job definition.");
-        }
-
-        // must include job cluster name
-        if (mjd.getName() == null || mjd.getName().length() == 0) {
-            logger.info("rejecting job submit request, must include name {}", mjd);
-            return Pair.apply(false, "Job definition must include name");
-        }
-
-        // validate specified job cluster name matches with what specified in REST resource endpoint
-        if (clusterNameInResource.isPresent()) {
-            if (!clusterNameInResource.get().equals(mjd.getName())) {
-                String msg = String.format("Cluster name specified in request payload [%s] " +
-                                           "does not match with what specified in resource endpoint [%s]",
-                                           mjd.getName(), clusterNameInResource.get());
-                logger.info("rejecting job submit request, {} {}", msg, mjd);
-                return Pair.apply(false, msg);
-            }
-        }
-
-        // validate scheduling info
-        SchedulingInfo schedulingInfo = mjd.getSchedulingInfo();
-        if (schedulingInfo != null) {
-            Map<Integer, StageSchedulingInfo> stages = schedulingInfo.getStages();
-            if (stages != null) {
-                for (StageSchedulingInfo stageSchedInfo : stages.values()) {
-                    double cpuCores = stageSchedInfo.getMachineDefinition().getCpuCores();
-                    int maxCpuCores = ConfigurationProvider.getConfig()
-                                                           .getWorkerMachineDefinitionMaxCpuCores();
-                    if (cpuCores > maxCpuCores) {
-                        logger.info(
-                                "rejecting job submit request, requested CPU {} > max for {} (user: {}) (stage: {})",
-                                cpuCores,
-                                mjd.getName(),
-                                mjd.getUser(),
-                                stages);
-                        return Pair.apply(
-                                false,
-                                "requested CPU cannot be more than max CPU per worker " +
-                                maxCpuCores);
-                    }
-                    double memoryMB = stageSchedInfo.getMachineDefinition().getMemoryMB();
-                    int maxMemoryMB = ConfigurationProvider.getConfig()
-                                                           .getWorkerMachineDefinitionMaxMemoryMB();
-                    if (memoryMB > maxMemoryMB) {
-                        logger.info(
-                                "rejecting job submit request, requested memory {} > max for {} (user: {}) (stage: {})",
-                                memoryMB,
-                                mjd.getName(),
-                                mjd.getUser(),
-                                stages);
-                        return Pair.apply(
-                                false,
-                                "requested memory cannot be more than max memoryMB per worker " +
-                                maxMemoryMB);
-                    }
-                    double networkMbps = stageSchedInfo.getMachineDefinition().getNetworkMbps();
-                    int maxNetworkMbps = ConfigurationProvider.getConfig()
-                                                              .getWorkerMachineDefinitionMaxNetworkMbps();
-                    if (networkMbps > maxNetworkMbps) {
-                        logger.info(
-                                "rejecting job submit request, requested network {} > max for {} (user: {}) (stage: {})",
-                                networkMbps,
-                                mjd.getName(),
-                                mjd.getUser(),
-                                stages);
-                        return Pair.apply(
-                                false,
-                                "requested network cannot be more than max networkMbps per worker " +
-                                maxNetworkMbps);
-                    }
-                    int numberOfInstances = stageSchedInfo.getNumberOfInstances();
-                    int maxWorkersPerStage = ConfigurationProvider.getConfig()
-                                                                  .getMaxWorkersPerStage();
-                    if (numberOfInstances > maxWorkersPerStage) {
-                        logger.info(
-                                "rejecting job submit request, requested num instances {} > max for {} (user: {}) (stage: {})",
-                                numberOfInstances,
-                                mjd.getName(),
-                                mjd.getUser(),
-                                stages);
-                        return Pair.apply(
-                                false,
-                                "requested number of instances per stage cannot be more than " +
-                                maxWorkersPerStage);
-                    }
-
-                    StageScalingPolicy scalingPolicy = stageSchedInfo.getScalingPolicy();
-                    if (scalingPolicy != null) {
-                        if (scalingPolicy.getMax() > maxWorkersPerStage) {
-                            logger.info(
-                                    "rejecting job submit request, requested num instances in scaling policy {} > max for {} (user: {}) (stage: {})",
-                                    numberOfInstances,
-                                    mjd.getName(),
-                                    mjd.getUser(),
-                                    stages);
-                            return Pair.apply(
-                                    false,
-                                    "requested number of instances per stage in scaling policy cannot be more than " +
-                                    maxWorkersPerStage);
-                        }
-                    }
-                }
-            }
-        }
-        return Pair.apply(true, "");
-    }
-
 }


### PR DESCRIPTION
### Context

1. add validation for numOfPorts, as it's not supported right now 
2. move shared job request validation logic to utils 
3. remove wrapped request in taskexecutor, as there's no subscriber registered on this wrapped object in the current code base

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable

@Andyz26 