### PR TITLE
Fix compile warnings in mantis-control-plane-client module

### DIFF
--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/ConditionalRetry.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/ConditionalRetry.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.functions.Func1;
-import rx.functions.Func2;
 
 
 public class ConditionalRetry {
@@ -41,32 +40,18 @@ public class ConditionalRetry {
     public ConditionalRetry(Counter counter, String name, final int max) {
         this.counter = counter;
         this.name = name;
-        this.retryLogic =
-                new Func1<Observable<? extends Throwable>, Observable<?>>() {
-                    @Override
-                    public Observable<?> call(Observable<? extends Throwable> attempts) {
-                        return attempts
-                                .zipWith(Observable.range(1, max), new Func2<Throwable, Integer, Integer>() {
-                                    @Override
-                                    public Integer call(Throwable t1, Integer integer) {
-                                        return integer;
-                                    }
-                                })
-                                .flatMap(new Func1<Integer, Observable<?>>() {
-                                    @Override
-                                    public Observable<?> call(Integer integer) {
-                                        if (errorRef.get() != null)
-                                            return Observable.error(errorRef.get());
-                                        if (ConditionalRetry.this.counter != null)
-                                            ConditionalRetry.this.counter.increment();
-                                        long delay = 2 * (integer > 10 ? 10 : integer);
-                                        logger.info(": retrying " + ConditionalRetry.this.name +
-                                                " after sleeping for " + delay + " secs");
-                                        return Observable.timer(delay, TimeUnit.SECONDS);
-                                    }
-                                });
-                    }
-                };
+        this.retryLogic = attempts -> attempts
+                .zipWith(Observable.range(1, max), (t1, integer) -> integer)
+                .flatMap(integer -> {
+                    if (errorRef.get() != null)
+                        return Observable.error(errorRef.get());
+                    if (ConditionalRetry.this.counter != null)
+                        ConditionalRetry.this.counter.increment();
+                    long delay = 2 * (integer > 10 ? 10 : integer);
+                    logger.info(": retrying " + ConditionalRetry.this.name +
+                            " after sleeping for " + delay + " secs");
+                    return Observable.timer(delay, TimeUnit.SECONDS);
+                });
     }
 
     public void setErrorRef(Throwable error) {

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HttpUtility.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/HttpUtility.java
@@ -36,8 +36,6 @@ import mantis.io.reactivex.netty.protocol.http.client.HttpClientResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
-import rx.functions.Action1;
-import rx.functions.Func1;
 
 
 /* package */ class HttpUtility {
@@ -49,74 +47,54 @@ import rx.functions.Func1;
     static Observable<String> getGetResponse(String host, int port, String uri) {
         return new CompositeHttpClientBuilder<ByteBuf, ByteBuf>()
                 .appendPipelineConfigurator(
-                        new PipelineConfigurator<HttpClientResponse<ByteBuf>, HttpClientRequest<ByteBuf>>() {
-                            @Override
-                            public void configureNewPipeline(ChannelPipeline pipeline) {
-                                pipeline.addLast("introspecting-handler", new ChannelDuplexHandler() {
-                                    private String uri = "<undefined>";
+                        (PipelineConfigurator<HttpClientResponse<ByteBuf>, HttpClientRequest<ByteBuf>>) pipeline -> {
+                            pipeline.addLast("introspecting-handler", new ChannelDuplexHandler() {
+                                private String uri = "<undefined>";
 
-                                    @Override
-                                    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
-                                            throws Exception {
-                                        if (msg instanceof HttpRequest) {
-                                            HttpRequest request = (HttpRequest) msg;
-                                            uri = request.getUri();
-                                            logger.info("Sending request on channel id: " + ctx.channel().toString() +
-                                                    ", request URI: " + uri);
-                                        }
-                                        super.write(ctx, msg, promise);
+                                @Override
+                                public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+                                        throws Exception {
+                                    if (msg instanceof HttpRequest) {
+                                        HttpRequest request = (HttpRequest) msg;
+                                        uri = request.uri();
+                                        logger.info("Sending request on channel id: " + ctx.channel().toString() +
+                                                ", request URI: " + uri);
                                     }
+                                    super.write(ctx, msg, promise);
+                                }
 
-                                    @Override
-                                    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-                                        if (msg instanceof HttpResponse) {
-                                            logger.info("Received response on channel id: " + ctx.channel().toString() +
-                                                    ", request URI: " + uri);
-                                        }
-                                        super.channelRead(ctx, msg);
+                                @Override
+                                public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+                                    if (msg instanceof HttpResponse) {
+                                        logger.info("Received response on channel id: " + ctx.channel().toString() +
+                                                ", request URI: " + uri);
                                     }
-                                });
+                                    super.channelRead(ctx, msg);
+                                }
+                            });
 
-                                try {
-                                    int maxContentLength = 10 * 1024 * 1024; // Ten megabytes
-                                    pipeline.replace(HttpObjectAggregator.class, "http-object-aggregator",
-                                            new HttpObjectAggregator(maxContentLength));
-                                } catch (NoSuchElementException ex) {
-                                    logger.error("HttpObjectAggregator did not exist in this pipeline. Error: {}",
-                                            ex.getMessage(), ex);
-                                } catch (IllegalArgumentException ex) {
-                                    logger.error("ChannelHandler named http-object-aggregator already existed in this" +
-                                            " pipeline. Error: {}", ex.getMessage(), ex);
-                                }
-                                catch (Throwable t) {
-                                    logger.error("Unknown error adding HttpObjectAggregator to Master Client " +
-                                            "Pipeline. Error: {}", t.getMessage(), t);
-                                }
+                            try {
+                                int maxContentLength = 10 * 1024 * 1024; // Ten megabytes
+                                pipeline.replace(HttpObjectAggregator.class, "http-object-aggregator",
+                                        new HttpObjectAggregator(maxContentLength));
+                            } catch (NoSuchElementException ex) {
+                                logger.error("HttpObjectAggregator did not exist in this pipeline. Error: {}",
+                                        ex.getMessage(), ex);
+                            } catch (IllegalArgumentException ex) {
+                                logger.error("ChannelHandler named http-object-aggregator already existed in this" +
+                                        " pipeline. Error: {}", ex.getMessage(), ex);
+                            } catch (Throwable t) {
+                                logger.error("Unknown error adding HttpObjectAggregator to Master Client " +
+                                        "Pipeline. Error: {}", t.getMessage(), t);
                             }
-
                         })
                 .build()
                 .submit(new RxClient.ServerInfo(host, port),
                         HttpClientRequest.createGet(uri),
                         new HttpClient.HttpClientConfig.Builder().setFollowRedirect(true).followRedirect(MAX_REDIRECTS).build())
-                .flatMap(new Func1<HttpClientResponse<ByteBuf>, Observable<ByteBuf>>() {
-                    @Override
-                    public Observable<ByteBuf> call(HttpClientResponse<ByteBuf> response) {
-                        return response.getContent();
-                    }
-                })
-                .map(new Func1<ByteBuf, String>() {
-                    @Override
-                    public String call(ByteBuf o) {
-                        return o.toString(Charset.defaultCharset());
-                    }
-                })
-                .doOnError(new Action1<Throwable>() {
-                    @Override
-                    public void call(Throwable throwable) {
-                        logger.warn("Error: " + throwable.getMessage(), throwable);
-                    }
-                })
+                .flatMap(response -> response.getContent())
+                .map(o -> o.toString(Charset.defaultCharset()))
+                .doOnError(throwable -> logger.warn("Error: " + throwable.getMessage(), throwable))
                 .timeout(GET_TIMEOUT_SECS, TimeUnit.SECONDS);
     }
 }

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
@@ -27,7 +27,7 @@ import io.mantisrx.runtime.JobSla;
 import io.mantisrx.runtime.MantisJobDefinition;
 import io.mantisrx.runtime.MantisJobState;
 import io.mantisrx.runtime.WorkerMigrationConfig;
-import io.mantisrx.runtime.codec.JsonCodec;
+import io.mantisrx.runtime.codec.JacksonCodecs;
 import io.mantisrx.runtime.descriptor.DeploymentStrategy;
 import io.mantisrx.runtime.descriptor.SchedulingInfo;
 import io.mantisrx.runtime.parameter.Parameter;
@@ -837,7 +837,7 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 new ConnectToObservable.Builder<JobAssignmentResult>()
                         .subscribeAttempts(subscribeAttemptsToMaster)
                         .name("/v1/api/master/assignmentresults")
-                        .decoder(new JsonCodec<JobAssignmentResult>(JobAssignmentResult.class));
+                        .decoder(JacksonCodecs.pojo(JobAssignmentResult.class));
         if (jobId != null && !jobId.isEmpty()) {
             Map<String, String> subscriptionParams = new HashMap<>();
             subscriptionParams.put("jobId", jobId);

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterClientApi.java
@@ -31,7 +31,12 @@ import io.mantisrx.runtime.codec.JacksonCodecs;
 import io.mantisrx.runtime.descriptor.DeploymentStrategy;
 import io.mantisrx.runtime.descriptor.SchedulingInfo;
 import io.mantisrx.runtime.parameter.Parameter;
-import io.mantisrx.server.core.*;
+import io.mantisrx.server.core.JobAssignmentResult;
+import io.mantisrx.server.core.JobScalerRuleInfo;
+import io.mantisrx.server.core.JobSchedulingInfo;
+import io.mantisrx.server.core.NamedJobInfo;
+import io.mantisrx.server.core.PostJobStatusRequest;
+import io.mantisrx.server.core.Status;
 import io.mantisrx.server.core.master.MasterDescription;
 import io.mantisrx.server.core.master.MasterMonitor;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
@@ -78,9 +83,6 @@ import rx.functions.Func1;
 import rx.functions.Func2;
 
 
-/**
- *
- */
 public class MantisMasterClientApi implements MantisMasterGateway {
 
     static final String ConnectTimeoutSecsPropertyName = "MantisClientConnectTimeoutSecs";
@@ -136,10 +138,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
             });
     private MasterMonitor masterMonitor;
 
-    /**
-     *
-     * @param masterMonitor
-     */
     public MantisMasterClientApi(MasterMonitor masterMonitor) {
         this.masterMonitor = masterMonitor;
         masterEndpoint = masterMonitor.getMasterObservable()
@@ -170,15 +168,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
     }
 
 
-    /**
-     *
-     * @param name
-     * @param version
-     * @param parameters
-     * @param jobSla
-     * @param schedulingInfo
-     * @return
-     */
     public Observable<JobSubmitResponse> submitJob(final String name, final String version,
                                                    final List<Parameter> parameters,
                                                    final JobSla jobSla,
@@ -187,17 +176,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 WorkerMigrationConfig.DEFAULT);
     }
 
-    /**
-     *
-     * @param name
-     * @param version
-     * @param parameters
-     * @param jobSla
-     * @param subscriptionTimeoutSecs
-     * @param schedulingInfo
-     * @param migrationConfig
-     * @return
-     */
     public Observable<JobSubmitResponse> submitJob(final String name, final String version,
                                                    final List<Parameter> parameters,
                                                    final JobSla jobSla,
@@ -208,17 +186,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 false, migrationConfig);
     }
 
-    /**
-     *
-     * @param name
-     * @param version
-     * @param parameters
-     * @param jobSla
-     * @param subscriptionTimeoutSecs
-     * @param schedulingInfo
-     * @return
-     */
-
     public Observable<JobSubmitResponse> submitJob(final String name, final String version,
                                                    final List<Parameter> parameters,
                                                    final JobSla jobSla,
@@ -228,17 +195,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 false, WorkerMigrationConfig.DEFAULT);
     }
 
-    /**
-     *
-     * @param name
-     * @param version
-     * @param parameters
-     * @param jobSla
-     * @param subscriptionTimeoutSecs
-     * @param schedulingInfo
-     * @param readyForJobMaster
-     * @return
-     */
     public Observable<JobSubmitResponse> submitJob(final String name, final String version,
                                                    final List<Parameter> parameters,
                                                    final JobSla jobSla,
@@ -249,18 +205,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 readyForJobMaster, WorkerMigrationConfig.DEFAULT);
     }
 
-    /**
-     *
-     * @param name
-     * @param version
-     * @param parameters
-     * @param jobSla
-     * @param subscriptionTimeoutSecs
-     * @param schedulingInfo
-     * @param readyForJobMaster
-     * @param migrationConfig
-     * @return
-     */
     public Observable<JobSubmitResponse> submitJob(final String name, final String version,
                                                    final List<Parameter> parameters,
                                                    final JobSla jobSla,
@@ -272,19 +216,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 readyForJobMaster, migrationConfig, new LinkedList<>());
     }
 
