### PR TITLE
Add log to check #TE archived was not in disabled state

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
@@ -119,8 +119,11 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
     private final Cache<TaskExecutorID, TaskExecutorState> archivedState = CacheBuilder.newBuilder()
         .maximumSize(10000)
         .expireAfterWrite(24, TimeUnit.HOURS)
-        .removalListener(notification ->
-            log.info("Archived TaskExecutor: {} removed due to: {}", notification.getKey(), notification.getCause()))
+        .removalListener(notification -> {
+            TaskExecutorState state = (TaskExecutorState) notification.getValue();
+            boolean teIsDisabled = state != null && state.onNodeDisabled();
+            log.info("Archived TaskExecutor: {} with disabled state: {} removed due to: {}", notification.getKey(), teIsDisabled, notification.getCause());
+        })
         .build();
 
     private final AvailableTaskExecutorMutatorHook availableTaskExecutorMutatorHook;


### PR DESCRIPTION
### Context

- TE will be set to disabled state when scale down, add logs to check how many TE stayed in the archived state are not in disabled state.
- the archived state contains all the ghost TEs and other explicitly removed TE, adding this log to check if we could filter the ghost ones from this archived state

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
