### PR TITLE
Fix test failure for ResourceClusterActorTest

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/ResourceClusterActorTest.java
@@ -957,7 +957,7 @@ public class ResourceClusterActorTest {
 
     @Test
     public void testTaskExecutorIsDisabledEvenAfterRestart() throws Exception {
-        when(mantisJobStore.getTaskExecutor(TASK_EXECUTOR_ID)).thenReturn(TASK_EXECUTOR_REGISTRATION);
+        doReturn(TASK_EXECUTOR_REGISTRATION).when(mantisJobStore).getTaskExecutor(TASK_EXECUTOR_ID);
         doReturn(ImmutableList.of()).when(mantisJobStore).getJobArtifactsToCache(CLUSTER_ID);
 
         resourceCluster.registerTaskExecutor(TASK_EXECUTOR_REGISTRATION);


### PR DESCRIPTION
### Context

 It's a classic Mockito multi-threading race condition. The actor starts in @Before and runs background threads. When the test calls when(mantisJobStore.getTaskExecutor(...)) at line 960, Mockito records that invocation — but a background actor thread can call loadAllDisableTaskExecutorsRequests on the mock between Mockito's "record call" and the .thenReturn(...), causing the return value to be associated with the wrong method.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
