### PR TITLE
Make scale-up worker additions transactional

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/IWorkerManager.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/IWorkerManager.java
@@ -69,7 +69,7 @@ public interface IWorkerManager {
      *
      * @return
      */
-    int scaleStage(MantisStageMetadataImpl stageMetaData, int ruleMax, int ruleMin, int numWorkers, String reason);
+    ScaleStageResult scaleStage(MantisStageMetadataImpl stageMetaData, int ruleMax, int ruleMin, int numWorkers, String reason);
 
     /**
      * Explicitly kill and resubmit worker associated with the given workerNumber.
@@ -100,4 +100,32 @@ public interface IWorkerManager {
      * Force sending any updates in worker data.
      */
     void refreshAndSendWorkerAssignments();
+
+    final class ScaleStageResult {
+        private final int actualNumWorkers;
+        private final int requestedNumWorkers;
+        private final int failedAdditions;
+
+        ScaleStageResult(int actualNumWorkers, int requestedNumWorkers, int failedAdditions) {
+            this.actualNumWorkers = actualNumWorkers;
+            this.requestedNumWorkers = requestedNumWorkers;
+            this.failedAdditions = failedAdditions;
+        }
+
+        int getActualNumWorkers() {
+            return actualNumWorkers;
+        }
+
+        int getRequestedNumWorkers() {
+            return requestedNumWorkers;
+        }
+
+        int getFailedAdditions() {
+            return failedAdditions;
+        }
+
+        boolean hasFailedAdditions() {
+            return failedAdditions > 0;
+        }
+    }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -94,6 +94,7 @@ import io.mantisrx.server.core.scheduler.SchedulingConstraints;
 import io.mantisrx.server.master.agentdeploy.MigrationStrategyFactory;
 import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.config.MasterConfiguration;
+import io.mantisrx.server.master.domain.Costs;
 import io.mantisrx.server.master.domain.DataFormatAdapter;
 import io.mantisrx.server.master.domain.IJobClusterDefinition;
 import io.mantisrx.server.master.domain.JobDefinition;
@@ -167,6 +168,7 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
     private final Counter numPeriodicRefreshSkipped;
     private final Counter numReservationUpsertRetries;
     private final Counter numReservationUpsertFailures;
+    private final Counter numWorkerStoreFailures;
 
     /**
      * Behavior after being initialized.
@@ -298,6 +300,7 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                 .addCounter("numPeriodicRefreshSkipped")
                 .addCounter("numReservationUpsertRetries")
                 .addCounter("numReservationUpsertFailures")
+                .addCounter("numWorkerStoreFailures")
                 .build();
         this.metrics = MetricsRegistry.getInstance().registerAndGet(m);
         this.numWorkerResubmissions = metrics.getCounter("numWorkerResubmissions");
@@ -309,6 +312,7 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
         this.numPeriodicRefreshSkipped = metrics.getCounter("numPeriodicRefreshSkipped");
         this.numReservationUpsertRetries = metrics.getCounter("numReservationUpsertRetries");
         this.numReservationUpsertFailures = metrics.getCounter("numReservationUpsertFailures");
+        this.numWorkerStoreFailures = metrics.getCounter("numWorkerStoreFailures");
     }
 
     /**
@@ -798,6 +802,19 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                 .build();
     }
 
+    private static final class PartialScaleStageFailureException extends RuntimeException {
+        private final int actualNumWorkers;
+
+        PartialScaleStageFailureException(String message, int actualNumWorkers, Throwable cause) {
+            super(message, cause);
+            this.actualNumWorkers = actualNumWorkers;
+        }
+
+        int getActualNumWorkers() {
+            return actualNumWorkers;
+        }
+    }
+
     //////////////////////////////////////////// Akka Messages sent to the Job Actor Begin/////////////////////
 
     @Override
@@ -820,6 +837,7 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
             sender.tell(
                     new JobInitialized(i.requestId, SERVER_ERROR, "" + e.getMessage(), jobId, i.requstor),
                     getSelf());
+            getContext().stop(getSelf());
         }
     }
 
@@ -1144,15 +1162,55 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
             int ruleMin = policies.stream().min(Comparator.comparingInt(StageScalingPolicy::getMin))
                 .map(StageScalingPolicy::getMin).orElse(0);
 
-            int actualScaleup = this.workerManager.scaleStage(stageMetaData, ruleMax, ruleMin, scaleStage.getNumWorkers(),
+            IWorkerManager.ScaleStageResult scaleResult = this.workerManager.scaleStage(
+                    stageMetaData,
+                    ruleMax,
+                    ruleMin,
+                    scaleStage.getNumWorkers(),
                     scaleStage.getReason());
+            String responseMessage;
+            if (scaleResult.hasFailedAdditions()) {
+                responseMessage = String.format(
+                        "Partially scaled stage %d to %d workers (requested %d; %d add failures)",
+                        scaleStage.getStageNum(),
+                        scaleResult.getActualNumWorkers(),
+                        scaleResult.getRequestedNumWorkers(),
+                        scaleResult.getFailedAdditions());
+                eventPublisher.publishStatusEvent(new LifecycleEventsProto.JobStatusEvent(
+                        WARN,
+                        responseMessage,
+                        getJobId(),
+                        getJobState()));
+            } else {
+                responseMessage = String.format(
+                        "Scaled stage %d to %d workers",
+                        scaleStage.getStageNum(),
+                        scaleResult.getActualNumWorkers());
+            }
 
-            LOGGER.info("Scaled stage {} to {} workers for Job {}", scaleStage.getStageNum(), actualScaleup,
-                    this.jobId);
+            LOGGER.info(
+                    "Scaled stage {} to {} workers for Job {} (requested {}, failed additions={})",
+                    scaleStage.getStageNum(),
+                    scaleResult.getActualNumWorkers(),
+                    this.jobId,
+                    scaleResult.getRequestedNumWorkers(),
+                    scaleResult.getFailedAdditions());
             numScaleStage.increment();
             sender.tell(new ScaleStageResponse(scaleStage.requestId, SUCCESS,
-                    String.format("Scaled stage %d to %d workers", scaleStage.getStageNum(), actualScaleup),
-                    actualScaleup), getSelf());
+                    responseMessage,
+                    scaleResult.getActualNumWorkers()), getSelf());
+        } catch (PartialScaleStageFailureException e) {
+            LOGGER.error(e.getMessage(), e);
+            eventPublisher.publishStatusEvent(new LifecycleEventsProto.JobStatusEvent(
+                    ERROR,
+                    e.getMessage(),
+                    getJobId(),
+                    getJobState()));
+            sender.tell(new ScaleStageResponse(
+                    scaleStage.requestId,
+                    SERVER_ERROR,
+                    e.getMessage(),
+                    e.getActualNumWorkers()), getSelf());
         } catch (Exception e) {
             String msg = String.format("Stage %d scale failed due to %s", scaleStage.getStageNum(), e.getMessage());
             LOGGER.error(msg, e);
@@ -2146,13 +2204,34 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                     mantisJobMetaData.addJobStageIfAbsent(msmd);
                     jobStore.updateStage(msmd);
                 }
-                IMantisWorkerMetadata mwmd = addWorker(schedulingInfo, stageNum, workerIndex);
+                IMantisWorkerMetadata mwmd = addInitialWorkerMetadata(schedulingInfo, stageNum, workerIndex);
                 workerRequests.add(mwmd);
             }
             return workerRequests;
         }
 
-        private IMantisWorkerMetadata addWorker(SchedulingInfo schedulingInfo, int stageNo, int workerIndex)
+        private IMantisWorkerMetadata addInitialWorkerMetadata(
+                SchedulingInfo schedulingInfo,
+                int stageNo,
+                int workerIndex)
+                throws InvalidJobException {
+            // Initial-job paths are one-shot: init failure returns SERVER_ERROR and stops the
+            // actor, so callers never reuse the mutated metadata snapshot. They take the
+            // wrapper's metadata directly and let the wrapper become unreachable (no commit or
+            // rollback). The two-phase scale-up path uses prepareWorker(...) directly.
+            return prepareWorker(schedulingInfo, stageNo, workerIndex).metadata();
+        }
+
+        /**
+         * Two-phase variant of {@link #addInitialWorkerMetadata(SchedulingInfo, int, int)}. Performs the
+         * in-memory mutations on {@code mantisJobMetaData} (adding to stage maps and
+         * recomputing job costs) and returns a {@link PendingWorkerAddition} wrapper that
+         * the caller must either {@link PendingWorkerAddition#commit() commit} after
+         * successfully persisting via {@code MantisJobStore.storeNewWorker}, or
+         * {@link PendingWorkerAddition#rollback() rollback} if persistence fails — keeping
+         * the in-memory metadata consistent with what is durably stored.
+         */
+        private PendingWorkerAddition prepareWorker(SchedulingInfo schedulingInfo, int stageNo, int workerIndex)
                 throws InvalidJobException {
             StageSchedulingInfo stageSchedInfo = schedulingInfo.getStages().get(stageNo);
             int workerNumber = workerNumberGenerator.getNextWorkerNumber(mantisJobMetaData, jobStore);
@@ -2166,6 +2245,10 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                     .withLifecycleEventsPublisher(eventPublisher)
 
                     .build();
+
+            // Snapshot Costs BEFORE mutating so rollback can restore in O(1) instead of recomputing.
+            Costs previousJobCosts = mantisJobMetaData.getJobCosts();
+
             if (!mantisJobMetaData.addWorkerMetadata(stageNo, jw)) {
                 Optional<JobWorker> tmp = mantisJobMetaData.getWorkerByIndex(stageNo, workerIndex);
                 if (tmp.isPresent()) {
@@ -2179,7 +2262,8 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                 }
             }
             mantisJobMetaData.setJobCosts(costsCalculator.calculateCosts(mantisJobMetaData));
-            return jw.getMetadata();
+            return new PendingWorkerAddition(
+                    mantisJobMetaData, stageNo, workerIndex, workerNumber, jw.getMetadata(), previousJobCosts);
         }
 
         @Override
@@ -2763,13 +2847,16 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
         }
 
         /**
-         * Preconditions : Stage is Valid and scalable Determines the actual no of workers for this stage within min and
-         * max, updates the expected num workers first and saves to store. (If that fails we abort the operation) then
-         * continues adding/terminating worker one by one. If an exception occurs adding/removing any worker we continue
-         * forward with others. Heartbeat check should kick in and resubmit any workers that didn't get scheduled
+         * Preconditions: stage is valid and scalable. Determines the target number of workers for
+         * this stage within min and max bounds, persists that desired count first, then applies the
+         * add/remove operations one by one. Failed scale-up additions are rolled back and the stage
+         * target is shrunk to the realized worker count so stage metadata remains dense and
+         * consistent with what was durably stored. If that compensating shrink cannot be persisted
+         * after some additions already succeeded, those successes are still queued and the caller
+         * receives a dedicated error describing the preserved partial result.
          */
         @Override
