### PR TITLE
Fix: idle TEs leak from scheduler pool after disable + reconnect + expiry

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/resourcecluster/ExecutorStateManagerActor.java
@@ -1208,7 +1208,9 @@ public class ExecutorStateManagerActor extends AbstractActorWithTimers {
             } else {
                 this.delegate.getActiveExecutorEntry().forEach(idAndState -> {
                     if (disableRequest.covers(idAndState.getValue().getRegistration())) {
-                        idAndState.getValue().onNodeDisabled();
+                        if (idAndState.getValue().onNodeDisabled()) {
+                            this.delegate.tryMarkUnavailable(idAndState.getKey());
+                        }
                     }
                 });
             }
@@ -1217,7 +1219,9 @@ public class ExecutorStateManagerActor extends AbstractActorWithTimers {
         for (TaskExecutorID taskExecutorID : disabledTaskExecutors) {
             TaskExecutorState state = this.delegate.get(taskExecutorID);
             if (state != null) {
-                state.onNodeDisabled();
+                if (state.onNodeDisabled() && state.getRegistration() != null) {
+                    this.delegate.tryMarkUnavailable(taskExecutorID);
+                }
             }
         }
     }
@@ -1243,7 +1247,13 @@ public class ExecutorStateManagerActor extends AbstractActorWithTimers {
                 if (state != null) {
                     // Only re-enable if not still disabled by other requests
                     if (!isTaskExecutorDisabled(state.getRegistration())) {
-                        state.onNodeEnabled();
+                        if (state.onNodeEnabled()) {
+                            // Re-sync the scheduler's executorsByGroup index. If the TE reconnected
+                            // while disabled, onHeartbeat's tryMarkAvailable
+                            // was gated by disabled=true and never ran; without this call the TE
+                            // would remain invisible to findBestFit despite isAvailable()==true.
+                            this.delegate.tryMarkAvailable(taskExecutorID);
+                        }
                     }
                 }
             } else if (expiredRequest.isRequestByAttributes()) {
@@ -1255,7 +1265,9 @@ public class ExecutorStateManagerActor extends AbstractActorWithTimers {
                         // Only re-enable if not still covered by other active disable requests
                         if (!isTaskExecutorDisabled(registration)) {
                             log.info("re-enable TE: {}", idAndState.getKey());
-                            idAndState.getValue().onNodeEnabled();
+                            if (idAndState.getValue().onNodeEnabled()) {
+                                this.delegate.tryMarkAvailable(idAndState.getKey());
+                            }
                         }
                     }
                 });

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/DisableReconnectExpireStuckReproTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/DisableReconnectExpireStuckReproTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.mantisrx.master.resourcecluster;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.testkit.javadsl.TestKit;
+import io.mantisrx.common.Ack;
+import io.mantisrx.common.WorkerConstants;
+import io.mantisrx.common.WorkerPorts;
+import io.mantisrx.common.properties.DefaultMantisPropertiesLoader;
+import io.mantisrx.common.properties.MantisPropertiesLoader;
+import io.mantisrx.config.dynamic.LongDynamicProperty;
+import io.mantisrx.master.resourcecluster.ResourceClusterAkkaImpl;
+import io.mantisrx.master.scheduler.CpuWeightedFitnessCalculator;
+import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.MantisJobDurationType;
+import io.mantisrx.server.core.TestingRpcService;
+import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.core.scheduler.SchedulingConstraints;
+import io.mantisrx.server.master.ExecuteStageRequestFactory;
+import io.mantisrx.server.master.config.MasterConfiguration;
+import io.mantisrx.server.master.persistence.MantisJobStore;
+import io.mantisrx.server.master.resourcecluster.ClusterID;
+import io.mantisrx.server.master.resourcecluster.ContainerSkuID;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster;
+import io.mantisrx.server.master.resourcecluster.ResourceCluster.NoResourceAvailableException;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorAllocationRequest;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorDisconnection;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorHeartbeat;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorID;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorRegistration;
+import io.mantisrx.server.master.resourcecluster.TaskExecutorReport;
+import io.mantisrx.server.master.scheduler.JobMessageRouter;
+import io.mantisrx.server.worker.TaskExecutorGateway;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableList;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableMap;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Repro for the symptom: after a targeted DisableTaskExecutorsRequest + disconnect + reconnect-while-disabled
+ * + disable-expiry, the TE shows up in getAvailableTaskExecutors / ResourceOverview but getTaskExecutorsFor
+ * throws NoResourceAvailableException because the TE is missing from executorsByGroup.
+ *
+ * Expected on unfixed master: this test FAILS with NoResourceAvailableException at the final allocation.
+ * Expected after the fix (tryMarkAvailable on onNodeEnabled): test passes.
+ */
+@Slf4j
+public class DisableReconnectExpireStuckReproTest {
+
+    private static final TaskExecutorID TE_ID = TaskExecutorID.of("reproTE");
+    private static final String TE_ADDRESS = "127.0.0.1";
+    private static final ClusterID CLUSTER_ID = ClusterID.of("reproCluster");
+    private static final Duration HEARTBEAT_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration ASSIGNMENT_TIMEOUT = Duration.ofSeconds(1);
+    private static final Duration DISABLED_CHECK_INTERVAL = Duration.ofSeconds(10);
+    private static final Duration SCHEDULER_LEASE_EXPIRATION = Duration.ofMillis(100);
+    private static final String HOST_NAME = "reproHost";
+
+    private static final ContainerSkuID SKU_ID = ContainerSkuID.of("reproSku");
+    private static final WorkerPorts WORKER_PORTS = new WorkerPorts(1, 2, 3, 4, 5);
+    private static final MachineDefinition MACHINE_DEFINITION =
+        new MachineDefinition(2f, 2014, 128.0, 1024, 1);
+
+    private static ActorSystem actorSystem;
+
+    private final TestingRpcService rpcService = new TestingRpcService();
+    private final TaskExecutorGateway gateway = mock(TaskExecutorGateway.class);
+    private MantisJobStore mantisJobStore;
+    private JobMessageRouter jobMessageRouter;
+    private ActorRef resourceClusterActor;
+    private ResourceCluster resourceCluster;
+    private final MantisPropertiesLoader propertiesLoader =
+        new DefaultMantisPropertiesLoader(System.getProperties());
+
+    @BeforeClass
+    public static void bootActor() {
+        actorSystem = ActorSystem.create();
+    }
+
+    @AfterClass
+    public static void shutdownActor() {
+        TestKit.shutdownActorSystem(actorSystem);
+        actorSystem = null;
+    }
+
+    @Before
+    public void setupTest() throws Exception {
+        rpcService.registerGateway(TE_ADDRESS, gateway);
+
+        mantisJobStore = mock(MantisJobStore.class);
+        jobMessageRouter = mock(JobMessageRouter.class);
+
+        when(gateway.submitTask(any()))
+            .thenReturn(CompletableFuture.completedFuture(Ack.getInstance()));
+
+        doReturn(ImmutableList.of())
+            .when(mantisJobStore).loadAllDisableTaskExecutorsRequests(CLUSTER_ID);
+        doReturn(ImmutableList.of())
+            .when(mantisJobStore).getJobArtifactsToCache(CLUSTER_ID);
+
+        MasterConfiguration masterConfig = mock(MasterConfiguration.class);
+        when(masterConfig.getTimeoutSecondsToReportStart()).thenReturn(1);
+        ExecuteStageRequestFactory executeStageRequestFactory = new ExecuteStageRequestFactory(masterConfig);
+
+        final Props props = ResourceClusterActor.props(
+            CLUSTER_ID,
+            HEARTBEAT_TIMEOUT,
+            ASSIGNMENT_TIMEOUT,
+            DISABLED_CHECK_INTERVAL,
+            SCHEDULER_LEASE_EXPIRATION,
+            Clock.systemDefaultZone(),
+            rpcService,
+            mantisJobStore,
+            jobMessageRouter,
+            0,
+            "",
+            false,
+            ImmutableMap.of(),
+            new CpuWeightedFitnessCalculator(),
+            executeStageRequestFactory,
+            false);
+
+        resourceClusterActor = actorSystem.actorOf(props);
+        resourceCluster = new ResourceClusterAkkaImpl(
+            resourceClusterActor,
+            Duration.ofSeconds(15),
+            CLUSTER_ID,
+            new LongDynamicProperty(propertiesLoader, "resourcecluster.gateway.maxConcurrentRequests.repro", 100000L));
+    }
+
+    @Test
+    public void reconnectDuringTargetedDisablePlusExpirePreservesSchedulability() throws Exception {
+        runReproSequence(
+            /* disableAttributes */ ImmutableMap.of(),
+            /* targetedTaskExecutorId */ Optional.of(TE_ID));
+    }
+
+    /**
+     * Attribute-based variant: the same drift happens because
+     * {@code onDisableTaskExecutorsRequestExpiry}'s attribute branch
+     * (ExecutorStateManagerActor.java:1249-1262) calls {@code onNodeEnabled()}
+     * without calling {@code delegate.tryMarkAvailable(id)}. The attribute disable
+     * is used by NF's UpgradeClusterChildWorkflowImpl drain when the caller
+     * targets a scale group / SKU instead of a single TE id.
+     */
+    @Test
+    public void reconnectDuringAttributeBasedDisablePlusExpirePreservesSchedulability() throws Exception {
+        runReproSequence(
+            /* disableAttributes */ ImmutableMap.of("repro", "attr"),
+            /* targetedTaskExecutorId */ Optional.empty());
+    }
+
+    private void runReproSequence(
+        Map<String, String> disableAttributes,
+        Optional<TaskExecutorID> targetedTaskExecutorId) throws Exception {
+        new TestKit(actorSystem) {{
+            TaskExecutorRegistration registration = buildRegistration(TE_ID);
+            doReturn(registration).when(mantisJobStore).getTaskExecutor(TE_ID);
+
+            // 1) Register + Occupied heartbeat: TE becomes Running (simulates the realistic case where
+            //    the TE is actively running a worker at the time the ASG-upgrade workflow disables it).
+            //    The Running state causes tryMarkUnavailable -> the TE is NOT in executorsByGroup anymore.
+            //    This is important: the bug only manifests when the TE is NOT present in executorsByGroup
+            //    at the moment of the disconnect/reconnect sequence.
+            WorkerId occupyingWorker = WorkerId.fromIdUnsafe("repro-job-0-worker-0-1");
+            assertEquals(Ack.getInstance(), resourceCluster.registerTaskExecutor(registration).get());
+            assertEquals(Ack.getInstance(),
+                resourceCluster.heartBeatFromTaskExecutor(
+                    new TaskExecutorHeartbeat(TE_ID, CLUSTER_ID, TaskExecutorReport.occupied(occupyingWorker))).get());
+
+            assertTrue("Baseline: TE should be registered before disable",
+                resourceCluster.getRegisteredTaskExecutors().get().contains(TE_ID));
+
+            // 2) DisableTaskExecutorsRequest with short expiry (wall-clock via akka timers).
+            Duration expiryIn = Duration.ofSeconds(2);
+            Instant expiry = Instant.now().plus(expiryIn);
+            Instant disableAt = Instant.now();
+            assertEquals(Ack.getInstance(),
+                resourceCluster.disableTaskExecutorsFor(
+                    disableAttributes,
+                    expiry,
+                    targetedTaskExecutorId).get());
+
+            // Give CheckDisabledTaskExecutors a moment to flip the disabled flag on the state.
+            Thread.sleep(200);
+
+            // 3) Explicitly disconnect the TE (simulates heartbeat-timeout / crash).
+            assertEquals(Ack.getInstance(),
+                resourceCluster.disconnectTaskExecutor(
+                    new TaskExecutorDisconnection(TE_ID, CLUSTER_ID)).get());
+
+            // 4) Reconnect: re-register + available heartbeat BEFORE the disable expires.
+            assertEquals(Ack.getInstance(), resourceCluster.registerTaskExecutor(registration).get());
+            assertEquals(Ack.getInstance(),
+                resourceCluster.heartBeatFromTaskExecutor(
+                    new TaskExecutorHeartbeat(TE_ID, CLUSTER_ID, TaskExecutorReport.available())).get());
+
+            // 5) Wait past expiry so ExpireDisableTaskExecutorsRequest fires.
+            long elapsedMs = Instant.now().toEpochMilli() - disableAt.toEpochMilli();
+            long remainingMs = Math.max(0, expiryIn.toMillis() - elapsedMs);
+            Thread.sleep(remainingMs + 1500);
+
+            // Post-expiry: the TE is reported as available by the API & metric (matches the operator's symptom).
+            List<TaskExecutorID> availableList = resourceCluster.getAvailableTaskExecutors().get();
+            log.info("Post-expiry getAvailableTaskExecutors: {}", availableList);
+            assertTrue("Post-expiry: getAvailableTaskExecutors must report the TE (matches operator's symptom)",
+                availableList.contains(TE_ID));
+
+            ResourceCluster.ResourceOverview overview = resourceCluster.resourceOverview().get();
+            log.info("Post-expiry resourceOverview: {}", overview);
+            assertTrue("Post-expiry: numAvailable >= 1 (matches operator's symptom)",
+                overview.getNumAvailableTaskExecutors() >= 1);
+
+            // 6) The key assertion: scheduler must also be able to pick this TE.
+            //    Pre-fix: throws NoResourceAvailableException. Post-fix: returns the TE.
+            WorkerId scheduleWorkerId = WorkerId.fromIdUnsafe("repro-job-2-worker-0-1");
+            try {
+                Map<TaskExecutorAllocationRequest, TaskExecutorID> after =
+                    resourceCluster.getTaskExecutorsFor(
+                        Collections.singleton(makeAllocReq(scheduleWorkerId))).get();
+                assertNotNull(after);
+                assertEquals("Post-expiry: scheduler should find exactly the reconnected TE",
+                    1, after.size());
+                assertTrue("Post-expiry: scheduler should return the formerly-disabled TE",
+                    after.containsValue(TE_ID));
+            } catch (ExecutionException ee) {
+                Throwable cause = ee.getCause();
+                if (cause instanceof NoResourceAvailableException) {
+                    fail("REPRODUCED THE BUG: NoResourceAvailableException despite TE being reported "
+                        + "as available by getAvailableTaskExecutors and resourceOverview. Cause: " + cause.getMessage());
+                } else {
+                    throw ee;
+                }
+            }
+        }};
+    }
+
+    private TaskExecutorAllocationRequest makeAllocReq(WorkerId workerId) {
+        return TaskExecutorAllocationRequest.of(
+            workerId,
+            SchedulingConstraints.of(MACHINE_DEFINITION),
+            null,
+            0,
+            MantisJobDurationType.Perpetual);
+    }
+
+    private TaskExecutorRegistration buildRegistration(TaskExecutorID id) {
+        return TaskExecutorRegistration.builder()
+            .taskExecutorID(id)
+            .clusterID(CLUSTER_ID)
+            .taskExecutorAddress(TE_ADDRESS)
+            .hostname(HOST_NAME)
+            .workerPorts(WORKER_PORTS)
+            .machineDefinition(MACHINE_DEFINITION)
+            .taskExecutorAttributes(
+                ImmutableMap.of(
+                    WorkerConstants.WORKER_CONTAINER_DEFINITION_ID, SKU_ID.getResourceID(),
+                    "repro", "attr"))
+            .build();
+    }
+}


