### PR TITLE
Fix GET scale rules API stuck on disabled cluster

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
@@ -462,6 +462,7 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
             .match(DisableJobClusterRequest.class, (x) -> getSender().tell(new DisableJobClusterResponse(x.requestId, SUCCESS,"Cluster is already disabled"), getSelf()))
             .match(Terminated.class, this::onTerminated)
             .match(JobClusterProto.InitializeJobClusterRequest.class, (x) -> getSender().tell(new JobClustersManagerInitializeResponse(x.requestId, SUCCESS,"Cluster is already initialized"), getSelf()))
+            .match(JobClusterScalerRuleProto.GetScalerRulesRequest.class, this::onScalerRuleGet)
 
             // UNEXPECTED MESSAGES END //
             .matchAny(x -> logger.warn("unexpected message '{}' received by JobCluster actor {} in Disabled State", x, this.name))


### PR DESCRIPTION
### Context
```
http://100.65.91.100:7101/api/v1/jobClusters/test-dong/scalerRules  -> request against the control plane

failed with The server was not able to produce a timely response to your request.
Please try again in a short while!
```

we only log the message 

unexpected message 'JobClusterScalerRuleProto.GetScalerRulesRequest(jobClusterName=test-dong)' received by JobCluster actor test-dong in Disabled State

but not returning response when GET scaler rules is requested on the disabled cluster

Explain context and other details for this pull request.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
