### PR TITLE
Refactor existing logs and add logs

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerImpl.java
@@ -369,7 +369,9 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
         }
 
         if (noResourcesAvailable) {
-            log.warn("Not all scheduling constraints had enough workers available to fulfill the request {}", request);
+            log.warn("Not all scheduling constraints had enough workers for jobId={}, cluster={}, constraints={}",
+                request.getJobId(), request.getClusterID(),
+                request.getGroupedBySchedulingConstraints().keySet());
             return Optional.empty();
         } else {
             // Return best fit only if there are enough available TEs for all scheduling constraints
@@ -393,28 +395,41 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
             return Optional.empty();
         }
 
-        Stream<TaskExecutorHolder> availableTEs = this.executorsByGroup.get(bestFitTeGroupKey.get())
+        NavigableSet<TaskExecutorHolder> groupHolders = this.executorsByGroup.get(bestFitTeGroupKey.get());
+
+        List<TaskExecutorHolder> availableTEList = groupHolders
             .descendingSet()
             .stream()
             .filter(teHolder -> {
                 if (!this.taskExecutorStateMap.containsKey(teHolder.getId())) {
+                    log.debug("findBestFitFor: TE {} excluded - not in stateMap", teHolder.getId());
                     return false;
                 }
                 if (currentBestFit.contains(teHolder.getId())) {
+                    log.debug("findBestFitFor: TE {} excluded - already in bestFit", teHolder.getId());
                     return false;
                 }
                 TaskExecutorState st = this.taskExecutorStateMap.get(teHolder.getId());
-                return st.isAvailable() &&
-                    // when a TE is returned from here to be used for scheduling, its state remain active until
-                    // the scheduler trigger another message to update (lock) the state. However when large number
-                    // of the requests are active at the same time on same sku, the gap between here and the message
-                    // to lock the state can be large so another schedule request message can be in between and
-                    // got the same set of TEs. To avoid this, a lease is added to each TE state to temporarily
-                    // lock the TE to be used again. Since this is only lock between actor messages and lease
-                    // duration can be short.
-                    st.getLastSchedulerLeasedDuration().compareTo(this.schedulerLeaseExpirationDuration) > 0 &&
-                    st.getRegistration() != null;
-            });
+                if (!st.isAvailable()) {
+                    log.debug("findBestFitFor: TE {} excluded - not available", teHolder.getId());
+                    return false;
+                }
+                if (st.getLastSchedulerLeasedDuration().compareTo(this.schedulerLeaseExpirationDuration) <= 0) {
+                    log.debug("findBestFitFor: TE {} excluded - lease not expired ({}ms)", teHolder.getId(), st.getLastSchedulerLeasedDuration().toMillis());
+                    return false;
+                }
+                if (st.getRegistration() == null) {
+                    log.debug("findBestFitFor: TE {} excluded - no registration", teHolder.getId());
+                    return false;
+                }
+                return true;
+            })
+            .collect(Collectors.toList());
+
+        log.info("findBestFitFor: group={}, holdersInGroup={}, availableAfterFilter={}, requested={}",
+            bestFitTeGroupKey.get(), groupHolders.size(), availableTEList.size(), numWorkers);
+
+        Stream<TaskExecutorHolder> availableTEs = availableTEList.stream();
 
         if(availableTaskExecutorMutatorHook != null) {
             availableTEs = availableTaskExecutorMutatorHook.mutate(availableTEs, request, schedulingConstraints);
@@ -642,6 +657,7 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
 
         Map<String, Integer> reservationCountBySku = new HashMap<>();
 
+        log.info("mapReservationsToSku called with {} reservations", pendingReservations == null ? 0 : pendingReservations.size());
         if (pendingReservations == null || pendingReservations.isEmpty()) {
             return reservationCountBySku;
         }
@@ -783,14 +799,12 @@ public class ExecutorStateManagerImpl implements ExecutorStateManager {
         if (taskExecutors.isPresent() && taskExecutors.get().size() == allocationRequests.size()) {
             return taskExecutors;
         } else {
-            log.warn("Not enough available TEs found for scheduling constraints {}, request: {}", schedulingConstraints, request);
-            if (taskExecutors.isPresent()) {
-                log.debug("Found {} Task Executors: {} for request: {} with constraints: {}",
-                    taskExecutors.get().size(), taskExecutors.get(), request, schedulingConstraints);
-            } else {
-                log.warn("No suitable Task Executors found for request: {} with constraints: {}",
-                    request, schedulingConstraints);
-            }
+            log.warn("Not enough available TEs for constraints {} (found={}, needed={}, jobId={}, workerId={})",
+                schedulingConstraints,
+                taskExecutors.isPresent() ? taskExecutors.get().size() : 0,
+                allocationRequests.size(),
+                request.getJobId(),
+                allocationRequests.stream().map(a -> a.getWorkerId().toString()).collect(Collectors.joining(",")));
 
             // If there are not enough workers with the given spec then add the request the pending ones
             if (!isJobIdAlreadyPending && request.getAllocationRequests().size() > 2) {


### PR DESCRIPTION
### Context
```
Not all scheduling constraints had enough workers available to fulfill the request
ResourceClusterActor.TaskExecutorBatchAssignmentRequest(allocationRequests=[TaskExecutorAllocationRequest(workerId=kafka-cluster-monitor-21-worker-18-168,
constraints=SchedulingConstraints(machineDefinition=MachineDefinition{cpuCores=2.0, memoryMB=14336.0, networkMbps=700.0, diskMB=65536.0, numPorts=1}, sizeName=Optional.empty,
 schedulingAttributes={jdk=17plus, jenkins_job=unknown, repo_name=corp/kafka-mantis-kafka-monitor}), jobMetadata=io.mantisrx.server.core.domain.JobMetadata@3240fd30,
stageNum=1, readyAt=-1, durationType=Perpetual)], clusterID=ClusterID(resourceID=mantisrc.kaasall),
reservation=Reservation(key=MantisResourceClusterReservationProto.ReservationKey(jobId=kafka-cluster-monitor-21, stageNumber=1),
schedulingConstraints=SchedulingConstraints(machineDefinition=MachineDefinition{cpuCores=2.0, memoryMB=14336.0, networkMbps=700.0, diskMB=65536.0, numPorts=1},
sizeName=Optional.empty, schedulingAttributes={jdk=17plus, jenkins_job=unknown, repo_name=corp/kafka-mantis-kafka-monitor}),
canonicalConstraintKey=md:2.0/14336.0/65536.0/700.0/1;size=~;attr=jdk=17plus,jenkins_job=unknown,repo_name=corp/kafka-mantis-kafka-monitor,, stageTargetSize=35,
priority=MantisResourceClusterReservationProto.ReservationPriority(type=REPLACE, tier=0, timestamp=1774746017312), createdAt=1774746017312))

```

currently logs are way too long to read, it basically just saying we don't have enough worker to fulfill the request that request for one single worker, and we don't need all these `machineDefinition=MachineDefinition{cpuCores=2.0, memoryMB=14336.0, networkMbps=700.0, diskMB=65536.0, numPorts=1` to be part of the details. 

Besides, we don't have logs to explain why we can't find the TE for the worker even though the scheduler sees there are 2 idle TE, adding logs to show details why TE not selected for the worker


### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