-        public int scaleStage(
+        public ScaleStageResult scaleStage(
             MantisStageMetadataImpl stageMetaData,
             int ruleMax,
             int ruleMin,
@@ -2787,12 +2874,14 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
             }
 
             // sanitize input worker count to be between min and max
-            int newNumWorkerCount = max(min(numWorkers, max), min);
-            if (newNumWorkerCount != oldNumWorkers) {
+            int requestedNumWorkers = max(min(numWorkers, max), min);
+            int realizedTarget = requestedNumWorkers;
+            int failedAdditions = 0;
+            if (requestedNumWorkers != oldNumWorkers) {
                 try {
-                    stageMetaData.unsafeSetNumWorkers(newNumWorkerCount, jobStore);
+                    stageMetaData.unsafeSetNumWorkers(requestedNumWorkers, jobStore);
                     eventPublisher.publishStatusEvent(new LifecycleEventsProto.JobStatusEvent(INFO,
-                            String.format("Setting #workers to %d for stage %d, reason=%s", newNumWorkerCount,
+                            String.format("Setting #workers to %d for stage %d, reason=%s", requestedNumWorkers,
                                     stageMetaData.getStageNum(), reason), getJobId(), getJobState()));
                 } catch (Exception e) {
                     String error = String.format("Exception updating stage %d worker count for Job %s due to %s",
@@ -2804,29 +2893,58 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                     throw new RuntimeException(error);
                 }
                 List<IMantisWorkerMetadata> workerRequests = new ArrayList<>();
-                if (newNumWorkerCount > oldNumWorkers) {
-                    for (int i = 0; i < newNumWorkerCount - oldNumWorkers; i++) {
+                if (requestedNumWorkers > oldNumWorkers) {
+                    SchedulingInfo schedInfo = mantisJobMetaData.getJobDefinition().getSchedulingInfo();
+                    int successfulAdds = 0;
+                    for (int i = 0; i < requestedNumWorkers - oldNumWorkers; i++) {
+                        int newWorkerIndex = oldNumWorkers + successfulAdds;
+                        PendingWorkerAddition pending = null;
                         try {
-                            int newWorkerIndex = oldNumWorkers + i;
-                            SchedulingInfo schedInfo = mantisJobMetaData.getJobDefinition().getSchedulingInfo();
-                            IMantisWorkerMetadata workerRequest = addWorker(schedInfo, stageMetaData.getStageNum(),
-                                    newWorkerIndex);
-                            jobStore.storeNewWorker(workerRequest);
-                            markStageAssignmentsChanged(true);
-                            workerRequests.add(workerRequest);
+                            pending = prepareWorker(schedInfo, stageMetaData.getStageNum(), newWorkerIndex);
+                            jobStore.storeNewWorker(pending.metadata());
+                            pending.commit();
+                            workerRequests.add(pending.metadata());
+                            successfulAdds++;
                         } catch (Exception e) {
-                            // creating a worker failed but expected no of workers was set successfully,
-                            // during heartbeat check we will
-                            // retry launching this worker
-                            LOGGER.warn("Exception adding new worker for {}", stageMetaData.getJobId().getId(), e);
+                            if (pending != null) {
+                                try {
+                                    pending.rollback();
+                                } catch (RuntimeException rollbackException) {
+                                    rollbackException.addSuppressed(e);
+                                    throw rollbackException;
+                                }
+                            }
+                            failedAdditions++;
+                            numWorkerStoreFailures.increment();
+                            try {
+                                realizedTarget = shrinkStageTargetAfterFailedAddition(stageMetaData, realizedTarget);
+                            } catch (RuntimeException shrinkFailure) {
+                                flushQueuedScaleWorkers(workerRequests);
+                                if (!workerRequests.isEmpty()) {
+                                    throw new PartialScaleStageFailureException(
+                                            String.format(
+                                                    "Stage %d scale partially applied: queued workers were kept and %d workers remain realized (requested %d; %d add failures), but failed to persist the adjusted stage target",
+                                                    stageMetaData.getStageNum(),
+                                                    oldNumWorkers + successfulAdds,
+                                                    requestedNumWorkers,
+                                                    failedAdditions),
+                                            oldNumWorkers + successfulAdds,
+                                            shrinkFailure);
+                                }
+                                throw shrinkFailure;
+                            }
+                            LOGGER.warn(
+                                    "Exception adding new worker for {} at index {}. Rolled back in-memory state and shrunk stage target to {}",
+                                    stageMetaData.getJobId().getId(),
+                                    newWorkerIndex,
+                                    realizedTarget,
+                                    e);
                         }
                     }
-                    // Queue all new workers
-                    // Use SCALE priority (medium) for scaling operations in reservation system
-                    queueWorkers(workerRequests, PriorityType.SCALE, empty());
+                    flushQueuedScaleWorkers(workerRequests);
                 } else {
                     //  potential bulk removal opportunity?
-                    for (int i = 0; i < oldNumWorkers - newNumWorkerCount; i++) {
+                    for (int i = 0; i < oldNumWorkers - requestedNumWorkers; i++) {
                         try {
                             final JobWorker w = stageMetaData.getWorkerByIndex(oldNumWorkers - i - 1);
                             terminateAndRemoveWorker(w.getMetadata(), WorkerState.Completed, JobCompletedReason.Killed);
@@ -2839,8 +2957,37 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                     }
                 }
             }
-            LOGGER.info("{} Scaled stage to {} workers", stageMetaData.getJobId().getId(), newNumWorkerCount);
-            return newNumWorkerCount;
+            LOGGER.info(
+                    "{} Scaled stage to {} workers (requested {}, failed additions={})",
+                    stageMetaData.getJobId().getId(),
+                    realizedTarget,
+                    requestedNumWorkers,
+                    failedAdditions);
+            return new ScaleStageResult(realizedTarget, requestedNumWorkers, failedAdditions);
+        }
+
+        private void flushQueuedScaleWorkers(List<IMantisWorkerMetadata> workerRequests) {
+            if (!workerRequests.isEmpty()) {
+                markStageAssignmentsChanged(true);
+                // Use SCALE priority (medium) for scaling operations in reservation system.
+                queueWorkers(workerRequests, PriorityType.SCALE, empty());
+            }
+        }
+
+        private int shrinkStageTargetAfterFailedAddition(MantisStageMetadataImpl stageMetaData, int realizedTarget) {
+            int shrunkTarget = realizedTarget - 1;
+            try {
+                stageMetaData.unsafeSetNumWorkers(shrunkTarget, jobStore);
+                return shrunkTarget;
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        String.format(
+                                "Failed to shrink stage %d for Job %s to realized size %d after add failure",
+                                stageMetaData.getStageNum(),
+                                jobId,
+                                shrunkTarget),
+                        e);
+            }
         }
     }
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -804,14 +804,24 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
 
     private static final class PartialScaleStageFailureException extends RuntimeException {
         private final int actualNumWorkers;
+        private final boolean fatal;
 
         PartialScaleStageFailureException(String message, int actualNumWorkers, Throwable cause) {
+            this(message, actualNumWorkers, cause, false);
+        }
+
+        PartialScaleStageFailureException(String message, int actualNumWorkers, Throwable cause, boolean fatal) {
             super(message, cause);
             this.actualNumWorkers = actualNumWorkers;
+            this.fatal = fatal;
         }
 
         int getActualNumWorkers() {
             return actualNumWorkers;
+        }
+
+        boolean isFatal() {
+            return fatal;
         }
     }
 
@@ -837,7 +847,9 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
             sender.tell(
                     new JobInitialized(i.requestId, SERVER_ERROR, "" + e.getMessage(), jobId, i.requstor),
                     getSelf());
-            getContext().stop(getSelf());
+            if (i.isSubmit) {
+                getContext().stop(getSelf());
+            }
         }
     }
 
@@ -1211,6 +1223,20 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                     SERVER_ERROR,
                     e.getMessage(),
                     e.getActualNumWorkers()), getSelf());
+            if (e.isFatal()) {
+                getContext().getParent().tell(
+                        new JobClusterProto.KillJobRequest(
+                                jobId,
+                                e.getMessage(),
+                                JobCompletedReason.Error,
+                                MANTIS_MASTER_USER,
+                                ActorRef.noSender()),
+                        getSelf());
+            } else {
+                // Partial scale durably stored some workers; count it like a successful scale so dashboards
+                // don't under-report operator-initiated scaling activity.
+                numScaleStage.increment();
+            }
         } catch (Exception e) {
             String msg = String.format("Stage %d scale failed due to %s", scaleStage.getStageNum(), e.getMessage());
             LOGGER.error(msg, e);
@@ -2215,10 +2241,10 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                 int stageNo,
                 int workerIndex)
                 throws InvalidJobException {
-            // Initial-job paths are one-shot: init failure returns SERVER_ERROR and stops the
-            // actor, so callers never reuse the mutated metadata snapshot. They take the
-            // wrapper's metadata directly and let the wrapper become unreachable (no commit or
-            // rollback). The two-phase scale-up path uses prepareWorker(...) directly.
+            // Submit-time initial-worker paths are one-shot: init failure returns SERVER_ERROR
+            // and stops the actor, so callers never reuse the mutated metadata snapshot. They
+            // take the wrapper's metadata directly and let the wrapper become unreachable (no
+            // commit or rollback). The two-phase scale-up path uses prepareWorker(...) directly.
             return prepareWorker(schedulingInfo, stageNo, workerIndex).metadata();
         }
 
@@ -2910,8 +2936,23 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                                 try {
                                     pending.rollback();
                                 } catch (RuntimeException rollbackException) {
-                                    rollbackException.addSuppressed(e);
-                                    throw rollbackException;
+                                    PartialScaleStageFailureException partial = new PartialScaleStageFailureException(
+                                            String.format(
+                                                    "Stage %d scale failed after partially applying %d workers "
+                                                            + "(requested %d; %d add failures, last add failure: %s); "
+                                                            + "rollback of failed addition also threw: %s; "
+                                                            + "stage metadata rollback is corrupt and the job will be failed",
+                                                    stageMetaData.getStageNum(),
+                                                    oldNumWorkers + successfulAdds,
+                                                    requestedNumWorkers,
+                                                    failedAdditions + 1,
+                                                    e.getMessage(),
+                                                    rollbackException.getMessage()),
+                                            oldNumWorkers + successfulAdds,
+                                            e,
+                                            true);
+                                    partial.addSuppressed(rollbackException);
+                                    throw partial;
                                 }
                             }
                             failedAdditions++;
@@ -2921,16 +2962,25 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                             } catch (RuntimeException shrinkFailure) {
                                 flushQueuedScaleWorkers(workerRequests);
                                 if (!workerRequests.isEmpty()) {
-                                    throw new PartialScaleStageFailureException(
+                                    PartialScaleStageFailureException partial = new PartialScaleStageFailureException(
                                             String.format(
-                                                    "Stage %d scale partially applied: queued workers were kept and %d workers remain realized (requested %d; %d add failures), but failed to persist the adjusted stage target",
+                                                    "Stage %d scale partially applied: %d workers remain realized "
+                                                            + "(requested %d; %d add failures, last add failure: %s); "
+                                                            + "compensating shrink also failed: %s; "
+                                                            + "shrink did not stick and prior stage target %d remains in force",
                                                     stageMetaData.getStageNum(),
                                                     oldNumWorkers + successfulAdds,
                                                     requestedNumWorkers,
-                                                    failedAdditions),
+                                                    failedAdditions,
+                                                    e.getMessage(),
+                                                    shrinkFailure.getMessage(),
+                                                    stageMetaData.getNumWorkers()),
                                             oldNumWorkers + successfulAdds,
-                                            shrinkFailure);
+                                            e);
+                                    partial.addSuppressed(shrinkFailure);
+                                    throw partial;
                                 }
