### PR TITLE
Add GitHub Actions workflow to auto-publish docs

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,39 @@
+name: Publish Docs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: deploy-docs
+  cancel-in-progress: true
+
+jobs:
+  deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material pymdown-extensions
+
+      - name: Deploy docs
+        run: |
+          cd docs
+          mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/docs-publish.yml`) that automatically builds and deploys MkDocs documentation to GitHub Pages on pushes to `master` that modify `docs/`.
- Uses `mkdocs gh-deploy --force` — the same command currently run manually.
- Includes concurrency control to prevent race conditions on simultaneous deploys.

Closes #358

## Details
- Triggers only on `docs/**` path changes to avoid unnecessary runs
- Uses `github-actions[bot]` identity for gh-pages commits
- Installs the same 3 dependencies listed in `docs/README.md`: mkdocs, mkdocs-material, pymdown-extensions
- Follows the [official mkdocs-material publishing guide](https://squidfunk.github.io/mkdocs-material/publishing-your-site/)

## Test plan
- [x] Verify workflow YAML syntax is valid
- [ ] After merge, push a docs change to master and confirm the Actions tab shows the workflow running
- [ ] Confirm https://netflix.github.io/mantis updates with the change