### PR DESCRIPTION
## Summary

Resource-cluster scheduling can enter a state where a TaskExecutor is reported as available by the metrics endpoint and by `/getAvailableTaskExecutors`, yet new reservations for its SKU keep failing with `NoResourceAvailableException`. This PR closes the gap in `ExecutorStateManagerActor` that produces that drift and ships a deterministic repro test covering both by-id and attribute-based disable paths.

## Symptom

From an impacted master log:

```
Reconnected task executor TaskExecutorID(resourceId=2af3d069-…) was already marked for disabling.
Removed active disable task executors for request ExpireDisableTaskExecutorsRequest(
  request=DisableTaskExecutorsRequest(attributes={}, clusterID=ClusterID(resourceID=),
    expiry=…, taskExecutorID=Optional[TaskExecutorID(2af3d069-…)]))
```

After these two lines, the TE:
- shows up in `ResourceOverview.numAvailableTaskExecutors`,
- shows up in `GetAvailableTaskExecutorsRequest` responses,
- is **not** picked by `findBestFit`; assignment requests for its SKU raise `NoResourceAvailableException` with the accompanying scheduler log `"Cannot find any matching sku for request"` / `"Not enough available TEs found for scheduling constraints"`.

## Root cause

The three views read different data structures:

| View | Source |
|---|---|
| `ResourceOverview.numAvailable` metric | `taskExecutorStateMap.values().filter(isAvailable)` (`ExecutorStateManagerImpl.java:253`) |
| `GetAvailableTaskExecutorsRequest` API | `taskExecutorStateMap.entrySet().filter(isAvailable)` (`ExecutorStateManagerActor.java:410`) |
| Scheduler (`findBestFit`) | `executorsByGroup: Map<TaskExecutorGroupKey, NavigableSet<TaskExecutorHolder>>` (`ExecutorStateManagerImpl.java:124`, `381-417`) |