+                                shrinkFailure.addSuppressed(e);
                                 throw shrinkFailure;
                             }
                             LOGGER.warn(

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisJobMetadataImpl.java
@@ -273,6 +273,36 @@ public class MantisJobMetadataImpl implements IMantisJobMetadata {
         return false;
     }
 
+    /**
+     * Reverses {@link #addWorkerMetadata(int, JobWorker)} for rollback of a pending in-memory
+     * addition that failed to persist. Removes the worker from both the stage's index/number maps
+     * and the job-level workerNumberToStageMap. Does not archive — the worker was never durably stored.
+     */
+    void unsafeRemoveWorkerMetadata(int stageNum, int workerIndex, int workerNumber) {
+        IMantisStageMetadata stage = stageMetadataMap.get(stageNum);
+        if (!(stage instanceof MantisStageMetadataImpl)) {
+            throw new IllegalStateException(String.format(
+                    "Corrupt job worker rollback state for job %s: missing stage %d while removing index %d "
+                            + "workerNumber %d",
+                    jobId.getId(),
+                    stageNum,
+                    workerIndex,
+                    workerNumber));
+        }
+        ((MantisStageMetadataImpl) stage).removeWorkerIndex(workerIndex, workerNumber);
+        Integer removedStage = workerNumberToStageMap.remove(workerNumber);
+        if (removedStage == null || removedStage != stageNum) {
+            throw new IllegalStateException(String.format(
+                    "Corrupt job worker rollback state for job %s: workerNumber map for stage %d index %d "
+                            + "workerNumber %d removed mapping %s",
+                    jobId.getId(),
+                    stageNum,
+                    workerIndex,
+                    workerNumber,
+                    removedStage));
+        }
+    }
+
     @JsonIgnore
     public Optional<JobWorker> getWorkerByIndex(int stageNumber, int workerIndex) throws InvalidJobException {
         Optional<IMantisStageMetadata> stage = getStageMetadata(stageNumber);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisStageMetadataImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisStageMetadataImpl.java
@@ -332,9 +332,14 @@ public class MantisStageMetadataImpl implements IMantisStageMetadata {
      * @throws Exception
      */
     public void unsafeSetNumWorkers(int numWorkers, MantisJobStore store) throws Exception {
+        int previousNumWorkers = this.numWorkers;
         this.numWorkers = numWorkers;
-
-        store.updateStage(this);
+        try {
+            store.updateStage(this);
+        } catch (Exception e) {
+            this.numWorkers = previousNumWorkers;
+            throw e;
+        }
     }
 
     /**
@@ -576,32 +581,62 @@ public class MantisStageMetadataImpl implements IMantisStageMetadata {
      * threw); use {@link #unsafeRemoveWorker(int, int, MantisJobStore)} for the archive-on-remove path.
      */
     void removeWorkerIndex(int workerIndex, int workerNumber) {
-        JobWorker removedIdx = workerByIndexMetadataSet.remove(workerIndex);
-        JobWorker removedNum = workerByNumberMetadataSet.remove(workerNumber);
-        if (removedIdx == null
-                || removedNum == null
-                || removedIdx.getMetadata().getWorkerNumber() != workerNumber
-                || removedNum.getMetadata().getWorkerIndex() != workerIndex) {
+        JobWorker workerByIndex = workerByIndexMetadataSet.get(workerIndex);
+        JobWorker workerByNumber = workerByNumberMetadataSet.get(workerNumber);
+        if (workerByIndex == null
+                || workerByNumber == null
+                || workerByIndex.getMetadata().getWorkerIndex() != workerIndex
+                || workerByIndex.getMetadata().getWorkerNumber() != workerNumber
+                || workerByNumber.getMetadata().getWorkerIndex() != workerIndex
+                || workerByNumber.getMetadata().getWorkerNumber() != workerNumber
+                || workerByIndex != workerByNumber) {
             throw new IllegalStateException(String.format(
                     "Corrupt stage worker rollback state for job %s stage %d index %d workerNumber %d "
-                            + "(removedByIndex=%s, removedByNumber=%s)",
+                            + "(workerByIndex=%s, workerByNumber=%s)",
                     jobId.getId(),
                     stageNum,
                     workerIndex,
                     workerNumber,
-                    removedIdx == null
-                            ? "null"
-                            : String.format(
-                                    "index=%d,workerNumber=%d",
-                                    removedIdx.getMetadata().getWorkerIndex(),
-                                    removedIdx.getMetadata().getWorkerNumber()),
-                    removedNum == null
-                            ? "null"
-                            : String.format(
-                                    "index=%d,workerNumber=%d",
-                                    removedNum.getMetadata().getWorkerIndex(),
-                                    removedNum.getMetadata().getWorkerNumber())));
+                    describeRollbackWorker(workerByIndex),
+                    describeRollbackWorker(workerByNumber)));
         }
+
+        if (!workerByIndexMetadataSet.remove(workerIndex, workerByIndex)) {
+            throw new IllegalStateException(String.format(
+                    "Corrupt stage worker rollback state for job %s stage %d index %d workerNumber %d "
+                            + "(workerByIndex=%s, workerByNumber=%s, removedByIndex=false)",
+                    jobId.getId(),
+                    stageNum,
+                    workerIndex,
+                    workerNumber,
+                    describeRollbackWorker(workerByIndex),
+                    describeRollbackWorker(workerByNumber)));
+        }
+
+        if (!workerByNumberMetadataSet.remove(workerNumber, workerByNumber)) {
+            workerByIndexMetadataSet.put(workerIndex, workerByIndex);
+            throw new IllegalStateException(String.format(
+                    "Corrupt stage worker rollback state for job %s stage %d index %d workerNumber %d "
+                            + "(workerByIndex=%s, workerByNumber=%s, removedByNumber=false)",
+                    jobId.getId(),
+                    stageNum,
+                    workerIndex,
+                    workerNumber,
+                    describeRollbackWorker(workerByIndex),
+                    describeRollbackWorker(workerByNumber)));
+        }
+    }
+
+    private static String describeRollbackWorker(JobWorker worker) {
+        if (worker == null) {
+            return "null";
+        }
+
+        return String.format(
+                "index=%d,workerNumber=%d,identity=%s",
+                worker.getMetadata().getWorkerIndex(),
+                worker.getMetadata().getWorkerNumber(),
+                Integer.toHexString(System.identityHashCode(worker)));
     }
 
     /**

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisStageMetadataImpl.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/MantisStageMetadataImpl.java
@@ -571,6 +571,40 @@ public class MantisStageMetadataImpl implements IMantisStageMetadata {
     }
 
     /**
+     * Reverses {@link #addWorkerIndex(JobWorker)} without archiving. Intended for rolling back a
+     * pending in-memory addition that failed to persist (e.g. {@code MantisJobStore.storeNewWorker}
+     * threw); use {@link #unsafeRemoveWorker(int, int, MantisJobStore)} for the archive-on-remove path.
+     */
+    void removeWorkerIndex(int workerIndex, int workerNumber) {
+        JobWorker removedIdx = workerByIndexMetadataSet.remove(workerIndex);
+        JobWorker removedNum = workerByNumberMetadataSet.remove(workerNumber);
+        if (removedIdx == null
+                || removedNum == null
+                || removedIdx.getMetadata().getWorkerNumber() != workerNumber
+                || removedNum.getMetadata().getWorkerIndex() != workerIndex) {
+            throw new IllegalStateException(String.format(
+                    "Corrupt stage worker rollback state for job %s stage %d index %d workerNumber %d "
+                            + "(removedByIndex=%s, removedByNumber=%s)",
+                    jobId.getId(),
+                    stageNum,
+                    workerIndex,
+                    workerNumber,
+                    removedIdx == null
+                            ? "null"
+                            : String.format(
+                                    "index=%d,workerNumber=%d",
+                                    removedIdx.getMetadata().getWorkerIndex(),
+                                    removedIdx.getMetadata().getWorkerNumber()),
+                    removedNum == null
+                            ? "null"
+                            : String.format(
+                                    "index=%d,workerNumber=%d",
+                                    removedNum.getMetadata().getWorkerIndex(),
+                                    removedNum.getMetadata().getWorkerNumber())));
+        }
+    }
+
+    /**
      * Updates the the state of a worker based on the worker event.
      * @param event
      * @param jobStore

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/PendingWorkerAddition.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/PendingWorkerAddition.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.jobcluster.job;
+
+import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
+import io.mantisrx.server.master.domain.Costs;
+
+/**
+ * Two-phase wrapper for a worker addition that has been applied to in-memory job metadata
+ * but not yet durably persisted. Lets the caller commit the addition (after a successful
+ * {@code MantisJobStore.storeNewWorker}) or roll it back (after the store call throws),
+ * keeping the in-memory {@link MantisJobMetadataImpl} consistent across partial failures
+ * during a scale-up loop.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * PendingWorkerAddition pending = prepareWorker(...);
+ * try {
+ *     jobStore.storeNewWorker(pending.metadata());
+ *     pending.commit();
+ *     // ... use pending.metadata() ...
+ * } catch (Exception e) {
+ *     pending.rollback();
+ *     // ... handle/log ...
+ * }
+ * }</pre>
+ *
+ * <p>{@link #commit()} and a successful {@link #rollback()} are mutually exclusive and idempotent:
+ * once one completes, the other becomes a no-op. If rollback itself throws because the underlying
+ * metadata is already corrupt, this wrapper remains unfinished so callers can surface that failure.
+ */
+final class PendingWorkerAddition {
+
+    private final MantisJobMetadataImpl jobMetaData;
+    private final int stageNum;
+    private final int workerIndex;
+    private final int workerNumber;
+    private final IMantisWorkerMetadata metadata;
+    private final Costs previousJobCosts;
+
+    private boolean committed;
+    private boolean rolledBack;
+
+    PendingWorkerAddition(
+            MantisJobMetadataImpl jobMetaData,
+            int stageNum,
+            int workerIndex,
+            int workerNumber,
+            IMantisWorkerMetadata metadata,
+            Costs previousJobCosts) {
+        this.jobMetaData = jobMetaData;
+        this.stageNum = stageNum;
+        this.workerIndex = workerIndex;
+        this.workerNumber = workerNumber;
+        this.metadata = metadata;
+        this.previousJobCosts = previousJobCosts;
+    }
+
+    /** The worker metadata to pass to {@code MantisJobStore.storeNewWorker}. */
+    IMantisWorkerMetadata metadata() {
+        return metadata;
+    }
+
+    /**
+     * Marks this addition as durable. Subsequent {@link #rollback()} calls become no-ops.
+     */
+    synchronized void commit() {
+        if (rolledBack) {
+            return;
+        }
+        committed = true;
+    }
+
+    /**
+     * Reverses the in-memory mutations performed when this pending addition was created:
+     * removes the worker from the stage's index/number maps and the job-level
+     * workerNumber→stage map, and restores the job-level Costs to the snapshot taken
+     * before the addition. Idempotent after a successful rollback; no-op if {@link #commit()}
+     * has already been called. If rollback itself throws, this wrapper remains unfinished so
+     * callers can surface the corruption instead of silently finalizing it.
+     */
+    synchronized void rollback() {
+        if (committed || rolledBack) {
+            return;
+        }
+        jobMetaData.unsafeRemoveWorkerMetadata(stageNum, workerIndex, workerNumber);
+        jobMetaData.setJobCosts(previousJobCosts);
+        rolledBack = true;
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/PendingWorkerAddition.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/PendingWorkerAddition.java
@@ -77,8 +77,14 @@ final class PendingWorkerAddition {
 
     /**
      * Marks this addition as durable. Subsequent {@link #rollback()} calls become no-ops.
+     *
+     * <p>Not synchronized: this wrapper is constructed and consumed entirely within a single
+     * {@code JobActor} message handler, never escapes that scope, and never crosses a thread
+     * boundary. Adding cross-thread guarantees here would mislead callers about the wider
+     * thread-safety of the underlying {@link MantisJobMetadataImpl}, which is itself
+     * actor-confined.
      */
-    synchronized void commit() {
+    void commit() {
         if (rolledBack) {
             return;
         }
@@ -92,8 +98,10 @@ final class PendingWorkerAddition {
      * before the addition. Idempotent after a successful rollback; no-op if {@link #commit()}
      * has already been called. If rollback itself throws, this wrapper remains unfinished so
      * callers can surface the corruption instead of silently finalizing it.
+     *
+     * <p>Not synchronized — see {@link #commit()} for the actor-confinement rationale.
      */
-    synchronized void rollback() {
+    void rollback() {
         if (committed || rolledBack) {
             return;
         }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -225,7 +225,7 @@ public interface MasterConfiguration extends CoreConfiguration {
     int getMaximumResubmissionsPerWorker();
 
     @Config("mantis.worker.resubmission.interval.secs")
-    @Default("5:10:20")
+    @Default("5:10:30:60:120:600")
     String getWorkerResubmitIntervalSecs();
 
     @Config("mantis.worker.expire.resubmit.delay.secs")

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
@@ -32,6 +32,7 @@
 
 package io.mantisrx.master.jobcluster.job;
 import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.CLIENT_ERROR;
+import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SERVER_ERROR;
 import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SUCCESS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -51,6 +52,7 @@ import io.mantisrx.master.events.StatusEventSubscriberLoggingImpl;
 import io.mantisrx.master.events.WorkerEventSubscriberLoggingImpl;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.master.jobcluster.proto.JobClusterProto;
+import io.mantisrx.master.jobcluster.proto.JobProto;
 import io.mantisrx.runtime.MachineDefinition;
 import io.mantisrx.runtime.MantisJobState;
 import io.mantisrx.runtime.descriptor.SchedulingInfo;
@@ -62,6 +64,8 @@ import io.mantisrx.server.core.JobSchedulingInfo;
 import io.mantisrx.server.core.WorkerAssignments;
 import io.mantisrx.server.core.WorkerHost;
 import io.mantisrx.server.core.domain.WorkerId;
+import io.mantisrx.server.master.domain.IJobClusterDefinition;
+import io.mantisrx.server.master.domain.JobDefinition;
 import io.mantisrx.server.master.domain.JobId;
 import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.exceptions.InvalidJobException;
@@ -71,6 +75,7 @@ import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -82,6 +87,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
 
@@ -308,6 +314,54 @@ public class JobScaleUpDownTests {
 		verify(schedulerMock, times(1)).scheduleWorkers(any());
 		verify(schedulerMock, never()).upsertReservation(any(UpsertReservation.class));
 
+	}
+
+	@Test
+	public void initFailureStopsActorAndPreventsDirtySnapshotReuse() throws Exception {
+		setupLegacyConfig();
+		final TestKit probe = new TestKit(system);
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerStageWithConstraints(
+						1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList())
+				.build();
+		String clusterName = "initFailureStopsActor";
+		IJobClusterDefinition jobClusterDefn = JobTestHelper.generateJobClusterDefinition(clusterName, sInfo);
+		JobDefinition jobDefn = JobTestHelper.generateJobDefinition(clusterName, sInfo);
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+		doThrow(new IOException("induced init store failure"))
+				.when(jobStoreMock).storeNewWorkers(any(), any());
+
+		MantisJobMetadataImpl mantisJobMetaData = new MantisJobMetadataImpl.Builder()
+				.withJobId(new JobId(clusterName, 1))
+				.withSubmittedAt(Instant.now())
+				.withJobState(JobState.Accepted)
+				.withNextWorkerNumToUse(1)
+				.withJobDefinition(jobDefn)
+				.build();
+		ActorRef jobActor = system.actorOf(JobActor.props(
+				jobClusterDefn,
+				mantisJobMetaData,
+				jobStoreMock,
+				schedulerMock,
+				lifecycleEventPublisher,
+				CostsCalculator.noop()));
+
+		probe.watch(jobActor);
+		jobActor.tell(new JobProto.InitJob(probe.getRef()), probe.getRef());
+		JobProto.JobInitialized initMsg = probe.expectMsgClass(JobProto.JobInitialized.class);
+		assertEquals(SERVER_ERROR, initMsg.responseCode);
+		assertTrue(initMsg.message.contains("Exception saving worker for Job"));
+		probe.expectTerminated(jobActor);
+
+		verify(jobStoreMock, times(1)).storeNewJob(any());
+		verify(jobStoreMock, times(1)).storeNewWorkers(any(), any());
+		verify(schedulerMock, never()).scheduleWorkers(any());
+		verify(schedulerMock, never()).upsertReservation(any(UpsertReservation.class));
 	}
 
 	private void validateHost(Map<Integer, WorkerHost> hosts, int workerIdx, int workerNum, MantisJobState workerState) {
@@ -785,6 +839,318 @@ SchedulingChange [jobId=testSchedulingInfo-1, workerAssignments={
 		verify(schedulerMock, times(1)).scheduleWorkers(any());
 		verify(schedulerMock, never()).upsertReservation(any(UpsertReservation.class));
 	}
+
+	////////////////////// Scale-up + storeNewWorker failure tests /////////////////////////
+	// These verify that JobActor.scaleStage keeps worker indexes dense when storeNewWorker fails:
+	// failed additions are rolled back from in-memory metadata, the stage target shrinks to the
+	// realized worker count, and only durably-stored workers are queued to the scheduler.
+
+	/**
+	 * First storeNewWorker call (for worker index 1) throws; the next two attempts succeed.
+	 * After the scale: the stage target shrinks to 3 workers, later successes reuse the failed
+	 * index so the worker indexes remain dense, and the SCALE reservation contains only the
+	 * 2 durably-stored new workers.
+	 */
+	@Test
+	public void scaleUpStageWithStoreNewWorkerFailureOnNthIteration_shrinksToRealizedCount() throws Exception {
+		setupReservationConfig();
+		final TestKit probe = new TestKit(system);
+		Map<ScalingReason, Strategy> smap = new HashMap<>();
+		smap.put(ScalingReason.CPU, new Strategy(ScalingReason.CPU, 0.5, 0.75, null));
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerScalableStageWithConstraints(1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList(),
+						new StageScalingPolicy(1, 0, 10, 1, 1, 0, smap, true))
+				.build();
+		String clusterName = "scaleUpStoreFailureRollback";
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+		// Fail the FIRST scale-up storeNewWorker call (worker index 1), allow the next two.
+		// Initial-job path uses storeNewWorkers(...) (plural batch) — unaffected by this stub.
+		doThrow(new IOException("induced storeNewWorker failure"))
+				.doNothing()
+				.doNothing()
+				.when(jobStoreMock).storeNewWorker(any());
+
+		ActorRef jobActor = JobTestHelper.submitSingleStageScalableJob(
+				system, probe, clusterName, sInfo, schedulerMock, jobStoreMock, lifecycleEventPublisher);
+
+		// Scale 1 -> 4 (delta=3): one will fail, two will succeed
+		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 4, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		assertEquals(SUCCESS, scaleResp.responseCode);
+		assertEquals(3, scaleResp.getActualNumWorkers());
+		assertTrue(scaleResp.message.contains("requested 4"));
+		assertTrue(scaleResp.message.contains("1 add failures"));
+
+		// All three storeNewWorker calls were attempted (the failure didn't abort the loop)
+		verify(jobStoreMock, times(3)).storeNewWorker(any());
+
+		// Inspect the live job metadata: stage 1 must contain exactly 3 workers with no missing index.
+		jobActor.tell(new JobClusterManagerProto.GetJobDetailsRequest("nj", JobId.fromId(clusterName + "-1").get()), probe.getRef());
+		JobClusterManagerProto.GetJobDetailsResponse detailsResp = probe.expectMsgClass(JobClusterManagerProto.GetJobDetailsResponse.class);
+		assertEquals(SUCCESS, detailsResp.responseCode);
+		assertTrue(detailsResp.getJobMetadata().isPresent());
+		IMantisJobMetadata md = detailsResp.getJobMetadata().get();
+		IMantisStageMetadata stage1 = md.getStageMetadata().get(1);
+		assertStageHasDenseWorkerIndexes(stage1, 3);
+
+		// Capture the actual reservation upsert payloads. The scale event's upsert must carry
+		// exactly 2 workers (only the successfully-stored ones). Initial submission and JobMaster
+		// upserts are NEW_JOB-priority; the scale upsert is SCALE-priority — filter on that.
+		ArgumentCaptor<UpsertReservation> upsertCap = ArgumentCaptor.forClass(UpsertReservation.class);
+		verify(schedulerMock, atLeast(1)).upsertReservation(upsertCap.capture());
+		UpsertReservation scaleUpsert = lastUpsertOfType(upsertCap.getAllValues(),
+				io.mantisrx.server.master.resourcecluster.proto.MantisResourceClusterReservationProto.ReservationPriority.PriorityType.SCALE);
+		assertEquals("scale upsert must contain only the 2 successfully-stored workers",
+				2, scaleUpsert.getAllocationRequests().size());
+
+		// Follow-on scale-down must remove the highest realized index cleanly.
+		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 2, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleDownResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		assertEquals(SUCCESS, scaleDownResp.responseCode);
+		assertEquals(2, scaleDownResp.getActualNumWorkers());
+		jobActor.tell(new JobClusterManagerProto.GetJobDetailsRequest("nj", JobId.fromId(clusterName + "-1").get()), probe.getRef());
+		JobClusterManagerProto.GetJobDetailsResponse postScaleDownResp = probe.expectMsgClass(JobClusterManagerProto.GetJobDetailsResponse.class);
+		assertEquals(SUCCESS, postScaleDownResp.responseCode);
+		assertStageHasDenseWorkerIndexes(postScaleDownResp.getJobMetadata().get().getStageMetadata().get(1), 2);
+	}
+
+	/**
+	 * Every storeNewWorker call during the scale fails. After the scale: the stage target shrinks
+	 * back to its pre-scale worker count (1), and the reservation upsert from the scale must
+	 * contain zero workers (queueWorkers was called with an empty list).
+	 */
+	@Test
+	public void scaleUpStageWithAllStoreNewWorkerFailures_keepsOriginalState() throws Exception {
+		setupReservationConfig();
+		final TestKit probe = new TestKit(system);
+		Map<ScalingReason, Strategy> smap = new HashMap<>();
+		smap.put(ScalingReason.CPU, new Strategy(ScalingReason.CPU, 0.5, 0.75, null));
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerScalableStageWithConstraints(1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList(),
+						new StageScalingPolicy(1, 0, 10, 1, 1, 0, smap, true))
+				.build();
+		String clusterName = "scaleUpAllStoreFailures";
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+		// Make every scale-up storeNewWorker call throw.
+		doThrow(new IOException("induced storeNewWorker failure"))
+				.when(jobStoreMock).storeNewWorker(any());
+
+		ActorRef jobActor = JobTestHelper.submitSingleStageScalableJob(
+				system, probe, clusterName, sInfo, schedulerMock, jobStoreMock, lifecycleEventPublisher);
+
+		// Scale 1 -> 4 (delta=3): all three will fail
+		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 4, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		assertEquals(SUCCESS, scaleResp.responseCode);
+		assertEquals(1, scaleResp.getActualNumWorkers());
+		assertTrue(scaleResp.message.contains("requested 4"));
+		assertTrue(scaleResp.message.contains("3 add failures"));
+
+		verify(jobStoreMock, times(3)).storeNewWorker(any());
+
+		// Stage worker count must be back to its pre-scale value (1 initial worker).
+		jobActor.tell(new JobClusterManagerProto.GetJobDetailsRequest("nj", JobId.fromId(clusterName + "-1").get()), probe.getRef());
+		JobClusterManagerProto.GetJobDetailsResponse detailsResp = probe.expectMsgClass(JobClusterManagerProto.GetJobDetailsResponse.class);
+		assertEquals(SUCCESS, detailsResp.responseCode);
+		IMantisJobMetadata md = detailsResp.getJobMetadata().get();
+		IMantisStageMetadata stage1 = md.getStageMetadata().get(1);
+		assertStageHasDenseWorkerIndexes(stage1, 1);
+
+		// queueWorkersViaReservation short-circuits on an empty worker list (JobActor.java:1905)
+		// so when every store call rolls back, NO SCALE-priority upsert should be sent at all —
+		// the only upserts are the NEW_JOB ones from initial submission and JobMaster.
+		ArgumentCaptor<UpsertReservation> upsertCap = ArgumentCaptor.forClass(UpsertReservation.class);
+		verify(schedulerMock, atLeast(1)).upsertReservation(upsertCap.capture());
+		long scaleUpserts = upsertCap.getAllValues().stream()
+				.filter(u -> u.getPriority() != null
+						&& u.getPriority().getType() == io.mantisrx.server.master.resourcecluster.proto.MantisResourceClusterReservationProto.ReservationPriority.PriorityType.SCALE)
+				.count();
+		assertEquals("no SCALE upsert should be sent when every storeNewWorker rolls back",
+				0L, scaleUpserts);
+	}
+
+	@Test
+	public void scaleUpStageWithStoreNewWorkerFailureOnNthIteration_legacyShrinksToRealizedCount() throws Exception {
+		setupLegacyConfig();
+		final TestKit probe = new TestKit(system);
+		Map<ScalingReason, Strategy> smap = new HashMap<>();
+		smap.put(ScalingReason.CPU, new Strategy(ScalingReason.CPU, 0.5, 0.75, null));
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerScalableStageWithConstraints(1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList(),
+						new StageScalingPolicy(1, 0, 10, 1, 1, 0, smap, true))
+				.build();
+		String clusterName = "scaleUpStoreFailureRollbackLegacy";
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		when(schedulerMock.schedulerHandlesAllocationRetries()).thenReturn(false);
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+		doThrow(new IOException("induced storeNewWorker failure"))
+				.doNothing()
+				.doNothing()
+				.when(jobStoreMock).storeNewWorker(any());
+
+		ActorRef jobActor = JobTestHelper.submitSingleStageScalableJob(
+				system, probe, clusterName, sInfo, schedulerMock, jobStoreMock, lifecycleEventPublisher);
+
+		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 4, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		assertEquals(SUCCESS, scaleResp.responseCode);
+		assertEquals(3, scaleResp.getActualNumWorkers());
+		assertTrue(scaleResp.message.contains("requested 4"));
+		assertTrue(scaleResp.message.contains("1 add failures"));
+
+		verify(jobStoreMock, times(3)).storeNewWorker(any());
+		verify(schedulerMock, times(2)).scheduleWorkers(any());
+		verify(schedulerMock, never()).upsertReservation(any(UpsertReservation.class));
+
+		jobActor.tell(new JobClusterManagerProto.GetJobDetailsRequest("nj", JobId.fromId(clusterName + "-1").get()), probe.getRef());
+		JobClusterManagerProto.GetJobDetailsResponse detailsResp = probe.expectMsgClass(JobClusterManagerProto.GetJobDetailsResponse.class);
+		assertEquals(SUCCESS, detailsResp.responseCode);
+		assertStageHasDenseWorkerIndexes(detailsResp.getJobMetadata().get().getStageMetadata().get(1), 3);
+	}
+
+	@Test
+	public void scaleUpStageShrinkPersistenceFailurePreservesQueuedPartialResult() throws Exception {
+		setupReservationConfig();
+		final TestKit probe = new TestKit(system);
+		Map<ScalingReason, Strategy> smap = new HashMap<>();
+		smap.put(ScalingReason.CPU, new Strategy(ScalingReason.CPU, 0.5, 0.75, null));
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerScalableStageWithConstraints(1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList(),
+						new StageScalingPolicy(1, 0, 10, 1, 1, 0, smap, true))
+				.build();
+		String clusterName = "scaleUpShrinkPersistenceFailure";
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+		doNothing()
+				.doThrow(new IOException("induced storeNewWorker failure"))
+				.when(jobStoreMock).storeNewWorker(any());
+		doAnswer(invocation -> {
+			IMantisStageMetadata stage = (IMantisStageMetadata) invocation.getArguments()[0];
+			if (stage.getStageNum() == 1 && stage.getNumWorkers() == 3) {
+				throw new IOException("induced shrink updateStage failure");
+			}
+			return null;
+		}).when(jobStoreMock).updateStage(any());
+
+		ActorRef jobActor = JobTestHelper.submitSingleStageScalableJob(
+				system, probe, clusterName, sInfo, schedulerMock, jobStoreMock, lifecycleEventPublisher);
+
+		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 4, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		assertEquals(SERVER_ERROR, scaleResp.responseCode);
+		assertEquals(2, scaleResp.getActualNumWorkers());
+		assertTrue(scaleResp.message.contains("queued workers were kept"));
+		assertTrue(scaleResp.message.contains("requested 4"));
+		assertTrue(scaleResp.message.contains("failed to persist the adjusted stage target"));
+
+		verify(jobStoreMock, times(2)).storeNewWorker(any());
+
+		ArgumentCaptor<UpsertReservation> upsertCap = ArgumentCaptor.forClass(UpsertReservation.class);
+		verify(schedulerMock, atLeast(1)).upsertReservation(upsertCap.capture());
+		UpsertReservation scaleUpsert = lastUpsertOfType(
+				upsertCap.getAllValues(),
+				io.mantisrx.server.master.resourcecluster.proto.MantisResourceClusterReservationProto.ReservationPriority.PriorityType.SCALE);
+		assertEquals("the already-persisted worker must still be queued",
+				1, scaleUpsert.getAllocationRequests().size());
+	}
+
+	private static UpsertReservation lastUpsertOfType(
+			List<UpsertReservation> upserts,
+			io.mantisrx.server.master.resourcecluster.proto.MantisResourceClusterReservationProto.ReservationPriority.PriorityType priorityType) {
+		UpsertReservation last = null;
+		for (UpsertReservation u : upserts) {
+			if (u.getPriority() != null && u.getPriority().getType() == priorityType) {
+				last = u;
+			}
+		}
+		if (last == null) {
+			fail("no upsertReservation captured with priority type " + priorityType);
+		}
+		return last;
+	}
+
+	private static void assertStageHasDenseWorkerIndexes(IMantisStageMetadata stage, int expectedNumWorkers) throws InvalidJobException {
+		assertEquals("stage target size should match realized worker count", expectedNumWorkers, stage.getNumWorkers());
+		assertEquals("worker metadata count should match realized worker count", expectedNumWorkers, stage.getAllWorkers().size());
+		for (int workerIndex = 0; workerIndex < expectedNumWorkers; workerIndex++) {
+			assertEquals(workerIndex, stage.getWorkerByIndex(workerIndex).getMetadata().getWorkerIndex());
+		}
+		assertMissingWorkerIndex(stage, expectedNumWorkers);
+	}
+
+	private static void assertMissingWorkerIndex(IMantisStageMetadata stage, int workerIndex) {
+		try {
+			stage.getWorkerByIndex(workerIndex);
+			fail("expected worker index " + workerIndex + " to be absent");
+		} catch (InvalidJobException expected) {
+			// Expected: dense index set stops before workerIndex.
+		}
+	}
+
+	/**
+	 * Regression guard: when every storeNewWorker call succeeds, the post-fix behavior must
+	 * match the legacy expectation set by {@link #testJobScaleUpReservation()} — same
+	 * storeNewWorker call count, same worker count after scale, same upsertReservation count.
+	 */
+	@Test
+	public void scaleUpStageWithAllStoreNewWorkerSuccesses_unchangedBehavior() throws Exception {
+		setupReservationConfig();
+		final TestKit probe = new TestKit(system);
+		Map<ScalingReason, Strategy> smap = new HashMap<>();
+		smap.put(ScalingReason.CPU, new Strategy(ScalingReason.CPU, 0.5, 0.75, null));
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerScalableStageWithConstraints(1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList(),
+						new StageScalingPolicy(1, 0, 10, 1, 1, 0, smap, true))
+				.build();
+		String clusterName = "scaleUpAllStoreSuccesses";
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+		ActorRef jobActor = JobTestHelper.submitSingleStageScalableJob(
+				system, probe, clusterName, sInfo, schedulerMock, jobStoreMock, lifecycleEventPublisher);
+
+		// Scale 1 -> 3 (delta=2): same as the existing reservation test
+		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 3, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		assertEquals(SUCCESS, scaleResp.responseCode);
+		assertEquals(3, scaleResp.getActualNumWorkers());
+
+		verify(jobStoreMock, times(2)).storeNewWorker(any());
+
+		jobActor.tell(new JobClusterManagerProto.GetJobDetailsRequest("nj", JobId.fromId(clusterName + "-1").get()), probe.getRef());
+		JobClusterManagerProto.GetJobDetailsResponse detailsResp = probe.expectMsgClass(JobClusterManagerProto.GetJobDetailsResponse.class);
+		assertEquals(SUCCESS, detailsResp.responseCode);
+		IMantisJobMetadata md = detailsResp.getJobMetadata().get();
+		IMantisStageMetadata stage1 = md.getStageMetadata().get(1);
+		assertEquals("all-success path should yield 3 workers in stage", 3, stage1.getAllWorkers().size());
+	}
+
 	@Test
 	public void stageScalingPolicyTest() {
 		int stageNo = 1;

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
@@ -41,15 +41,26 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
+import akka.actor.ActorIdentity;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
+import akka.actor.Identify;
 import akka.testkit.javadsl.TestKit;
 import com.netflix.mantis.master.scheduler.TestHelpers;
+import io.mantisrx.common.WorkerPorts;
 import io.mantisrx.master.events.AuditEventSubscriberLoggingImpl;
 import io.mantisrx.master.events.LifecycleEventPublisher;
 import io.mantisrx.master.events.LifecycleEventPublisherImpl;
 import io.mantisrx.master.events.StatusEventSubscriberLoggingImpl;
 import io.mantisrx.master.events.WorkerEventSubscriberLoggingImpl;
+import io.mantisrx.master.jobcluster.JobClusterActor;
+import io.mantisrx.master.jobcluster.job.worker.IMantisWorkerMetadata;
+import io.mantisrx.master.jobcluster.job.worker.JobWorker;
+import io.mantisrx.common.metrics.Counter;
+import io.mantisrx.common.metrics.Metrics;
+import io.mantisrx.common.metrics.MetricsRegistry;
+import io.mantisrx.common.metrics.spectator.MetricGroupId;
+import com.netflix.spectator.api.BasicTag;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.master.jobcluster.proto.JobClusterProto;
 import io.mantisrx.master.jobcluster.proto.JobProto;
@@ -71,6 +82,7 @@ import io.mantisrx.server.master.persistence.MantisJobStore;
 import io.mantisrx.server.master.persistence.exceptions.InvalidJobException;
 import io.mantisrx.server.master.resourcecluster.proto.MantisResourceClusterReservationProto.UpsertReservation;
 import io.mantisrx.server.master.scheduler.MantisScheduler;
+import io.mantisrx.server.master.scheduler.MantisSchedulerFactory;
 import io.mantisrx.shaded.com.fasterxml.jackson.core.JsonProcessingException;
 import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 import io.mantisrx.shaded.com.google.common.collect.Lists;
@@ -93,6 +105,13 @@ import rx.subjects.BehaviorSubject;
 
 public class JobScaleUpDownTests {
 
+	static {
+		// Wire a real Spectator registry before any JobActor is constructed so Counter.value()
+		// reflects increments instead of returning 0 from the default no-op composite registry.
+		io.mantisrx.common.metrics.spectator.SpectatorRegistryFactory.setRegistry(
+				new com.netflix.spectator.api.DefaultRegistry());
+	}
+
 	static ActorSystem system;
 	final LifecycleEventPublisher lifecycleEventPublisher = new LifecycleEventPublisherImpl(new AuditEventSubscriberLoggingImpl(), new StatusEventSubscriberLoggingImpl(), new WorkerEventSubscriberLoggingImpl());
 
@@ -100,7 +119,6 @@ public class JobScaleUpDownTests {
 	public static void setup() {
 		system = ActorSystem.create();
 		TestHelpers.setupMasterConfig();
-
 	}
 
 	@AfterClass
@@ -1057,13 +1075,19 @@ SchedulingChange [jobId=testSchedulingInfo-1, workerAssignments={
 		ActorRef jobActor = JobTestHelper.submitSingleStageScalableJob(
 				system, probe, clusterName, sInfo, schedulerMock, jobStoreMock, lifecycleEventPublisher);
 
+		long scaleCounterBefore = readNumScaleStage(clusterName + "-1");
 		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 4, "", ""), probe.getRef());
 		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
 		assertEquals(SERVER_ERROR, scaleResp.responseCode);
 		assertEquals(2, scaleResp.getActualNumWorkers());
-		assertTrue(scaleResp.message.contains("queued workers were kept"));
 		assertTrue(scaleResp.message.contains("requested 4"));
-		assertTrue(scaleResp.message.contains("failed to persist the adjusted stage target"));
+		assertTrue(scaleResp.message.contains("compensating shrink also failed"));
+		assertTrue(scaleResp.message.contains("shrink did not stick"));
+		assertTrue(scaleResp.message.contains("prior stage target 4 remains in force"));
+		assertTrue("response message must include the original add-failure cause",
+				scaleResp.message.contains("induced storeNewWorker failure"));
+		assertTrue("response message must include the shrink-failure summary",
+				scaleResp.message.contains("Failed to shrink stage"));
 
 		verify(jobStoreMock, times(2)).storeNewWorker(any());
 
@@ -1074,6 +1098,182 @@ SchedulingChange [jobId=testSchedulingInfo-1, workerAssignments={
 				io.mantisrx.server.master.resourcecluster.proto.MantisResourceClusterReservationProto.ReservationPriority.PriorityType.SCALE);
 		assertEquals("the already-persisted worker must still be queued",
 				1, scaleUpsert.getAllocationRequests().size());
+
+		jobActor.tell(new JobClusterManagerProto.GetJobDetailsRequest("nj", JobId.fromId(clusterName + "-1").get()), probe.getRef());
+		JobClusterManagerProto.GetJobDetailsResponse detailsResp = probe.expectMsgClass(JobClusterManagerProto.GetJobDetailsResponse.class);
+		assertEquals(SUCCESS, detailsResp.responseCode);
+		assertStageHasDenseWorkerIndexes(detailsResp.getJobMetadata().get().getStageMetadata().get(1), 4, 2);
+
+		assertEquals("partial-success scale must increment numScaleStage",
+				scaleCounterBefore + 1, readNumScaleStage(clusterName + "-1"));
+	}
+
+	@Test
+	public void scaleUpStageRollbackCorruptionFailsJobWithoutQueueingScaleReservation() throws Exception {
+		setupReservationConfig();
+		final TestKit probe = new TestKit(system);
+		Map<ScalingReason, Strategy> smap = new HashMap<>();
+		smap.put(ScalingReason.CPU, new Strategy(ScalingReason.CPU, 0.5, 0.75, null));
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerScalableStageWithConstraints(1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList(),
+						new StageScalingPolicy(1, 0, 10, 1, 1, 0, smap, true))
+				.build();
+		String clusterName = "scaleUpRollbackCorruption";
+		MantisSchedulerFactory schedulerMockFactory = mock(MantisSchedulerFactory.class);
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		when(schedulerMockFactory.forJob(any())).thenReturn(schedulerMock);
+		when(schedulerMockFactory.forClusterID(any())).thenReturn(schedulerMock);
+		List<UpsertReservation> upserts = new CopyOnWriteArrayList<>();
+		doAnswer(invocation -> {
+			UpsertReservation request = (UpsertReservation) invocation.getArguments()[0];
+			upserts.add(request);
+			return java.util.concurrent.CompletableFuture.completedFuture(io.mantisrx.common.Ack.getInstance());
+		}).when(schedulerMock).upsertReservation(any());
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+		final java.util.concurrent.atomic.AtomicReference<MantisStageMetadataImpl> stageRef =
+				new java.util.concurrent.atomic.AtomicReference<>();
+		final java.util.concurrent.atomic.AtomicInteger storeCallCount = new java.util.concurrent.atomic.AtomicInteger();
+		doAnswer(invocation -> {
+			int call = storeCallCount.incrementAndGet();
+			if (call == 1) {
+				return null;
+			}
+			IMantisWorkerMetadata stored = (IMantisWorkerMetadata) invocation.getArguments()[0];
+			MantisStageMetadataImpl stage = stageRef.get();
+			assertTrue("stage reference must be captured before rollback corruption fires", stage != null);
+			corruptStageIndexEntry(stage, stored.getWorkerIndex(), duplicateWorker(stored));
+			throw new IOException("induced storeNewWorker failure");
+		}).when(jobStoreMock).storeNewWorker(any());
+
+		IJobClusterDefinition jobClusterDefn = JobTestHelper.generateJobClusterDefinition(clusterName, sInfo);
+		JobDefinition jobDefn = JobTestHelper.generateJobDefinition(clusterName, sInfo);
+		ActorRef jobClusterActor = system.actorOf(JobClusterActor.props(
+				clusterName,
+				jobStoreMock,
+				schedulerMockFactory,
+				lifecycleEventPublisher,
+				CostsCalculator.noop(),
+				0));
+		jobClusterActor.tell(new JobClusterProto.InitializeJobClusterRequest(
+				(io.mantisrx.server.master.domain.JobClusterDefinitionImpl) jobClusterDefn,
+				"user",
+				probe.getRef()), probe.getRef());
+		JobClusterProto.InitializeJobClusterResponse initResp =
+				probe.expectMsgClass(JobClusterProto.InitializeJobClusterResponse.class);
+		assertEquals(SUCCESS, initResp.responseCode);
+
+		String jobId = clusterName + "-1";
+		JobTestHelper.submitJobAndVerifySuccess(probe, clusterName, jobClusterActor, jobDefn, jobId);
+		JobTestHelper.getJobDetailsAndVerify(probe, jobClusterActor, jobId, SUCCESS, JobState.Accepted);
+		JobTestHelper.sendLaunchedInitiatedStartedEventsToWorker(
+				probe,
+				jobClusterActor,
+				jobId,
+				0,
+				new WorkerId(clusterName, jobId, 0, 1));
+		JobTestHelper.sendLaunchedInitiatedStartedEventsToWorker(
+				probe,
+				jobClusterActor,
+				jobId,
+				1,
+				new WorkerId(clusterName, jobId, 0, 2));
+		JobTestHelper.getJobDetailsAndVerify(probe, jobClusterActor, jobId, SUCCESS, JobState.Launched);
+
+		ActorRef jobActor = resolveJobActor(probe, jobClusterActor, jobId);
+		probe.watch(jobActor);
+
+		jobClusterActor.tell(new JobClusterManagerProto.GetJobDetailsRequest("nj", JobId.fromId(jobId).get()), probe.getRef());
+		JobClusterManagerProto.GetJobDetailsResponse pre = probe.expectMsgClass(JobClusterManagerProto.GetJobDetailsResponse.class);
+		stageRef.set((MantisStageMetadataImpl) pre.getJobMetadata().get().getStageMetadata().get(1));
+
+		long scaleCounterBefore = readNumScaleStage(jobId);
+		long scaleUpsertsBefore = countUpsertsOfType(
+				upserts,
+				io.mantisrx.server.master.resourcecluster.proto.MantisResourceClusterReservationProto.ReservationPriority.PriorityType.SCALE);
+
+		jobClusterActor.tell(new JobClusterManagerProto.ScaleStageRequest(jobId, 1, 3, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		assertEquals(SERVER_ERROR, scaleResp.responseCode);
+		assertEquals(2, scaleResp.getActualNumWorkers());
+		assertTrue(scaleResp.message.contains("rollback of failed addition also threw"));
+		assertTrue("response message must include the original add-failure cause",
+				scaleResp.message.contains("induced storeNewWorker failure"));
+		assertTrue(scaleResp.message.contains("job will be failed"));
+
+		assertEquals("fatal rollback corruption must not queue SCALE reservations",
+				scaleUpsertsBefore,
+				countUpsertsOfType(
+						upserts,
+						io.mantisrx.server.master.resourcecluster.proto.MantisResourceClusterReservationProto.ReservationPriority.PriorityType.SCALE));
+		assertEquals("fatal rollback corruption must NOT increment numScaleStage",
+				scaleCounterBefore, readNumScaleStage(jobId));
+
+		probe.expectTerminated(jobActor);
+		verify(jobStoreMock, timeout(2000).times(1)).archiveJob(any());
+	}
+
+	/**
+	 * Item 1 negative case: when scaleStage fails *before* anything is durably stored
+	 * (the initial unsafeSetNumWorkers call throws), the scale produced no durable state
+	 * change and numScaleStage must NOT increment.
+	 */
+	@Test
+	public void scaleUpStageInitialTargetPersistFailureDoesNotIncrementScaleCounter() throws Exception {
+		setupReservationConfig();
+		final TestKit probe = new TestKit(system);
+		Map<ScalingReason, Strategy> smap = new HashMap<>();
+		smap.put(ScalingReason.CPU, new Strategy(ScalingReason.CPU, 0.5, 0.75, null));
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerScalableStageWithConstraints(1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList(),
+						new StageScalingPolicy(1, 0, 10, 1, 1, 0, smap, true))
+				.build();
+		String clusterName = "scaleUpTargetPersistFailure";
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+		ActorRef jobActor = JobTestHelper.submitSingleStageScalableJob(
+				system, probe, clusterName, sInfo, schedulerMock, jobStoreMock, lifecycleEventPublisher);
+
+		// Now arm updateStage to throw — the *initial* unsafeSetNumWorkers in scaleStage will fail
+		// before any worker is durably stored.
+		doThrow(new IOException("induced updateStage failure"))
+				.when(jobStoreMock).updateStage(any());
+
+		long scaleCounterBefore = readNumScaleStage(clusterName + "-1");
+
+		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 3, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		assertEquals(SERVER_ERROR, scaleResp.responseCode);
+
+		jobActor.tell(new JobClusterManagerProto.GetJobDetailsRequest("nj", JobId.fromId(clusterName + "-1").get()), probe.getRef());
+		JobClusterManagerProto.GetJobDetailsResponse detailsResp = probe.expectMsgClass(JobClusterManagerProto.GetJobDetailsResponse.class);
+		assertEquals(SUCCESS, detailsResp.responseCode);
+		assertStageHasDenseWorkerIndexes(detailsResp.getJobMetadata().get().getStageMetadata().get(1), 1);
+
+		assertEquals("scale that never durably stored anything must NOT increment numScaleStage",
+				scaleCounterBefore, readNumScaleStage(clusterName + "-1"));
+	}
+
+	private long readNumScaleStage(String jobId) {
+		// Look up the JobActor's metrics group from the global registry. We scan rather than
+		// build the exact MetricGroupId so the lookup is robust against tag-ordering or
+		// resourceCluster differences across test setups.
+		for (Metrics m : MetricsRegistry.getInstance().getMetrics("JobActor")) {
+			if (m.getMetricGroupId().id().contains("jobId=" + jobId)) {
+				Counter c = m.getCounter("numScaleStage");
+				return c == null ? 0L : c.value();
+			}
+		}
+		return 0L;
 	}
 
 	private static UpsertReservation lastUpsertOfType(
@@ -1092,12 +1292,60 @@ SchedulingChange [jobId=testSchedulingInfo-1, workerAssignments={
 	}
 
 	private static void assertStageHasDenseWorkerIndexes(IMantisStageMetadata stage, int expectedNumWorkers) throws InvalidJobException {
-		assertEquals("stage target size should match realized worker count", expectedNumWorkers, stage.getNumWorkers());
-		assertEquals("worker metadata count should match realized worker count", expectedNumWorkers, stage.getAllWorkers().size());
-		for (int workerIndex = 0; workerIndex < expectedNumWorkers; workerIndex++) {
+		assertStageHasDenseWorkerIndexes(stage, expectedNumWorkers, expectedNumWorkers);
+	}
+
+	private static void assertStageHasDenseWorkerIndexes(
+			IMantisStageMetadata stage,
+			int expectedTargetWorkers,
+			int expectedRealizedWorkers) throws InvalidJobException {
+		assertEquals("stage target size should match expected target", expectedTargetWorkers, stage.getNumWorkers());
+		assertEquals("worker metadata count should match realized worker count", expectedRealizedWorkers, stage.getAllWorkers().size());
+		for (int workerIndex = 0; workerIndex < expectedRealizedWorkers; workerIndex++) {
 			assertEquals(workerIndex, stage.getWorkerByIndex(workerIndex).getMetadata().getWorkerIndex());
 		}
-		assertMissingWorkerIndex(stage, expectedNumWorkers);
+		assertMissingWorkerIndex(stage, expectedRealizedWorkers);
+	}
+
+	private static ActorRef resolveJobActor(TestKit probe, ActorRef jobClusterActor, String jobId) {
+		system.actorSelection(jobClusterActor.path().child("JobActor-" + jobId))
+				.tell(new Identify(jobId), probe.getRef());
+		ActorIdentity identity = probe.expectMsgClass(ActorIdentity.class);
+		assertTrue("job actor must be resolvable for " + jobId, identity.getActorRef().isPresent());
+		return identity.getActorRef().get();
+	}
+
+	private static long countUpsertsOfType(
+			List<UpsertReservation> upserts,
+			io.mantisrx.server.master.resourcecluster.proto.MantisResourceClusterReservationProto.ReservationPriority.PriorityType priorityType) {
+		long count = 0;
+		for (UpsertReservation upsert : upserts) {
+			if (upsert.getPriority() != null && upsert.getPriority().getType() == priorityType) {
+				count++;
+			}
+		}
+		return count;
+	}
+
+	private static void corruptStageIndexEntry(MantisStageMetadataImpl stageMeta, int workerIndex, JobWorker worker)
+			throws Exception {
+		java.lang.reflect.Field idxField = MantisStageMetadataImpl.class.getDeclaredField("workerByIndexMetadataSet");
+		idxField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		Map<Integer, JobWorker> idxMap = (Map<Integer, JobWorker>) idxField.get(stageMeta);
+		idxMap.put(workerIndex, worker);
+	}
+
+	private JobWorker duplicateWorker(IMantisWorkerMetadata stored) {
+		return new JobWorker.Builder()
+				.withJobId(stored.getJobId())
+				.withWorkerIndex(stored.getWorkerIndex())
+				.withWorkerNumber(stored.getWorkerNumber())
+				.withNumberOfPorts(1 + io.mantisrx.master.jobcluster.job.worker.MantisWorkerMetadataImpl.MANTIS_SYSTEM_ALLOCATED_NUM_PORTS)
+				.withWorkerPorts(new WorkerPorts(Lists.newArrayList(9091, 9092, 9093, 9094, 9095)))
+				.withStageNum(stored.getStageNum())
+				.withLifecycleEventsPublisher(lifecycleEventPublisher)
+				.build();
 	}
 
 	private static void assertMissingWorkerIndex(IMantisStageMetadata stage, int workerIndex) {

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobTestLifecycle.java
@@ -471,17 +471,17 @@ public class JobTestLifecycle {
                     .build();
             final ActorRef jobActor = system.actorOf(JobActor.props(jobClusterDefn, mantisJobMetaData, jobStoreMock, schedulerMock, eventPublisher, costsCalculator));
 
+            probe.watch(jobActor);
 			jobActor.tell(new JobProto.InitJob(probe.getRef()), probe.getRef());
 			JobProto.JobInitialized initMsg = probe.expectMsgClass(JobProto.JobInitialized.class);
 			assertEquals(SERVER_ERROR, initMsg.responseCode);
 			System.out.println(initMsg.message);
 
-			String jobId = clusterName + "-1";
-			jobActor.tell(new JobClusterManagerProto.GetJobDetailsRequest("nj", jobId), probe.getRef());
-			//jobActor.tell(new JobProto.InitJob(probe.getRef()), probe.getRef());
-			GetJobDetailsResponse resp = probe.expectMsgClass(GetJobDetailsResponse.class);
-			System.out.println("resp " + resp + " msg " + resp.message);
-			assertEquals(CLIENT_ERROR, resp.responseCode);
+			// Submit-time init failure leaves the in-memory job metadata in a dirty state
+			// (setupStageWorkers may have mutated the stage maps before storeNewJob threw),
+			// so the actor stops itself to prevent any subsequent message from observing
+			// that dirty snapshot. Verify it terminates.
+			probe.expectTerminated(jobActor);
 		} catch (InvalidJobException  e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/PendingWorkerAdditionTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/PendingWorkerAdditionTest.java
@@ -167,7 +167,7 @@ public class PendingWorkerAdditionTest {
         corruptStageIndexEntry(
                 stageMeta,
                 NEW_WORKER_INDEX,
-                makeWorker(jobMetaData.getJobId(), NEW_WORKER_INDEX, EXISTING_WORKER_NUMBER));
+                makeWorker(jobMetaData.getJobId(), NEW_WORKER_INDEX, NEW_WORKER_NUMBER));
 
         try {
             pending.rollback();
@@ -177,8 +177,14 @@ public class PendingWorkerAdditionTest {
             assertTrue(expected.getMessage().contains("stage " + STAGE_NUM));
         }
 
-        assertTrue("failed rollback must leave the job-level worker mapping untouched",
-                jobMetaData.getWorkerNumberToStageMap().containsKey(NEW_WORKER_NUMBER));
+        assertEquals("failed rollback must leave the pending worker in the stage index map",
+                NEW_WORKER_NUMBER,
+                stageMeta.getWorkerByIndex(NEW_WORKER_INDEX).getMetadata().getWorkerNumber());
+        assertTrue("failed rollback must leave the pending worker in stage worker metadata",
+                stageContainsWorker(NEW_WORKER_NUMBER));
+        assertEquals("failed rollback must leave the job-level worker mapping untouched",
+                Integer.valueOf(STAGE_NUM),
+                jobMetaData.getWorkerNumberToStageMap().get(NEW_WORKER_NUMBER));
         assertEquals("failed rollback must not restore costs",
                 postAdditionCosts, jobMetaData.getJobCosts());
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/PendingWorkerAdditionTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/PendingWorkerAdditionTest.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.jobcluster.job;
+
+import static io.mantisrx.master.jobcluster.job.worker.MantisWorkerMetadataImpl.MANTIS_SYSTEM_ALLOCATED_NUM_PORTS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import io.mantisrx.common.WorkerPorts;
+import io.mantisrx.master.events.AuditEventSubscriberLoggingImpl;
+import io.mantisrx.master.events.LifecycleEventPublisher;
+import io.mantisrx.master.events.LifecycleEventPublisherImpl;
+import io.mantisrx.master.events.StatusEventSubscriberLoggingImpl;
+import io.mantisrx.master.events.WorkerEventSubscriberLoggingImpl;
+import io.mantisrx.master.jobcluster.job.worker.JobWorker;
+import io.mantisrx.runtime.MachineDefinition;
+import io.mantisrx.runtime.descriptor.SchedulingInfo;
+import io.mantisrx.runtime.descriptor.StageSchedulingInfo;
+import io.mantisrx.server.master.domain.Costs;
+import io.mantisrx.server.master.domain.JobDefinition;
+import io.mantisrx.server.master.domain.JobId;
+import io.mantisrx.shaded.com.google.common.collect.ImmutableList;
+import io.mantisrx.shaded.com.google.common.collect.Lists;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentMap;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link PendingWorkerAddition}'s rollback / commit semantics.
+ *
+ * <p>These tests construct a real {@link MantisJobMetadataImpl} with one stage and one
+ * pre-existing worker, simulate the in-memory mutations that {@code prepareWorker} would
+ * have applied, wrap them in a {@code PendingWorkerAddition}, then assert that
+ * {@link PendingWorkerAddition#rollback()} fully reverts those mutations and that
+ * {@link PendingWorkerAddition#commit()} disables further rollback.
+ */
+public class PendingWorkerAdditionTest {
+
+    private static final String CLUSTER = "PendingWorkerAdditionTestCluster";
+    private static final int STAGE_NUM = 1;
+    private static final int EXISTING_WORKER_INDEX = 0;
+    private static final int EXISTING_WORKER_NUMBER = 1;
+    private static final int NEW_WORKER_INDEX = 1;
+    private static final int NEW_WORKER_NUMBER = 2;
+
+    private LifecycleEventPublisher eventPublisher;
+    private MantisJobMetadataImpl jobMetaData;
+    private Costs preAdditionCosts;
+
+    @Before
+    public void setUp() throws Exception {
+        eventPublisher = new LifecycleEventPublisherImpl(
+                new AuditEventSubscriberLoggingImpl(),
+                new StatusEventSubscriberLoggingImpl(),
+                new WorkerEventSubscriberLoggingImpl());
+
+        JobDefinition jobDefn = JobTestHelper.generateJobDefinition(CLUSTER, makeSchedulingInfo());
+        JobId jobId = new JobId(CLUSTER, 1);
+        jobMetaData = new MantisJobMetadataImpl.Builder()
+                .withJobId(jobId)
+                .withSubmittedAt(Instant.now())
+                .withJobState(io.mantisrx.master.jobcluster.job.JobState.Accepted)
+                .withNextWorkerNumToUse(EXISTING_WORKER_NUMBER + 1)
+                .withJobDefinition(jobDefn)
+                .build();
+
+        // Add the stage and a pre-existing worker so we have a meaningful baseline state to compare against.
+        StageSchedulingInfo stage = jobDefn.getSchedulingInfo().getStages().get(STAGE_NUM);
+        IMantisStageMetadata stageMeta = new MantisStageMetadataImpl.Builder()
+                .withJobId(jobId)
+                .withStageNum(STAGE_NUM)
+                .withNumStages(1)
+                .withMachineDefinition(stage.getMachineDefinition())
+                .withNumWorkers(stage.getNumberOfInstances())
+                .withHardConstraints(stage.getHardConstraints())
+                .withSoftConstraints(stage.getSoftConstraints())
+                .withScalingPolicy(stage.getScalingPolicy())
+                .isScalable(stage.getScalable())
+                .build();
+        jobMetaData.addJobStageIfAbsent(stageMeta);
+        jobMetaData.addWorkerMetadata(STAGE_NUM, makeWorker(jobId, EXISTING_WORKER_INDEX, EXISTING_WORKER_NUMBER));
+
+        // Snapshot baseline costs (set before the simulated pending addition).
+        preAdditionCosts = new Costs(42.0);
+        jobMetaData.setJobCosts(preAdditionCosts);
+    }
+
+    @Test
+    public void rollback_removesFromBothStageMaps_andRestoresCosts() {
+        PendingWorkerAddition pending = simulatePreparedAddition(new Costs(99.0));
+
+        assertTrue("new worker should be in stage maps after addition",
+                stageContainsWorker(NEW_WORKER_NUMBER));
+        assertEquals("workerNumberToStageMap should map new worker number",
+                Integer.valueOf(STAGE_NUM),
+                jobMetaData.getWorkerNumberToStageMap().get(NEW_WORKER_NUMBER));
+        assertEquals(new Costs(99.0), jobMetaData.getJobCosts());
+        assertEquals("stage size should reflect both workers", 2, stageWorkerCount());
+
+        pending.rollback();
+
+        assertFalse("new worker must be absent from stage maps after rollback",
+                stageContainsWorker(NEW_WORKER_NUMBER));
+        assertFalse("workerNumberToStageMap must not contain the rolled-back worker number",
+                jobMetaData.getWorkerNumberToStageMap().containsKey(NEW_WORKER_NUMBER));
+        assertEquals("Costs must be restored to the pre-addition snapshot",
+                preAdditionCosts, jobMetaData.getJobCosts());
+        assertTrue("pre-existing worker must be untouched",
+                stageContainsWorker(EXISTING_WORKER_NUMBER));
+        assertEquals("stage size should be back to 1 after rollback", 1, stageWorkerCount());
+    }
+
+    @Test
+    public void rollback_isIdempotent() {
+        PendingWorkerAddition pending = simulatePreparedAddition(new Costs(99.0));
+        pending.rollback();
+        // Second rollback must be a no-op even if internal state would otherwise be inconsistent.
+        pending.rollback();
+        assertFalse(stageContainsWorker(NEW_WORKER_NUMBER));
+        assertEquals(preAdditionCosts, jobMetaData.getJobCosts());
+        assertEquals(1, stageWorkerCount());
+    }
+
+    @Test
+    public void commit_thenRollback_isNoop() {
+        Costs postAdditionCosts = new Costs(99.0);
+        PendingWorkerAddition pending = simulatePreparedAddition(postAdditionCosts);
+        pending.commit();
+        // After commit, rollback() must NOT undo anything: the worker stays in metadata,
+        // costs remain at the post-addition value (i.e. what storeNewWorker successfully durably stored).
+        pending.rollback();
+        assertTrue("committed worker must remain in stage maps after attempted rollback",
+                stageContainsWorker(NEW_WORKER_NUMBER));
+        assertEquals("workerNumberToStageMap must still map committed worker",
+                Integer.valueOf(STAGE_NUM),
+                jobMetaData.getWorkerNumberToStageMap().get(NEW_WORKER_NUMBER));
+        assertEquals("post-addition costs must be preserved after commit",
+                postAdditionCosts, jobMetaData.getJobCosts());
+        assertEquals(2, stageWorkerCount());
+    }
+
+    @Test
+    public void rollback_corruptionThrows_andDoesNotFinalizeWrapper() throws Exception {
+        Costs postAdditionCosts = new Costs(99.0);
+        PendingWorkerAddition pending = simulatePreparedAddition(postAdditionCosts);
+        MantisStageMetadataImpl stageMeta =
+                (MantisStageMetadataImpl) jobMetaData.getStageMetadata(STAGE_NUM).get();
+
+        corruptStageIndexEntry(
+                stageMeta,
+                NEW_WORKER_INDEX,
+                makeWorker(jobMetaData.getJobId(), NEW_WORKER_INDEX, EXISTING_WORKER_NUMBER));
+
+        try {
+            pending.rollback();
+            fail("expected rollback corruption to throw");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains(jobMetaData.getJobId().getId()));
+            assertTrue(expected.getMessage().contains("stage " + STAGE_NUM));
+        }
+
+        assertTrue("failed rollback must leave the job-level worker mapping untouched",
+                jobMetaData.getWorkerNumberToStageMap().containsKey(NEW_WORKER_NUMBER));
+        assertEquals("failed rollback must not restore costs",
+                postAdditionCosts, jobMetaData.getJobCosts());
+
+        try {
+            pending.rollback();
+            fail("expected second rollback attempt to retry and throw again");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains(jobMetaData.getJobId().getId()));
+        }
+    }
+
+    private boolean stageContainsWorker(int workerNumber) {
+        return jobMetaData.getStageMetadata(STAGE_NUM).get().getAllWorkers().stream()
+                .anyMatch(w -> w.getMetadata().getWorkerNumber() == workerNumber);
+    }
+
+    private int stageWorkerCount() {
+        return jobMetaData.getStageMetadata(STAGE_NUM).get().getAllWorkers().size();
+    }
+
+    private void corruptStageIndexEntry(MantisStageMetadataImpl stageMeta, int workerIndex, JobWorker worker)
+            throws Exception {
+        stageIndexMap(stageMeta).put(workerIndex, worker);
+    }
+
+    /**
+     * Mimics what {@code JobActor.prepareWorker} does: snapshots the current Costs,
+     * adds a new worker to the stage, sets a new (post-addition) Costs, and returns the wrapper.
+     */
+    private PendingWorkerAddition simulatePreparedAddition(Costs postAdditionCosts) {
+        Costs previousJobCosts = jobMetaData.getJobCosts();
+
+        JobWorker newWorker = makeWorker(jobMetaData.getJobId(), NEW_WORKER_INDEX, NEW_WORKER_NUMBER);
+        assertTrue("addWorkerMetadata must succeed in test fixture",
+                jobMetaData.addWorkerMetadata(STAGE_NUM, newWorker));
+        jobMetaData.setJobCosts(postAdditionCosts);
+
+        return new PendingWorkerAddition(
+                jobMetaData,
+                STAGE_NUM,
+                NEW_WORKER_INDEX,
+                NEW_WORKER_NUMBER,
+                newWorker.getMetadata(),
+                previousJobCosts);
+    }
+
+    private JobWorker makeWorker(JobId jobId, int workerIndex, int workerNumber) {
+        return new JobWorker.Builder()
+                .withJobId(jobId)
+                .withWorkerIndex(workerIndex)
+                .withWorkerNumber(workerNumber)
+                .withNumberOfPorts(1 + MANTIS_SYSTEM_ALLOCATED_NUM_PORTS)
+                .withWorkerPorts(new WorkerPorts(ImmutableList.of(9091, 9092, 9093, 9094, 9095)))
+                .withStageNum(STAGE_NUM)
+                .withLifecycleEventsPublisher(eventPublisher)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private ConcurrentMap<Integer, JobWorker> stageIndexMap(MantisStageMetadataImpl stageMeta)
+            throws Exception {
+        Field field = MantisStageMetadataImpl.class.getDeclaredField("workerByIndexMetadataSet");
+        field.setAccessible(true);
+        return (ConcurrentMap<Integer, JobWorker>) field.get(stageMeta);
+    }
+
+    private static SchedulingInfo makeSchedulingInfo() {
+        return new SchedulingInfo.Builder()
+                .numberOfStages(1)
+                .multiWorkerStageWithConstraints(
+                        1,
+                        new MachineDefinition(1.0, 1.0, 1.0, 3),
+                        Lists.newArrayList(),
+                        Lists.newArrayList())
+                .build();
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/worker/JobWorkerTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/worker/JobWorkerTest.java
@@ -36,8 +36,11 @@ public class JobWorkerTest {
 
     @BeforeClass
     public static void setup() {
-        registry = new DefaultRegistry();
-        SpectatorRegistryFactory.setRegistry(registry);
+        // SpectatorRegistryFactory.setRegistry uses a one-shot CAS — whichever test class
+        // loads first wins. Install a DefaultRegistry if no one has yet, then read back the
+        // actually-installed registry so we query the same one JobWorker writes to.
+        SpectatorRegistryFactory.setRegistry(new DefaultRegistry());
+        registry = SpectatorRegistryFactory.getRegistry();
     }
 
     @Test


### PR DESCRIPTION
# Make scale-up worker additions transactional

  ## Summary

  `JobActor.scaleStage` previously allowed in-memory job metadata to drift from
  durable storage on `MantisJobStore.storeNewWorker` failures: the new `JobWorker`
   was added to the stage's index/number maps but no record reached the store,
  leaving sparse worker indexes that broke subsequent scale-down, heartbeat
  resubmits, and index-based lookups.

  This PR makes each scale-up addition transactional via a two-phase
  prepare/commit/rollback flow. Failed adds are reverted in-memory, the stage
  target is shrunk by one, and the loop continues with the failed slot reused —
  keeping indexes dense. Partial scales are visible to the caller through a richer
   response and a new metric.

  ## Changes

  **Core (`JobActor`, `MantisJobMetadataImpl`, `MantisStageMetadataImpl`)**
  - New `PendingWorkerAddition` wraps the in-memory mutation done by
  `prepareWorker`. Caller commits after a successful `storeNewWorker` or rolls
  back on failure.
  - `IWorkerManager.scaleStage` now returns `ScaleStageResult` (actual / requested
   / failedAdditions) instead of a bare int. Response messages distinguish full
  success from partial: `"Partially scaled stage 1 to 3 workers (requested 4; 1
  add failures)"`.
  - New rollback primitives `MantisJobMetadataImpl.unsafeRemoveWorkerMetadata` and
   `MantisStageMetadataImpl.removeWorkerIndex` use a check-first-then-CAS pattern
  (`remove(K, V)`) and fully revert if the second remove fails.
  - `MantisStageMetadataImpl.unsafeSetNumWorkers` reverts `this.numWorkers` if
  `updateStage` throws, keeping in-memory and durable counts coherent.
  - `JobActor.onJobInitialize` stops the actor on submit-time init failure
  (`isSubmit=true` only, to preserve init-retry semantics for store reloads).

  **Failure-mode escalation**
  - *Shrink-failure after partial success:* throw
  `PartialScaleStageFailureException` carrying the realized partial count; queued
  workers are flushed first; caller gets `SERVER_ERROR` with `actualNumWorkers` =
  realized count. Original add-failure preserved as cause; shrink failure attached
   as suppressed.
  - *Rollback corruption (stage maps inconsistent):* fatal — sends
  `JobClusterProto.KillJobRequest` to the parent so the job is failed and
  archived. Workers stored before the corruption are cleaned up via the job
  archive lifecycle.

  **Metrics**
  - New `numWorkerStoreFailures` counter increments per rollback-and-shrink.
  - `numScaleStage` now also increments on partial-success scales (still skipped
  on plain failures that durably stored nothing).

  **Misc**
  - `mantis.worker.resubmission.interval.secs` default lengthened from `5:10:20` →
   `5:10:30:60:120:600`. (Tangential — flag for split if reviewers prefer.)