-    /**
-     *
-     * @param name
-     * @param version
-     * @param parameters
-     * @param jobSla
-     * @param subscriptionTimeoutSecs
-     * @param schedulingInfo
-     * @param readyForJobMaster
-     * @param migrationConfig
-     * @param labels
-     * @return
-     */
     public Observable<JobSubmitResponse> submitJob(final String name, final String version,
                                                    final List<Parameter> parameters,
                                                    final JobSla jobSla,
@@ -319,12 +250,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
             return Observable.error(e);
         }
     }
-
-    /**
-     *
-     * @param submitJobRequestJson
-     * @return
-     */
 
     public Observable<JobSubmitResponse> submitJob(final String submitJobRequestJson) {
         return masterMonitor.getMasterObservable()
@@ -363,13 +288,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 "User requested");
     }
 
-    /**
-     *
-     * @param jobId
-     * @param user
-     * @param reason
-     * @return
-     */
     public Observable<Void> killJob(final String jobId, final String user, final String reason) {
         return masterMonitor.getMasterObservable()
                 .filter(md -> md != null)
@@ -394,14 +312,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 });
     }
 
-    /**
-     *
-     * @param jobId
-     * @param stageNum
-     * @param numWorkers
-     * @param reason
-     * @return
-     */
     public Observable<Boolean> scaleJobStage(final String jobId, final int stageNum, final int numWorkers,
                                              final String reason) {
         return masterMonitor
@@ -423,14 +333,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 });
     }
 
