### PR TITLE
Fix incorrect number of source job types in docs

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,0 +1,77 @@
+# Requirements Document
+
+## 1. Introduction
+Mantis is a distributed stream processing platform designed to build, deploy, and operate real-time data processing applications.
+
+The platform enables continuous data processing and scalable execution of jobs.
+
+---
+
+## 2. Project Objective
+
+- Process streaming data in real time
+- Provide scalable execution
+- Simplify deployment and management of jobs
+
+---
+
+## 3. Functional Requirements
+
+### Job Execution
+- Execute distributed jobs
+- Support continuous processing
+
+### Runtime Management
+- Manage job lifecycle
+- Support scheduling and execution
+
+### Communication
+- Support communication across workers and services
+
+### Deployment
+- Support local and container deployment
+
+---
+
+## 4. Non Functional Requirements
+
+### Performance
+- Low latency processing
+
+### Scalability
+- Horizontal scaling
+
+### Reliability
+- Fault tolerant execution
+
+### Maintainability
+- Modular architecture
+
+---
+
+## 5. Architecture Overview
+
+Core modules:
+
+- mantis-runtime
+- mantis-common
+- mantis-control-plane-server
+- mantis-control-plane-client
+- mantis-server-worker
+- mantis-server-agent
+- mantis-client
+
+---
+
+## 6. Development Requirements
+
+### Environment
+
+- Java 17
+- Gradle
+- Docker
+
+### Build
+
+```bash
+./gradlew clean build

--- a/docs/docs/internals/source-jobs.md
+++ b/docs/docs/internals/source-jobs.md
@@ -1,6 +1,5 @@
-Mantis Source Jobs are [Mantis Jobs] that fetch data from external sources. There are four types of
+Mantis Source Jobs are [Mantis Jobs] that fetch data from external sources. There are two types of
 Source Jobs:
-
 1. **Mantis Publish Source Jobs**
    read from their sources by using the [Mantis Publish](../../developing/mre) client library. As such, they do not apply [MQL](../../developing/mql) on events
    themselves. Instead, they propagate the MQL queries upstream to Mantis Publish running on the external


### PR DESCRIPTION
The documentation stated there are four types of Source Jobs, but only two are currently documented on the page.

Updated the text to reflect the documented behavior.