### PR TITLE
Initial impl to support marking TE as zombie

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManager.java
@@ -105,4 +105,20 @@ interface ExecutorStateManager {
 
     Predicate<Entry<TaskExecutorID, TaskExecutorState>> isAssigned =
         e -> e.getValue().isAssigned();
+
+    /***
+     * Move the given task executor to the zombie collection.
+     * Zombie collection contains the task executors that failes to report heartbeat within a threshold and are ready to be permanently removed.
+     *
+     * @param taskExecutorID TaskExecutorID
+     */
+    void markAsZombie(TaskExecutorID taskExecutorID);
+
+    /**
+     * True indicate the given task executor is already marked as zombie.
+     *
+     * @param taskExecutorID TaskExecutorID
+     * @return True indicates the task executor is zombie.
+     */
+    boolean isZombie(TaskExecutorID taskExecutorID);
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ResourceClustersManagerActor.java
@@ -184,7 +184,8 @@ class ResourceClustersManagerActor extends AbstractActor {
                     masterConfiguration.isJobArtifactCachingEnabled(),
                     masterConfiguration.getSchedulingConstraints(),
                     masterConfiguration.getFitnessCalculator(),
-                    masterConfiguration.getAvailableTaskExecutorMutatorHook()),
+                    masterConfiguration.getAvailableTaskExecutorMutatorHook(),
+                    Duration.ofMillis(masterConfiguration.zombieDetectThreshold())),
                 "ResourceClusterActor-" + clusterID.getResourceID());
         log.info("Created resource cluster actor for {}", clusterID);
         return clusterActor;

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -282,6 +282,10 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("false")
     boolean getDisableShortfallEvaluation();
 
+    @Config("mantis.agent.zombie.detect.threshold")
+    @Default("1800000")
+    long zombieDetectThreshold();
+
     @Config("mantis.scheduling.info.observable.heartbeat.interval.secs")
     @Default("120")
     long getSchedulingInfoObservableHeartbeatIntervalSecs();


### PR DESCRIPTION
### Context

For TE that lost heartbeat for over 30mins (a given threshold), we should mark it as permanently failure and terminate the instance + internal process. Because the master would reassign the worker to a different TE after worker heartbeat timeout, and if we don't remove the ghost instance, we would have two process running the task (one inside the ghost container, and another is reassigned by the master).


<img width="630" height="188" alt="Screenshot 2025-09-25 at 11 01 12 AM" src="https://github.com/user-attachments/assets/eeb407ca-95a8-4d2c-b67c-884c4008062f" />

- Introduce a zombie collection to save list of TE that non-recoverable and should be killed
- Add logs to collect the data for #TE that lost heartbeat for > 30mins.


### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