-    /**
-     *
-     * @param jobId
-     * @param user
-     * @param workerNum
-     * @param reason
-     * @return
-     */
     public Observable<Boolean> resubmitJobWorker(final String jobId, final String user, final int workerNum,
                                                  final String reason) {
         return masterMonitor.getMasterObservable()
@@ -462,7 +364,7 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                                 .withContent(postContent),
                         new HttpClient.HttpClientConfig.Builder()
                                 .build())
-                .map(b -> b.getStatus());
+                .map(HttpClientResponse::getStatus);
     }
 
     private Observable<String> getPostResponse(String uri, String postContent) {
@@ -473,15 +375,9 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                                 .withContent(postContent),
                         new HttpClient.HttpClientConfig.Builder()
                                 .build())
-                .flatMap((Func1<HttpClientResponse<ByteBuf>, Observable<ByteBuf>>) b -> b.getContent())
+                .flatMap(HttpClientResponse::getContent)
                 .map(o -> o.toString(Charset.defaultCharset()));
     }
-
-    /**
-     *
-     * @param jobName
-     * @return
-     */
 
     public Observable<Boolean> namedJobExists(final String jobName) {
         return masterMonitor.getMasterObservable()
@@ -507,11 +403,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 ;
     }
 
-    /**
-     *
-     * @param jobId
-     * @return
-     */
     public Observable<Integer> getSinkStageNum(final String jobId) {
         return masterMonitor.getMasterObservable()
                 .filter(masterDescription -> masterDescription != null)
@@ -543,12 +434,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 });
     }
 
