### PR TITLE
Return descriptive 409 for scaleStage on non-active jobs

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/job/JobActor.java
@@ -23,6 +23,7 @@ import static io.mantisrx.master.events.LifecycleEventsProto.StatusEvent.StatusE
 import static io.mantisrx.master.events.LifecycleEventsProto.StatusEvent.StatusEventType.WARN;
 import static io.mantisrx.master.jobcluster.job.worker.MantisWorkerMetadataImpl.MANTIS_SYSTEM_ALLOCATED_NUM_PORTS;
 import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.CLIENT_ERROR;
+import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.CLIENT_ERROR_CONFLICT;
 import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SERVER_ERROR;
 import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SUCCESS;
 import static java.lang.Math.max;
@@ -510,10 +511,8 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                 .match(JobClusterProto.KillJobRequest.class, (x) -> getSender().tell(new KillJobResponse(x.requestId,
                         SUCCESS, JobState.Noop, genUnexpectedMsg(x.toString(), this.jobId.getId(), state),
                         this.jobId, x.user), getSelf()))
-                // scale stage request
-                .match(ScaleStageRequest.class, (x) -> getSender().tell(new ScaleStageResponse(x.requestId,
-                        CLIENT_ERROR, genUnexpectedMsg(x.toString(), this.jobId.getId(), state),
-                        0), getSelf()))
+                // scale stage request — surface the job state (terminating) rather than a generic message.
+                .match(ScaleStageRequest.class, this::onScaleStageNonActive)
                 // scheduling Info observable
                 .match(GetJobSchedInfoRequest.class, (x) -> getSender().tell(
                         new GetJobSchedInfoResponse(x.requestId, CLIENT_ERROR,
@@ -719,10 +718,9 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
                 // runtime limit reached
                 .match(JobProto.RuntimeLimitReached.class, (x) -> LOGGER.warn(genUnexpectedMsg(
                         x.toString(), this.jobId.getId(), state)))
-                // scale stage request
-                .match(ScaleStageRequest.class, (x) -> getSender().tell(
-                        new ScaleStageResponse(x.requestId, CLIENT_ERROR, genUnexpectedMsg(
-                                x.toString(), this.jobId.getId(), state), 0), getSelf()))
+                // scale stage request — a job that is stuck (e.g. workers cannot start) stays in this
+                // non-active state, so surface a descriptive reason instead of a generic rejection.
+                .match(ScaleStageRequest.class, this::onScaleStageNonActive)
 
                 .match(InitJob.class, (x) -> getSender().tell(new JobInitialized(x.requestId, SUCCESS,
                         genUnexpectedMsg(x.toString(), this.jobId.getId(), state), this.jobId, x.requstor), getSelf()))
@@ -1242,6 +1240,26 @@ public class JobActor extends AbstractActorWithTimers implements IMantisJobManag
             LOGGER.error(msg, e);
             sender.tell(new ScaleStageResponse(scaleStage.requestId, SERVER_ERROR, msg, 0), getSelf());
         }
+    }
+
+    /**
+     * Handles a {@link ScaleStageRequest} that arrives while the job is not active (e.g. it is still
+     * in {@code Accepted} because its workers cannot start, or it is terminating). The job only becomes
+     * active once all workers have started, so a stuck job stays in a non-active behavior and previously
+     * received a generic "unexpected message" rejection here. This instead returns a 409 that names the
+     * job state so the operator can see why the scale did not take effect.
+     */
+    private void onScaleStageNonActive(ScaleStageRequest scaleStage) {
+        ActorRef sender = getSender();
+        JobState jobState = getJobState();
+        String msg = String.format(
+                "Cannot scale stage %d: job %s is in state %s and is not currently scalable",
+                scaleStage.getStageNum(), this.jobId, jobState);
+        LOGGER.warn(msg);
+        eventPublisher.publishStatusEvent(new LifecycleEventsProto.JobStatusEvent(
+                LifecycleEventsProto.StatusEvent.StatusEventType.WARN, msg, getJobId(), jobState));
+        sender.tell(new ScaleStageResponse(
+                scaleStage.requestId, CLIENT_ERROR_CONFLICT, msg, 0), getSelf());
     }
 
     /**

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/job/JobScaleUpDownTests.java
@@ -32,6 +32,7 @@
 
 package io.mantisrx.master.jobcluster.job;
 import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.CLIENT_ERROR;
+import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.CLIENT_ERROR_CONFLICT;
 import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SERVER_ERROR;
 import static io.mantisrx.master.jobcluster.proto.BaseResponse.ResponseCode.SUCCESS;
 import static org.junit.Assert.assertEquals;
@@ -239,6 +240,122 @@ public class JobScaleUpDownTests {
 		verify(schedulerMock, times(2)).scheduleWorkers(any());
 		verify(schedulerMock, never()).upsertReservation(any(UpsertReservation.class));
 
+	}
+
+	/**
+	 * A job that is not yet active (still in Accepted because its workers never started — the classic
+	 * "stuck job" caused by a runtime error such as a missing required parameter) lands in the
+	 * non-active behavior. A scaleStage request there should return a descriptive 409 that names the
+	 * job state and surfaces the worker-health reason, instead of the previous generic
+	 * "Unexpected message ... in initialized State" rejection.
+	 */
+	@Test
+	public void testScaleStageRejectedWhenJobStuckInAccepted() throws Exception {
+		setupLegacyConfig();
+		final TestKit probe = new TestKit(system);
+		Map<ScalingReason, Strategy> smap = new HashMap<>();
+		smap.put(ScalingReason.CPU, new Strategy(ScalingReason.CPU, 0.5, 0.75, null));
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerScalableStageWithConstraints(1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList(),
+						new StageScalingPolicy(1, 0, 10, 1, 1, 0, smap, true))
+				.build();
+		String clusterName = "testScaleStageRejectedWhenJobStuckInAccepted";
+		IJobClusterDefinition jobClusterDefn = JobTestHelper.generateJobClusterDefinition(clusterName, sInfo);
+		JobDefinition jobDefn = JobTestHelper.generateJobDefinition(clusterName, sInfo);
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+		MantisJobMetadataImpl mantisJobMetaData = new MantisJobMetadataImpl.Builder()
+				.withJobId(new JobId(clusterName, 1))
+				.withSubmittedAt(Instant.now())
+				.withJobState(JobState.Accepted)
+				.withNextWorkerNumToUse(1)
+				.withJobDefinition(jobDefn)
+				.build();
+		ActorRef jobActor = system.actorOf(JobActor.props(
+				jobClusterDefn,
+				mantisJobMetaData,
+				jobStoreMock,
+				schedulerMock,
+				lifecycleEventPublisher,
+				CostsCalculator.noop()));
+		// Submit-init the job, but never send worker started events: the job stays in Accepted and the
+		// actor remains in its non-active (initialized) behavior.
+		jobActor.tell(new JobProto.InitJob(probe.getRef(), true), probe.getRef());
+		JobProto.JobInitialized initMsg = probe.expectMsgClass(JobProto.JobInitialized.class);
+		assertEquals(SUCCESS, initMsg.responseCode);
+
+		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 3, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		System.out.println("ScaleupResp " + scaleResp.message);
+		assertEquals(CLIENT_ERROR_CONFLICT, scaleResp.responseCode);
+		assertEquals(0, scaleResp.getActualNumWorkers());
+		assertTrue("expected state-naming message but was: " + scaleResp.message,
+				scaleResp.message.contains("Accepted"));
+		assertFalse("should not be the old generic unexpected-message error: " + scaleResp.message,
+				scaleResp.message.contains("Unexpected message"));
+		verify(jobStoreMock, never()).storeNewWorker(any());
+	}
+
+	/**
+	 * A job that is terminating (still tracked by its actor, so the request reaches JobActor) must
+	 * not be scaled. Instead of durably storing workers that can never start, scaleStage returns a
+	 * descriptive 409 CLIENT_ERROR_CONFLICT naming the job state.
+	 */
+	@Test
+	public void testScaleStageRejectedWhenJobTerminating() throws Exception {
+		setupLegacyConfig();
+		final TestKit probe = new TestKit(system);
+		Map<ScalingReason, Strategy> smap = new HashMap<>();
+		smap.put(ScalingReason.CPU, new Strategy(ScalingReason.CPU, 0.5, 0.75, null));
+		SchedulingInfo sInfo = new SchedulingInfo.Builder()
+				.numberOfStages(1)
+				.multiWorkerScalableStageWithConstraints(1,
+						new MachineDefinition(1.0, 1.0, 1.0, 3),
+						Lists.newArrayList(),
+						Lists.newArrayList(),
+						new StageScalingPolicy(1, 0, 10, 1, 1, 0, smap, true))
+				.build();
+		String clusterName = "testScaleStageRejectedWhenJobTerminating";
+		IJobClusterDefinition jobClusterDefn = JobTestHelper.generateJobClusterDefinition(clusterName, sInfo);
+		JobDefinition jobDefn = JobTestHelper.generateJobDefinition(clusterName, sInfo);
+		MantisScheduler schedulerMock = JobTestHelper.createMockScheduler();
+		MantisJobStore jobStoreMock = mock(MantisJobStore.class);
+
+		// Construct the actor with the job already in a terminating state. A non-submit InitJob does
+		// not reset this state, so getJobState() reports Terminating_abnormal when scaleStage runs.
+		MantisJobMetadataImpl mantisJobMetaData = new MantisJobMetadataImpl.Builder()
+				.withJobId(new JobId(clusterName, 1))
+				.withSubmittedAt(Instant.now())
+				.withJobState(JobState.Terminating_abnormal)
+				.withNextWorkerNumToUse(1)
+				.withJobDefinition(jobDefn)
+				.build();
+		ActorRef jobActor = system.actorOf(JobActor.props(
+				jobClusterDefn,
+				mantisJobMetaData,
+				jobStoreMock,
+				schedulerMock,
+				lifecycleEventPublisher,
+				CostsCalculator.noop()));
+		// Non-submit init: do not re-store the job or set up workers, just bring up the actor with the
+		// existing (terminating) state so the request reaches the non-active behavior.
+		jobActor.tell(new JobProto.InitJob(probe.getRef(), false), probe.getRef());
+		JobProto.JobInitialized initMsg = probe.expectMsgClass(JobProto.JobInitialized.class);
+		assertEquals(SUCCESS, initMsg.responseCode);
+
+		jobActor.tell(new JobClusterManagerProto.ScaleStageRequest(clusterName + "-1", 1, 3, "", ""), probe.getRef());
+		JobClusterManagerProto.ScaleStageResponse scaleResp = probe.expectMsgClass(JobClusterManagerProto.ScaleStageResponse.class);
+		assertEquals(CLIENT_ERROR_CONFLICT, scaleResp.responseCode);
+		assertEquals(0, scaleResp.getActualNumWorkers());
+		assertTrue("expected state-naming message but was: " + scaleResp.message,
+				scaleResp.message.contains("Terminating_abnormal"));
+		// No new workers should have been durably stored for a terminating job.
+		verify(jobStoreMock, never()).storeNewWorker(any());
 	}
 
 	@Test


### PR DESCRIPTION
When a job is stuck (e.g. its workers cannot start due to a runtime error such as a missing required parameter) or still in init state, as in a non-active behavior. A scaleStage request in that state previously got a generic "Unexpected message ScaleStageRequest{...} received by Job actor <id> in <state> State" rejection, which gave operators no signal about the real problem and forced them to dig through logs to find the underlying cause.

Add onScaleStageNonActive, wired into the initialized and terminating behaviors, which returns a 409 CLIENT_ERROR_CONFLICT whose message names the job's current state, e.g. "Cannot scale stage 1: job <id> is in state Accepted and is not currently scalable". No workers are durably stored for a job that cannot be scaled.

Add JobScaleUpDownTests coverage for the stuck-in-Accepted and terminating cases.