`executorsByGroup` is populated only by `tryMarkAvailable(id, state)` and requires `state.isAvailable() && state.getRegistration() != null` at the moment of the call.

Drift sequence that produces the stuck state (trace for `2af3d069-…`):

1. **Targeted disable issued** (e.g. from `man-nfmantis`'s `UpgradeClusterChildWorkflowImpl` drain). `state.onNodeDisabled()` sets `disabled=true`. Scheduler's filter at `:407` correctly excludes the TE — fine.
2. **TE disconnects** (heartbeat-timeout or crash). `onDisconnection()` clears `registration` and `availabilityState`; `archive()` moves the state out of `taskExecutorStateMap`. A stale holder may linger in `executorsByGroup` but is dropped by the `!taskExecutorStateMap.containsKey(...)` guard during assignment.
3. **TE reconnects** via heartbeat before the disable expires.
   - `trackIfAbsent` puts a fresh `TaskExecutorState` into the map. `tryMarkAvailable(id, new state)` is a no-op because the new state has `registration=null, availabilityState=null`.
   - `onHeartbeat` loads the registration, calls `onRegistration` (returns `true`), then sees the TE is still in `disabledTaskExecutors` and calls `onNodeDisabled()` → `disabled=true`. This is the `"Reconnected task executor ... was already marked for disabling"` log.
   - `state.onHeartbeat(hb)` flips `availabilityState=Pending`, but the `if (stateChange && state.isAvailable())` gate fails because `isAvailable()` = `Pending && !disabled` = `false`. **`tryMarkAvailable` is not called; the TE never enters `executorsByGroup`.**
4. **Disable expiry fires**. `onDisableTaskExecutorsRequestExpiry` calls `state.onNodeEnabled()`, which clears the flag — **but it does not re-index the TE into `executorsByGroup`**. After this, `state.isAvailable()` is `true`, so the metric and the API both report the TE as available, while `findBestFit` still cannot see it.

The symmetric gap exists in `onCheckDisabledTaskExecutors`: when a TE is disabled while present in `executorsByGroup`, `state.onNodeDisabled()` is called without a matching `tryMarkUnavailable`. The filter at `:407` happens to rescue the assignment side, but the stale holder adds noise to the generation-first ordering in `findBestGroupBySizeNameMatch`.

## Fix

Three edits in `ExecutorStateManagerActor.java`; all keep `executorsByGroup` in sync with `isAvailable()`:

1. **`onDisableTaskExecutorsRequestExpiry` by-id path** — after `state.onNodeEnabled()` flips to `false`, call `delegate.tryMarkAvailable(taskExecutorID)`. Idempotent: no-op if `isAvailable()==false` or if the holder is already present.
2. **`onDisableTaskExecutorsRequestExpiry` attribute path** — same fix for the by-attributes branch.
3. **`onCheckDisabledTaskExecutors`** — after `state.onNodeDisabled()` flips to `true`, call `delegate.tryMarkUnavailable(id)`. The by-id branch also guards on `state.getRegistration() != null` to avoid `tryMarkUnavailable`'s `log.warn` firing when a disable request arrives for a TE that is currently disconnected.

All calls are guarded by the `onNodeDisabled` / `onNodeEnabled` return value, so they only run on an actual flag flip — no double-remove or double-add. `tryMarkAvailable` / `tryMarkUnavailable` are already safe and idempotent under the preconditions.

No behavior change in any other path.

New `DisableReconnectExpireStuckReproTest` exercises the full sequence end-to-end via `ResourceCluster`:

- `reconnectDuringTargetedDisablePlusExpirePreservesSchedulability` — by-id `DisableTaskExecutorsRequest`.
- `reconnectDuringAttributeBasedDisablePlusExpirePreservesSchedulability` — attribute-matching `DisableTaskExecutorsRequest` (exercises the other fix site; confirmed by the `re-enable TE:` log line).

Each test registers a TE, heartbeats `Occupied` (so it drops from `executorsByGroup` just like a running TE during ASG drain), disables it, disconnects it, re-registers it with an Available heartbeat before the expiry, waits past expiry, and then asserts that `getTaskExecutorsFor` returns the TE. On unfixed master both tests fail with `"NoResourceAvailableException despite TE being reported as available…"`; with the fix, both pass.