### PR TITLE
Fix compile warnings in mantis-server-agent module

### DIFF
--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/Hardware.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/Hardware.java
@@ -60,7 +60,7 @@ public class Hardware {
      * Returns the total size of the disk. Assumes that it's a UNIX style filesystem. Will not work
      * in Windows.
      *
-     * @return
+     * @return total disk size in bytes
      */
     public static long getSizeOfDisk() {
         try {

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/MantisAgent.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/MantisAgent.java
@@ -28,12 +28,7 @@ public class MantisAgent implements Service {
     private CountDownLatch blockUntilShutdown = new CountDownLatch(1);
 
     public MantisAgent() {
-        Thread t = new Thread() {
-            @Override
-            public void run() {
-                shutdown();
-            }
-        };
+        Thread t = new Thread(this::shutdown);
         t.setDaemon(true);
         // shutdown hook
         Runtime.getRuntime().addShutdownHook(t);

--- a/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
+++ b/mantis-server/mantis-server-agent/src/main/java/io/mantisrx/server/agent/TaskExecutor.java
@@ -643,7 +643,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     }
 
     private static ListenerCallQueue.Event<Listener> getTaskStartingEvent(RuntimeTask task) {
-        return new ListenerCallQueue.Event<Listener>() {
+        return new ListenerCallQueue.Event<>() {
             @Override
             public void call(Listener listener) {
                 listener.onTaskStarting(task);
@@ -657,7 +657,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     }
 
     private static ListenerCallQueue.Event<Listener> getTaskCancellingEvent(RuntimeTask task) {
-        return new ListenerCallQueue.Event<Listener>() {
+        return new ListenerCallQueue.Event<>() {
             @Override
             public void call(Listener listener) {
                 listener.onTaskCancelling(task);
@@ -671,7 +671,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     }
 
     private static ListenerCallQueue.Event<Listener> getTaskFailedEvent(RuntimeTask task, Throwable throwable) {
-        return new ListenerCallQueue.Event<Listener>() {
+        return new ListenerCallQueue.Event<>() {
             @Override
             public void call(Listener listener) {
                 listener.onTaskFailed(task, throwable);
@@ -685,7 +685,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
     }
 
     private static ListenerCallQueue.Event<Listener> getTaskCancelledEvent(RuntimeTask task, @Nullable Throwable throwable) {
-        return new ListenerCallQueue.Event<Listener>() {
+        return new ListenerCallQueue.Event<>() {
             @Override
             public void call(Listener listener) {
                 listener.onTaskCancelled(task, throwable);


### PR DESCRIPTION
### Context

mantis-server-agent module update for removing warnings, refer issue #393.

Change set:
- `MantisAgent`: anonymous `Thread` subclass overriding only `run()` replaced with `new Thread(this::shutdown)`.
- `TaskExecutor`: anonymous `ListenerCallQueue.Event<Listener>` implementations now use the diamond operator instead of a redundant explicit type argument.
- `Hardware`: filled in an empty `@return` javadoc tag on `getSizeOfDisk()`.

No logic changes, no public interface changes.

### Checklist

- [x] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [x] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable