### PR TITLE
Add Builder.from() copy constructor to MantisJobClusterMetadataView

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/MantisJobClusterMetadataView.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/MantisJobClusterMetadataView.java
@@ -191,6 +191,24 @@ public class MantisJobClusterMetadataView {
 
         }
 
+        public static Builder from(MantisJobClusterMetadataView view) {
+            Builder builder = new Builder();
+            builder.name = view.getName();
+            builder.jars = view.getJars();
+            builder.sla = view.getSla();
+            builder.parameters = view.getParameters();
+            builder.owner = view.getOwner();
+            builder.lastJobCount = view.getLastJobCount();
+            builder.disabled = view.isDisabled();
+            builder.isReadyForJobMaster = view.getIsReadyForJobMaster();
+            builder.migrationConfig = view.getMigrationConfig();
+            builder.labels = view.getLabels();
+            builder.cronActive = view.isCronActive();
+            builder.latestVersion = view.getLatestVersion();
+            builder.jobPrincipal = view.getJobPrincipal();
+            return builder;
+        }
+
         public Builder withName(String name) {
             this.name = name;
             return this;

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
@@ -25,6 +25,7 @@ import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.ServerBinding;
+import akka.pattern.PatternsCS;
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.HttpEntities;
 import akka.http.javadsl.model.HttpRequest;
@@ -130,9 +131,11 @@ public class JobsRouteTest extends RouteTestBase {
                 MantisSchedulerFactory fakeSchedulerFactory = mock(MantisSchedulerFactory.class);
                 MantisScheduler fakeScheduler = new FakeMantisScheduler(jobClustersManagerActor);
                 when(fakeSchedulerFactory.forJob(any())).thenReturn(fakeScheduler);
-                jobClustersManagerActor.tell(new JobClusterManagerProto.JobClustersManagerInitialize(
-                        fakeSchedulerFactory,
-                        false), ActorRef.noSender());
+                PatternsCS.ask(
+                        jobClustersManagerActor,
+                        new JobClusterManagerProto.JobClustersManagerInitialize(fakeSchedulerFactory, false),
+                        Duration.ofSeconds(30))
+                    .toCompletableFuture().get();
 
                 final JobClusterRouteHandler jobClusterRouteHandler = new JobClusterRouteHandlerAkkaImpl(
                         jobClustersManagerActor);
@@ -224,6 +227,7 @@ public class JobsRouteTest extends RouteTestBase {
                         routeFlow,
                         ConnectHttp.toHost("localhost", SERVER_PORT),
                         materializer);
+                binding.toCompletableFuture().get();
                 latch.countDown();
             } catch (Exception e) {
                 logger.info("caught exception", e);


### PR DESCRIPTION
### Context

- Adds a static Builder.from(MantisJobClusterMetadataView) factory method to MantisJobClusterMetadataView.Builder that copies all fields from an existing instance
- Enables creating modified copies of an immutable MantisJobClusterMetadataView without repeating all field assignments

**WHY**
MantisJobClusterMetadataView is fully immutable with no setters. When overlaying a field (e.g. jobPrincipal from a global store) onto an existing instance returned from Akka, callers previously had to manually copy all constructor arguments. The from() factory method eliminates this boilerplate and makes the pattern future-proof if new fields are added to the class.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
