### PR TITLE
Make oss mantis java8 compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,9 +132,6 @@ subprojects {
 
     group = 'io.mantisrx'
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-
     if (project.hasProperty('useMavenLocal')) {
         repositories {
             mavenLocal()

--- a/mantis-common-serde/build.gradle
+++ b/mantis-common-serde/build.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+tasks.withType(JavaCompile).configureEach {
+    options.release = 8
+}
+
 dependencies {
     api libraries.mantisShaded
 }

--- a/mantis-discovery-proto/build.gradle
+++ b/mantis-discovery-proto/build.gradle
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+tasks.withType(JavaCompile).configureEach {
+    options.release = 8
+}
+
 dependencies {
     api libraries.mantisShaded
 

--- a/mantis-publish/mantis-publish-core/build.gradle
+++ b/mantis-publish/mantis-publish-core/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     testImplementation libraries.spectatorApi
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.release = 8
+}
+
 test {
     useJUnitPlatform()
 }

--- a/mantis-publish/mantis-publish-netty-guice/build.gradle
+++ b/mantis-publish/mantis-publish-netty-guice/build.gradle
@@ -41,6 +41,10 @@ test {
     useJUnitPlatform()
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.release = 8
+}
+
 tasks.withType(Test) {
     jvmArgs += [
         '--add-opens', 'java.base/java.lang=ALL-UNNAMED',

--- a/mantis-publish/mantis-publish-netty/build.gradle
+++ b/mantis-publish/mantis-publish-netty/build.gradle
@@ -35,6 +35,10 @@ dependencies {
     testImplementation libraries.spectatorExtIpc
 }
 
+tasks.withType(JavaCompile).configureEach {
+    options.release = 8
+}
+
 test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
### Context

Using Java 17 toolchain to compile, but with --release 8 to produce Java 8 compatible bytecode.
mantis publish library depends on the publish-core, and we do not wanna publish library to be stick with java17 for compatibility concerns

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
