### PR TITLE
Add log to indicate the source job cluster is absent

### DIFF
--- a/mantis-client/src/main/java/io/mantisrx/client/MantisSSEJob.java
+++ b/mantis-client/src/main/java/io/mantisrx/client/MantisSSEJob.java
@@ -104,16 +104,17 @@ public class MantisSSEJob implements Closeable {
                     .take(1)
                     .toBlocking()
                     .first();
-            resultsObservable = exists ?
-                    sinksToObservable(builder.mantisClient.getSinkClientByJobName(
-                            builder.name,
-                            new SseSinkConnectionFunction(true, builder.onConnectionReset, builder.sinkParameters),
-                            builder.sinkConnectionsStatusObserver, builder.dataRecvTimeoutSecs)
-                    )
-                            .share()
-                    //.lift(new DropOperator<Observable<MantisServerSentEvent>>("client_connect_sse_share"))
-                    :
-                    Observable.just(Observable.just(new MantisServerSentEvent("No such job name " + builder.name)));
+            if (exists) {
+                resultsObservable = sinksToObservable(builder.mantisClient.getSinkClientByJobName(
+                        builder.name,
+                        new SseSinkConnectionFunction(true, builder.onConnectionReset, builder.sinkParameters),
+                        builder.sinkConnectionsStatusObserver, builder.dataRecvTimeoutSecs)
+                )
+                        .share();
+            } else {
+                logger.error("No such job cluster: {}", builder.name);
+                resultsObservable = Observable.just(Observable.just(new MantisServerSentEvent("No such job cluster: " + builder.name)));
+            }
         }
         return resultsObservable;
     }


### PR DESCRIPTION
### Context

- when source job cluster is absent, we simply returns a dummy SSE event without logging
- the downstream job would restart once dummy source job observable completes
- the job get stuck at restart loop if a stale source exists and job cluster is removed

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