-    /**
-     *
-     * @param jobName
-     * @param state
-     * @return
-     */
     // returns json array of job metadata
     public Observable<String> getJobsOfNamedJob(final String jobName, final MantisJobState.MetaState state) {
         return masterMonitor.getMasterObservable()
@@ -672,11 +557,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                         .build();
     }
 
-    /**
-     *
-     * @param jobId
-     * @return
-     */
     public Observable<String> getJobStatusObservable(final String jobId) {
         return masterMonitor.getMasterObservable()
                 .filter((md) -> md != null)
@@ -689,11 +569,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
                 .onErrorResumeNext(Observable.empty());
     }
 
-    /**
-     *
-     * @param jobId
-     * @return
-     */
     public Observable<JobSchedulingInfo> schedulingChanges(final String jobId) {
         final ConditionalRetry retryObject = new ConditionalRetry(null, "assignmentresults_" + jobId);
         return masterMonitor.getMasterObservable()
@@ -792,11 +667,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
             ;
     }
 
-    /**
-     *
-     * @param jobName
-     * @return
-     */
     public Observable<NamedJobInfo> namedJobInfo(final String jobName) {
         return masterMonitor.getMasterObservable()
                 .filter(masterDescription -> masterDescription != null)
@@ -827,11 +697,6 @@ public class MantisMasterClientApi implements MantisMasterGateway {
     }
 
 
-    /**
-     *
-     * @param jobId
-     * @return
-     */
     public Observable<JobAssignmentResult> assignmentResults(String jobId) {
         ConnectToObservable.Builder<JobAssignmentResult> connectionBuilder =
                 new ConnectToObservable.Builder<JobAssignmentResult>()

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterGateway.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MantisMasterGateway.java
@@ -22,7 +22,11 @@ import io.mantisrx.runtime.MantisJobState;
 import io.mantisrx.runtime.WorkerMigrationConfig;
 import io.mantisrx.runtime.descriptor.SchedulingInfo;
 import io.mantisrx.runtime.parameter.Parameter;
-import io.mantisrx.server.core.*;
+import io.mantisrx.server.core.JobAssignmentResult;
+import io.mantisrx.server.core.JobScalerRuleInfo;
+import io.mantisrx.server.core.JobSchedulingInfo;
+import io.mantisrx.server.core.NamedJobInfo;
+import io.mantisrx.server.core.Status;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MasterClientWrapper.java
+++ b/mantis-control-plane/mantis-control-plane-client/src/main/java/io/mantisrx/server/master/client/MasterClientWrapper.java
@@ -39,9 +39,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Observer;
-import rx.functions.Action0;
-import rx.functions.Action1;
-import rx.functions.Func1;
 import rx.subjects.PublishSubject;
 
 public class MasterClientWrapper {
@@ -86,21 +83,14 @@ public class MasterClientWrapper {
         Services.startAndWait(haServices);
         MasterClientWrapper clientWrapper = new MasterClientWrapper(haServices.getMasterClientApi());
         clientWrapper.getMasterClientApi()
-                .flatMap(new Func1<MantisMasterGateway, Observable<EndpointChange>>() {
-                    @Override
-                    public Observable<EndpointChange> call(MantisMasterGateway mantisMasterClientApi) {
-                        Integer sinkStage = null;
-                        return mantisMasterClientApi.getSinkStageNum(jobId)
+                .flatMap(mantisMasterClientApi ->
+                        mantisMasterClientApi.getSinkStageNum(jobId)
                                 .take(1) // only need to figure out sink stage number once
-                                .flatMap(new Func1<Integer, Observable<EndpointChange>>() {
-                                    @Override
-                                    public Observable<EndpointChange> call(Integer integer) {
-                                        logger.info("Getting sink locations for " + jobId);
-                                        return clientWrapper.getSinkLocations(jobId, integer, 0, 0);
-                                    }
-                                });
-                    }
-                }).toBlocking().subscribe((ep) -> {
+                                .flatMap(integer -> {
+                                    logger.info("Getting sink locations for " + jobId);
+                                    return clientWrapper.getSinkLocations(jobId, integer, 0, 0);
+                                })
+                ).toBlocking().subscribe((ep) -> {
             System.out.println("Endpoint Change -> " + ep);
         });
         Thread.sleep(50000);
@@ -149,19 +139,9 @@ public class MasterClientWrapper {
                     Endpoint ep = new WorkerEndpoint(getWrappedHost(host.getHost(), host.getWorkerNumber()), host.getPort().get(0),
                             stageNum, host.getMetricsPort(), host.getWorkerIndex(), host.getWorkerNumber(),
                             // completed callback
-                            new Action0() {
-                                @Override
-                                public void call() {
-                                    logger.info("job " + jobId + " WorkerIndex " + workerIndex + " completed");
-                                }
-                            },
+                            () -> logger.info("job " + jobId + " WorkerIndex " + workerIndex + " completed"),
                             // error callback
-                            new Action1<Throwable>() {
-                                @Override
-                                public void call(Throwable t1) {
-                                    logger.info("job " + jobId + " WorkerIndex " + workerIndex + " failed");
-                                }
-                            }
+                            t1 -> logger.info("job " + jobId + " WorkerIndex " + workerIndex + " failed")
                     );
                     endpoints.add(ep);
                 }
@@ -176,38 +156,15 @@ public class MasterClientWrapper {
         Observable<List<Endpoint>> schedulingUpdates =
                                 masterClientApi
                                         .schedulingChanges(jobId)
-                                        .doOnError(new Action1<Throwable>() {
-                                            @Override
-                                            public void call(Throwable throwable) {
-                                                logger.warn("Error on scheduling changes observable: " + throwable);
-                                            }
-                                        })
+                                        .doOnError(throwable -> logger.warn("Error on scheduling changes observable: " + throwable))
                                         .retryWhen(schedInfoRetry.getRetryLogic())
-                                        .map(new Func1<JobSchedulingInfo, Map<Integer, WorkerAssignments>>() {
-                                            @Override
-                                            public Map<Integer, WorkerAssignments> call(JobSchedulingInfo jobSchedulingInfo) {
-                                                logger.info("Got scheduling info for " + jobId);
-                                                return jobSchedulingInfo.getWorkerAssignments();
-                                            }
+                                        .map(jobSchedulingInfo -> {
+                                            logger.info("Got scheduling info for " + jobId);
+                                            return jobSchedulingInfo.getWorkerAssignments();
                                         })
-                                        .filter(new Func1<Map<Integer, WorkerAssignments>, Boolean>() {
-                                            @Override
-                                            public Boolean call(Map<Integer, WorkerAssignments> workerAssignments) {
-                                                return workerAssignments != null;
-                                            }
-                                        })
-                                        .map(new Func1<Map<Integer, WorkerAssignments>, List<Endpoint>>() {
-                                            @Override
-                                            public List<Endpoint> call(Map<Integer, WorkerAssignments> workerAssignments) {
-                                                return getAllNonJobMasterEndpoints(jobId, workerAssignments);
-                                            }
-                                        })
-                                        .doOnError(new Action1<Throwable>() {
-                                            @Override
-                                            public void call(Throwable throwable) {
-                                                logger.error(throwable.getMessage(), throwable);
-                                            }
-                                        });
+                                        .filter(workerAssignments -> workerAssignments != null)
+                                        .map(workerAssignments -> getAllNonJobMasterEndpoints(jobId, workerAssignments))
+                                        .doOnError(throwable -> logger.error(throwable.getMessage(), throwable));
 
         return (new ToDeltaEndpointInjector(schedulingUpdates)).deltas();
     }


### PR DESCRIPTION
## Summary
Comprehensive fix for compile warnings in the `mantis-control-plane-client` module.

- Convert anonymous classes to lambdas across `HttpUtility`, `ConditionalRetry`, and `MasterClientWrapper`
- Replace deprecated `JsonCodec` constructor with `JacksonCodecs.pojo()` as recommended by the `@Deprecated` annotation
- Replace deprecated `HttpRequest.getUri()` with `HttpRequest.uri()`
- Expand wildcard imports (`io.mantisrx.server.core.*`) to specific imports in `MantisMasterClientApi` and `MantisMasterGateway`
- Remove empty javadoc blocks with no descriptions
- Use method references where applicable (`HttpClientResponse::getStatus`, `HttpClientResponse::getContent`)
- Remove unused imports

Addresses #389. PR #421 addressed only 2 of many warnings — this PR provides a more comprehensive fix.

## Test plan
- [x] `./gradlew :mantis-control-plane:mantis-control-plane-client:compileJava` passes
- [x] `./gradlew :mantis-control-plane:mantis-control-plane-client:test` passes
- [x] All changes are purely syntactic refactors — no behavioral changes