### PR TITLE
Rate limit the job submission request

### DIFF
--- a/mantis-common/src/main/java/io/mantisrx/config/dynamic/DynamicProperty.java
+++ b/mantis-common/src/main/java/io/mantisrx/config/dynamic/DynamicProperty.java
@@ -23,14 +23,37 @@ import java.time.Instant;
 import java.util.Objects;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * A property that re-reads itself from the {@link MantisPropertiesLoader} roughly once per refresh
+ * interval ({@code mantis.config.dynamic.refreshSecs}, default 30s), lazily on whichever thread
+ * calls {@link #getValue()}.
+ *
+ * <p>Safe to read from many threads, which matters because callers sit on request paths (see
+ * {@code GlobalApiRequestRateLimiter}): the cached state is published through volatile fields, so a
+ * reader never sees a stale or partially-visible value and the steady-state read is lock-free.
+ *
+ * <p>The refresh itself is deliberately unsynchronized, and volatile alone is enough because the
+ * refresh is a blind overwrite: the new value is derived from the loader, never from
+ * {@link #lastValue}. So racing refreshers each compute a correct value independently and
+ * last-writer-wins leaves a correct one — there is no lost update the way there would be for a
+ * read-modify-write such as a counter. Nor do {@link #lastValue} and {@link #lastRefreshTime} need to
+ * be updated atomically with respect to each other: the stamp is written before the loader call, so a
+ * reader can briefly see a fresh stamp with the previous value, which is just the one-interval
+ * staleness the contract already allows. The only cost of a race is a duplicated lookup inside a
+ * window the width of one {@link System#getProperty}.
+ *
+ * <p>That reasoning breaks if a refresh ever becomes dependent on the previous value — rate
+ * smoothing, "reject a value more than 2x the last one", parse-failure backoff. Any of those makes
+ * this a read-modify-write and would need a lock or a CAS on the refresh stamp.
+ */
 @Slf4j
 public abstract class DynamicProperty<T>  {
     public static final String DYNAMIC_PROPERTY_REFRESH_SECONDS_KEY = "mantis.config.dynamic.refreshSecs";
     protected final MantisPropertiesLoader propertiesLoader;
     protected final String propertyName;
     protected final T defaultValue;
-    protected T lastValue;
-    protected Instant lastRefreshTime;
+    protected volatile T lastValue;
+    protected volatile Instant lastRefreshTime;
     private final Duration refreshDuration;
     private final Clock clock;
 

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
@@ -60,6 +60,7 @@ import io.mantisrx.master.api.akka.route.v1.LastSubmittedJobIdStreamRoute;
 import io.mantisrx.common.properties.MantisPropertiesLoader;
 import io.mantisrx.master.events.LifecycleEventPublisher;
 import io.mantisrx.master.utils.ApiRequestRateLimiterFactory;
+import io.mantisrx.master.utils.ApiRequestRateLimiterProvider;
 import io.mantisrx.server.core.BaseService;
 import io.mantisrx.server.core.ILeadershipManager;
 import io.mantisrx.server.core.master.MasterDescription;
@@ -100,6 +101,11 @@ public class MasterApiAkkaService extends BaseService {
     private final HttpsConnectionContext httpsConnectionContext;
     private final MantisPropertiesLoader dynamicPropertiesLoader;
 
+    /**
+     * Read by {@link #configureApiRoutes}, so it must be assigned before that call — see the note there.
+     */
+    private final ApiRequestRateLimiterProvider rateLimiterProvider;
+
     public MasterApiAkkaService(final MasterMonitor masterMonitor,
                                 final MasterDescription masterDescription,
                                 final ActorRef jobClustersManagerActor,
@@ -127,6 +133,7 @@ public class MasterApiAkkaService extends BaseService {
             null
         );
     }
+
     public MasterApiAkkaService(final MasterMonitor masterMonitor,
                                 final MasterDescription masterDescription,
                                 final ActorRef jobClustersManagerActor,
@@ -139,6 +146,36 @@ public class MasterApiAkkaService extends BaseService {
                                 final ILeadershipManager leadershipManager,
                                 final MantisPropertiesLoader dynamicPropertiesLoader,
                                 final HttpsConnectionContext httpsConnectionContext) {
+        this(
+            masterMonitor,
+            masterDescription,
+            jobClustersManagerActor,
+            statusEventBrokerActor,
+            resourceClusters,
+            resourceClustersHostManagerActor,
+            serverPort,
+            mantisStorageProvider,
+            lifecycleEventPublisher,
+            leadershipManager,
+            dynamicPropertiesLoader,
+            httpsConnectionContext,
+            ApiRequestRateLimiterProvider.GLOBAL
+        );
+    }
+
+    public MasterApiAkkaService(final MasterMonitor masterMonitor,
+                                final MasterDescription masterDescription,
+                                final ActorRef jobClustersManagerActor,
+                                final ActorRef statusEventBrokerActor,
+                                final ResourceClusters resourceClusters,
+                                final ActorRef resourceClustersHostManagerActor,
+                                final int serverPort,
+                                final IMantisPersistenceProvider mantisStorageProvider,
+                                final LifecycleEventPublisher lifecycleEventPublisher,
+                                final ILeadershipManager leadershipManager,
+                                final MantisPropertiesLoader dynamicPropertiesLoader,
+                                final HttpsConnectionContext httpsConnectionContext,
+                                final ApiRequestRateLimiterProvider rateLimiterProvider) {
         super(true);
         Preconditions.checkNotNull(masterMonitor, "MasterMonitor");
         Preconditions.checkNotNull(masterDescription, "masterDescription");
@@ -148,7 +185,9 @@ public class MasterApiAkkaService extends BaseService {
         Preconditions.checkNotNull(lifecycleEventPublisher, "lifecycleEventPublisher");
         Preconditions.checkNotNull(leadershipManager, "leadershipManager");
         Preconditions.checkNotNull(dynamicPropertiesLoader, "dynamicPropertiesLoader");
+        Preconditions.checkNotNull(rateLimiterProvider, "rateLimiterProvider");
         this.dynamicPropertiesLoader = dynamicPropertiesLoader;
+        this.rateLimiterProvider = rateLimiterProvider;
         this.masterMonitor = masterMonitor;
         this.masterDescription = masterDescription;
         this.jobClustersManagerActor = jobClustersManagerActor;
@@ -161,6 +200,8 @@ public class MasterApiAkkaService extends BaseService {
         this.leadershipManager = leadershipManager;
         this.system = ActorSystem.create("MasterApiActorSystem");
         this.materializer = Materializer.createMaterializer(system);
+        // Builds the routes, so every field it reads — rateLimiterProvider among them — has to be
+        // assigned above this line, not below it with httpsConnectionContext.
         this.mantisMasterRoute = configureApiRoutes(this.system);
         this.httpsConnectionContext = httpsConnectionContext;
         this.executorService = Executors.newSingleThreadExecutor(r -> {
@@ -198,9 +239,10 @@ public class MasterApiAkkaService extends BaseService {
         final JobClustersRoute v1JobClusterRoute = new JobClustersRoute(jobClusterRouteHandler, actorSystem);
 
         // A route gets its own budget, and a route not named here is not throttled at all. What each
-        // budget is called and which config sizes it lives on ApiRequestRateLimiterFactory.
-        final ApiRequestRateLimiterFactory rateLimiterFactory =
-            new ApiRequestRateLimiterFactory(ConfigurationProvider.getConfig(), dynamicPropertiesLoader);
+        // budget is called and which config sizes it lives on ApiRequestRateLimiterFactory; what kind of
+        // limiter backs it comes from the injected provider.
+        final ApiRequestRateLimiterFactory rateLimiterFactory = new ApiRequestRateLimiterFactory(
+            ConfigurationProvider.getConfig(), dynamicPropertiesLoader, rateLimiterProvider);
 
         final JobsRoute v1JobsRoute = new JobsRoute(
             jobClusterRouteHandler,

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/MasterApiAkkaService.java
@@ -57,12 +57,15 @@ import io.mantisrx.master.api.akka.route.v1.JobDiscoveryStreamRoute;
 import io.mantisrx.master.api.akka.route.v1.JobStatusStreamRoute;
 import io.mantisrx.master.api.akka.route.v1.JobsRoute;
 import io.mantisrx.master.api.akka.route.v1.LastSubmittedJobIdStreamRoute;
+import io.mantisrx.common.properties.MantisPropertiesLoader;
 import io.mantisrx.master.events.LifecycleEventPublisher;
+import io.mantisrx.master.utils.ApiRequestRateLimiterFactory;
 import io.mantisrx.server.core.BaseService;
 import io.mantisrx.server.core.ILeadershipManager;
 import io.mantisrx.server.core.master.MasterDescription;
 import io.mantisrx.server.core.master.MasterMonitor;
 import io.mantisrx.server.master.LeaderRedirectionFilter;
+import io.mantisrx.server.master.config.ConfigurationProvider;
 import io.mantisrx.server.master.persistence.IMantisPersistenceProvider;
 import io.mantisrx.server.master.resourcecluster.ResourceClusters;
 import java.util.concurrent.CompletionStage;
@@ -77,6 +80,7 @@ import scala.concurrent.duration.Duration;
 public class MasterApiAkkaService extends BaseService {
 
     private static final Logger logger = LoggerFactory.getLogger(MasterApiAkkaService.class);
+
     private final MasterMonitor masterMonitor;
     private final MasterDescription masterDescription;
     private final ActorRef jobClustersManagerActor;
@@ -94,6 +98,7 @@ public class MasterApiAkkaService extends BaseService {
     private final ExecutorService executorService;
     private final CountDownLatch serviceLatch = new CountDownLatch(1);
     private final HttpsConnectionContext httpsConnectionContext;
+    private final MantisPropertiesLoader dynamicPropertiesLoader;
 
     public MasterApiAkkaService(final MasterMonitor masterMonitor,
                                 final MasterDescription masterDescription,
@@ -104,7 +109,8 @@ public class MasterApiAkkaService extends BaseService {
                                 final int serverPort,
                                 final IMantisPersistenceProvider mantisStorageProvider,
                                 final LifecycleEventPublisher lifecycleEventPublisher,
-                                final ILeadershipManager leadershipManager
+                                final ILeadershipManager leadershipManager,
+                                final MantisPropertiesLoader dynamicPropertiesLoader
                                 ) {
         this(
             masterMonitor,
@@ -117,6 +123,7 @@ public class MasterApiAkkaService extends BaseService {
             mantisStorageProvider,
             lifecycleEventPublisher,
             leadershipManager,
+            dynamicPropertiesLoader,
             null
         );
     }
@@ -130,6 +137,7 @@ public class MasterApiAkkaService extends BaseService {
                                 final IMantisPersistenceProvider mantisStorageProvider,
                                 final LifecycleEventPublisher lifecycleEventPublisher,
                                 final ILeadershipManager leadershipManager,
+                                final MantisPropertiesLoader dynamicPropertiesLoader,
                                 final HttpsConnectionContext httpsConnectionContext) {
         super(true);
         Preconditions.checkNotNull(masterMonitor, "MasterMonitor");
@@ -139,6 +147,8 @@ public class MasterApiAkkaService extends BaseService {
         Preconditions.checkNotNull(mantisStorageProvider, "mantisStorageProvider");
         Preconditions.checkNotNull(lifecycleEventPublisher, "lifecycleEventPublisher");
         Preconditions.checkNotNull(leadershipManager, "leadershipManager");
+        Preconditions.checkNotNull(dynamicPropertiesLoader, "dynamicPropertiesLoader");
+        this.dynamicPropertiesLoader = dynamicPropertiesLoader;
         this.masterMonitor = masterMonitor;
         this.masterDescription = masterDescription;
         this.jobClustersManagerActor = jobClustersManagerActor;
@@ -186,7 +196,17 @@ public class MasterApiAkkaService extends BaseService {
         final JobStatusRoute v0JobStatusRoute = new JobStatusRoute(jobStatusRouteHandler);
 
         final JobClustersRoute v1JobClusterRoute = new JobClustersRoute(jobClusterRouteHandler, actorSystem);
-        final JobsRoute v1JobsRoute = new JobsRoute(jobClusterRouteHandler, jobRouteHandler, actorSystem);
+
+        // A route gets its own budget, and a route not named here is not throttled at all. What each
+        // budget is called and which config sizes it lives on ApiRequestRateLimiterFactory.
+        final ApiRequestRateLimiterFactory rateLimiterFactory =
+            new ApiRequestRateLimiterFactory(ConfigurationProvider.getConfig(), dynamicPropertiesLoader);
+
+        final JobsRoute v1JobsRoute = new JobsRoute(
+            jobClusterRouteHandler,
+            jobRouteHandler,
+            actorSystem,
+            rateLimiterFactory.v1Jobs());
         final AdminMasterRoute v1AdminMasterRoute = new AdminMasterRoute(masterDescription);
         final JobDiscoveryStreamRoute v1JobDiscoveryStreamRoute = new JobDiscoveryStreamRoute(jobDiscoveryRouteHandler);
         final LastSubmittedJobIdStreamRoute v1LastSubmittedJobIdStreamRoute = new LastSubmittedJobIdStreamRoute(jobDiscoveryRouteHandler);

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
@@ -29,6 +29,7 @@ import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.model.Uri;
+import akka.http.javadsl.model.headers.RetryAfter;
 import akka.http.javadsl.server.AllDirectives;
 import akka.http.javadsl.server.ExceptionHandler;
 import akka.http.javadsl.server.RequestContext;
@@ -77,6 +78,10 @@ abstract class BaseRoute extends AllDirectives {
     public static final String JOBMETADATA_FILTER = "jobMetadata";
     public static final String STAGEMETADATA_FILTER = "stageMetadataList";
     public static final String WORKERMETADATA_FILTER = "workerMetadataList";
+
+    /** Bounds on the {@code Retry-After} of a 429; see {@link #clampRetryAfterSeconds}. */
+    private static final long MIN_RETRY_AFTER_SECONDS = 1;
+    private static final long MAX_RETRY_AFTER_SECONDS = 60;
 
     private static final HttpHeader ACCESS_CONTROL_ALLOW_ORIGIN_HEADER =
             HttpHeader.parse("Access-Control-Allow-Origin", "*");
@@ -131,21 +136,100 @@ abstract class BaseRoute extends AllDirectives {
      * {@code post} and friends take — which is what makes this a request-time check rather than a
      * one-off when the route tree is built.
      *
+     * <p>Sheds are counted here rather than inside the limiter, and that placement is the point: which
+     * limiter guards a route is a deployment's choice — see {@code ApiRequestRateLimiterProvider} — so a
+     * counter owned by an implementation disappears the moment one is substituted, taking the dashboard
+     * with it exactly when admission-control policy is being changed. Every shed passes through this
+     * method whatever the mechanism, so counting here is the one placement no implementation can drop.
+     * The numbers are the ones the rest of these routes already emit: {@code apiv1} tagged with the
+     * endpoint and {@code responseCode=429}, so a shed reads as one more outcome of a call the operator
+     * is already graphing, and {@code MasterApiMetrics}' untagged totals.
+     *
      * @param rateLimiter the bucket to draw a permit from. Every endpoint handed the same instance
      *     shares its permits, so pass the limiter whose configured rate was sized for this endpoint's
      *     traffic; an endpoint given a limiter built for a different workload silently splits one
-     *     budget between two. The limiter counts its own sheds under its {@code route} tag, so the
-     *     metric names the bucket that ran out rather than whatever this call site claimed.
+     *     budget between two.
+     * @param endpointName the endpoint whose sheds are counted, one of
+     *     {@link HttpRequestMetrics.Endpoints}. Endpoints are a closed set, which is what keeps the tag's
+     *     cardinality bounded — the request path could not be used for this, since the cluster-submit path
+     *     carries a cluster name and would open a time series per cluster.
+     * @param verb the method the endpoint is reached by, tagged as on any other response
      * @param inner the route to run when a permit is available
      */
-    protected Route withThrottle(ApiRequestRateLimiter rateLimiter, Supplier<Route> inner) {
+    protected Route withThrottle(
+            ApiRequestRateLimiter rateLimiter,
+            String endpointName,
+            HttpRequestMetrics.HttpVerb verb,
+            Supplier<Route> inner) {
         return extractRequest(request -> {
             if (!rateLimiter.tryAcquire(request)) {
                 MasterApiMetrics.getInstance().incrementResp4xx();
-                return complete(StatusCodes.TOO_MANY_REQUESTS);
+                MasterApiMetrics.getInstance().incrementThrottledRequestCount();
+                HttpRequestMetrics.getInstance().incrementEndpointMetrics(
+                        endpointName,
+                        new BasicTag("verb", verb.toString()),
+                        new BasicTag(
+                                "responseCode",
+                                String.valueOf(StatusCodes.TOO_MANY_REQUESTS.intValue())));
+                return complete(throttledResponse(request, rateLimiter.getRetryAfter(request)));
             }
             return inner.get();
         });
+    }
+
+    /**
+     * The 429 a shed caller gets: a {@code Retry-After} header carrying the limiter's hint, and the same
+     * JSON failure body every other error on these routes uses, so a client already parsing {@code error}
+     * needs no special case for this one.
+     *
+     * <p>{@code Retry-After} is what makes the shed actionable to a client that does not read prose — the
+     * conventional signal, understood by most HTTP clients, that this is a wait-and-retry rather than a
+     * malformed request to give up on. The body says the same thing in words for the human reading a curl
+     * output, and names the endpoint, since a 429 says nothing about which of a client's calls was shed.
+     *
+     * <p>The hint is deliberately advisory: no permit is reserved, so honouring it exactly is not a
+     * guarantee of admission and every shed caller is handed the same number. The message asks for
+     * backoff and jitter on top rather than letting a fleet of clients synchronise on one instant.
+     */
+    // java.time.Duration is spelled out: this file already imports scala.concurrent.duration.Duration.
+    private HttpResponse throttledResponse(HttpRequest request, java.time.Duration retryAfter) {
+        final long retryAfterSeconds = clampRetryAfterSeconds(retryAfter);
+        final String message = String.format(
+                "Request throttled: %s %s exceeded the rate limit for this endpoint. Retry after %d "
+                        + "second(s), with exponential backoff and jitter; retrying sooner or in lockstep "
+                        + "with other clients will be shed again.",
+                request.method().value(), request.getUri().path(), retryAfterSeconds);
+        // Not logged: this path runs once per shed request, so under the storm it exists to survive a log
+        // line per shed would add load rather than shed it. The counters withThrottle increments are the
+        // signal to alert on.
+        return HttpResponse.create()
+                .withStatus(StatusCodes.TOO_MANY_REQUESTS)
+                .addHeader(RetryAfter.create(retryAfterSeconds))
+                .withEntity(
+                        ContentTypes.APPLICATION_JSON,
+                        // No request id: the request was shed before it became one.
+                        generateFailureResponsePayload(message, -1));
+    }
+
+    /**
+     * Turns a limiter's wait into the whole number of seconds {@code Retry-After} carries, clamped to a
+     * range that means something on these routes. Doing it here rather than in each limiter is what lets
+     * {@link ApiRequestRateLimiter#getRetryAfter} promise its implementors they need not round.
+     *
+     * <p>Rounds <em>up</em>: truncating 1.4s to 1s sends the caller back before the permit exists, turning
+     * one shed request into two. The floor of one second follows, and also catches zero and negative waits,
+     * which {@code Retry-After} renders as "retry now" — the opposite of what shedding was for.
+     *
+     * <p>The ceiling is the one that constrains a real implementation. A keyed limiter with a slowly
+     * refilling per-caller bucket can compute a wait of many minutes, and while that number is arithmetically
+     * right it is not useful advice on a submit path: a client told to wait a quarter of an hour has been
+     * handed an outage, and the honest reading is that the bucket is mis-sized rather than that the caller
+     * should sleep. Capping keeps the header actionable and turns the underlying problem into something the
+     * shed counters show rather than something clients absorb silently.
+     */
+    private static long clampRetryAfterSeconds(java.time.Duration retryAfter) {
+        final long ceiled = retryAfter.getNano() > 0 ? retryAfter.getSeconds() + 1 : retryAfter.getSeconds();
+        return Math.min(MAX_RETRY_AFTER_SECONDS, Math.max(MIN_RETRY_AFTER_SECONDS, ceiled));
     }
 
     protected abstract Route constructRoutes();

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/BaseRoute.java
@@ -44,6 +44,7 @@ import com.netflix.spectator.api.BasicTag;
 import io.mantisrx.master.api.akka.route.Jackson;
 import io.mantisrx.master.api.akka.route.MasterApiMetrics;
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
+import io.mantisrx.master.utils.ApiRequestRateLimiter;
 import io.mantisrx.server.master.resourcecluster.RequestThrottledException;
 import io.mantisrx.server.master.resourcecluster.ResourceCluster.TaskExecutorNotFoundException;
 import io.mantisrx.server.master.resourcecluster.TaskExecutorTaskCancelledException;
@@ -63,6 +64,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.concurrent.duration.Duration;
@@ -112,6 +114,38 @@ abstract class BaseRoute extends AllDirectives {
             .withTimeToLive(Duration.create(ttlMillis, TimeUnit.MILLISECONDS));
         final CachingSettings cachingSettings = defaultCachingSettings.withLfuCacheSettings(lfuCacheSettings);
         return LfuCache.create(cachingSettings);
+    }
+
+    /**
+     * Wraps {@code inner} in admission control: if {@code rateLimiter} has no permit left for the
+     * request, it is shed with a 429 and {@code inner} never runs.
+     *
+     * <p>Intended for the mutating endpoints — job submit, cluster create/update/delete — where a
+     * client storm turns into a backlog on an actor that reads do not touch. The limiter decides the
+     * policy (node-wide bucket, per-client bucket, unlimited); this only decides where the check
+     * happens.
+     *
+     * <p>Two properties matter at the call site. The check runs before the entity is unmarshalled, so
+     * a storm costs a rate-limiter check rather than a parse plus an ask into an actor. And
+     * {@code extractRequest} is evaluated per request — unlike the by-name {@code Supplier} that
+     * {@code post} and friends take — which is what makes this a request-time check rather than a
+     * one-off when the route tree is built.
+     *
+     * @param rateLimiter the bucket to draw a permit from. Every endpoint handed the same instance
+     *     shares its permits, so pass the limiter whose configured rate was sized for this endpoint's
+     *     traffic; an endpoint given a limiter built for a different workload silently splits one
+     *     budget between two. The limiter counts its own sheds under its {@code route} tag, so the
+     *     metric names the bucket that ran out rather than whatever this call site claimed.
+     * @param inner the route to run when a permit is available
+     */
+    protected Route withThrottle(ApiRequestRateLimiter rateLimiter, Supplier<Route> inner) {
+        return extractRequest(request -> {
+            if (!rateLimiter.tryAcquire(request)) {
+                MasterApiMetrics.getInstance().incrementResp4xx();
+                return complete(StatusCodes.TOO_MANY_REQUESTS);
+            }
+            return inner.get();
+        });
     }
 
     protected abstract Route constructRoutes();

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
@@ -277,7 +277,15 @@ public class JobsRoute extends BaseRoute {
     }
 
     private Route postJobsRoute(Optional<String> clusterName) {
-        return withThrottle(rateLimiter, () -> submitJobRoute(clusterName));
+        // Same endpoint split submitJobRoute makes once it has the body — done again here because a shed
+        // request never gets that far, and a shed has to land on the endpoint that would have served it.
+        return withThrottle(
+                rateLimiter,
+                clusterName.isPresent()
+                        ? HttpRequestMetrics.Endpoints.JOB_CLUSTER_INSTANCE_JOBS
+                        : HttpRequestMetrics.Endpoints.JOBS,
+                HttpRequestMetrics.HttpVerb.POST,
+                () -> submitJobRoute(clusterName));
     }
 
     private Route submitJobRoute(Optional<String> clusterName) {
@@ -500,7 +508,13 @@ public class JobsRoute extends BaseRoute {
     private Route postJobInstanceQuickSubmitRoute() {
         // quickSubmit is a job-creation path too, so it shares the submit bucket rather than getting
         // its own: the thing we are protecting is the cluster actor behind both, not the endpoint.
-        return withThrottle(rateLimiter, this::quickSubmitRoute);
+        // The bucket is shared, but the metric is not: sheds are counted under quickSubmit's own endpoint,
+        // so a dashboard shows which of the two callers is filling the bucket the other one drinks from.
+        return withThrottle(
+                rateLimiter,
+                HttpRequestMetrics.Endpoints.JOBS_ACTION_QUICKSUBMIT,
+                HttpRequestMetrics.HttpVerb.POST,
+                this::quickSubmitRoute);
     }
 
     private Route quickSubmitRoute() {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/JobsRoute.java
@@ -37,6 +37,7 @@ import io.mantisrx.master.api.akka.route.utils.JobRouteUtils;
 import io.mantisrx.master.jobcluster.job.MantisJobMetadataView;
 import io.mantisrx.master.jobcluster.proto.BaseResponse;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
+import io.mantisrx.master.utils.ApiRequestRateLimiter;
 import io.mantisrx.runtime.MantisJobDefinition;
 import io.mantisrx.server.core.PostJobStatusRequest;
 import io.mantisrx.server.master.config.ConfigurationProvider;
@@ -82,14 +83,24 @@ public class JobsRoute extends BaseRoute {
     private final MasterConfiguration config;
     private final Cache<Uri, RouteResult> routeResultCache;
 
+    /**
+     * Admission control for this route's job-creation endpoints. The reads and the per-job actions
+     * (scaleStage, resubmitWorker, postJobStatus) are deliberately left unguarded: it is the creation
+     * path whose backlog lands on the shared cluster actor. Which of these endpoints share a bucket, and
+     * whether that bucket is shared with another route, is decided where the instance is constructed.
+     */
+    private final ApiRequestRateLimiter rateLimiter;
+
     public JobsRoute(
             final JobClusterRouteHandler clusterRouteHandler,
             final JobRouteHandler jobRouteHandler,
-            final ActorSystem actorSystem) {
+            final ActorSystem actorSystem,
+            final ApiRequestRateLimiter rateLimiter) {
         this.jobRouteHandler = jobRouteHandler;
         this.clusterRouteHandler = clusterRouteHandler;
         this.config = ConfigurationProvider.getConfig();
         this.routeResultCache = createCache(actorSystem, config.getApiCacheMinSize(), config.getApiCacheMaxSize(), config.getApiCacheTtlMilliseconds());
+        this.rateLimiter = rateLimiter;
     }
 
 
@@ -266,7 +277,10 @@ public class JobsRoute extends BaseRoute {
     }
 
     private Route postJobsRoute(Optional<String> clusterName) {
+        return withThrottle(rateLimiter, () -> submitJobRoute(clusterName));
+    }
 
+    private Route submitJobRoute(Optional<String> clusterName) {
         return decodeRequest(() -> entity(
                 Jackson.unmarshaller(MantisJobDefinition.class),
                 submitJobRequest -> {
@@ -484,6 +498,12 @@ public class JobsRoute extends BaseRoute {
 
 
     private Route postJobInstanceQuickSubmitRoute() {
+        // quickSubmit is a job-creation path too, so it shares the submit bucket rather than getting
+        // its own: the thing we are protecting is the cluster actor behind both, not the endpoint.
+        return withThrottle(rateLimiter, this::quickSubmitRoute);
+    }
+
+    private Route quickSubmitRoute() {
         return entity(
                 Jackson.unmarshaller(JobClusterManagerProto.SubmitJobRequest.class),
                 request -> {

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.utils;
+
+import akka.http.javadsl.model.HttpRequest;
+
+/**
+ * Admission control for a set of API endpoints: decides whether an inbound request may proceed or
+ * should be shed (typically as a 429).
+ *
+ * <p>Implementations are called on the request thread before the entity is unmarshalled, so they
+ * must be cheap and must never block.
+ *
+ * <p>An instance owns one bucket, and which endpoints draw from it is decided entirely by where the
+ * instance is wired in — the granularity is a wiring decision, not a property of this interface.
+ * Endpoints wired to one instance share its permits, so group them by the resource they contend for
+ * (an actor mailbox, a store) rather than by convenience; giving an unrelated endpoint a limiter
+ * sized for a different workload silently splits one budget between two.
+ *
+ * @see GlobalApiRequestRateLimiter the node-wide single-bucket implementation
+ */
+@FunctionalInterface
+public interface ApiRequestRateLimiter {
+
+    /**
+     * An {@link ApiRequestRateLimiter} that admits everything. Used for tests and for routes whose
+     * throttle is switched off, so the route layer has no disabled case to special-case.
+     */
+    ApiRequestRateLimiter UNLIMITED = request -> true;
+
+    /**
+     * @param request the inbound request. Passed so that implementations can key on caller identity
+     *     (headers, remote address, ...) without every call site having to extract it first; the
+     *     node-wide implementation ignores it.
+     * @return true if a permit was available and the request may proceed, false if the caller
+     *     should be throttled. Never blocks.
+     */
+    boolean tryAcquire(HttpRequest request);
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiter.java
@@ -17,6 +17,7 @@
 package io.mantisrx.master.utils;
 
 import akka.http.javadsl.model.HttpRequest;
+import java.time.Duration;
 
 /**
  * Admission control for a set of API endpoints: decides whether an inbound request may proceed or
@@ -50,4 +51,31 @@ public interface ApiRequestRateLimiter {
      *     should be throttled. Never blocks.
      */
     boolean tryAcquire(HttpRequest request);
+
+    /**
+     * How long a shed caller should wait before trying again, reported to it as the {@code Retry-After}
+     * header of the 429. This is a hint, not a reservation: nothing holds a permit for the caller, so a
+     * client that waits exactly this long can still be shed again if others drained the bucket first.
+     *
+     * <p>The default of one second is the smallest value {@code Retry-After} can express in seconds, and
+     * suits any bucket refilling at a permit per second or faster. An implementation whose bucket refills
+     * more slowly than that should override this — telling a caller to come back in a second when the next
+     * permit is a minute away just converts one shed request into sixty.
+     *
+     * <p>The request is passed so that a keyed implementation can answer per caller: the client that
+     * drained its own bucket should be told to wait longer than one shed by a shared ceiling, and the
+     * two are indistinguishable without something to key on. It is called only on the shed path, and
+     * separately from {@link #tryAcquire}, so a keyed implementation pays a second lookup and may
+     * observe its bucket a moment later than the decision did. Both are deliberate: {@code Retry-After}
+     * has whole-second resolution, which is coarser than either effect. An implementation with no
+     * per-caller answer to give — no bucket for this client, because the shared ceiling shed it —
+     * should delegate to this default rather than invent one.
+     *
+     * @param request the request being shed, to key on
+     * @return a positive duration. The route layer clamps it into a range {@code Retry-After} can carry
+     *     sensibly, so an implementation need not round: see {@code BaseRoute.throttledResponse}.
+     */
+    default Duration getRetryAfter(HttpRequest request) {
+        return Duration.ofSeconds(1);
+    }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiterFactory.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiterFactory.java
@@ -42,18 +42,37 @@ import lombok.extern.slf4j.Slf4j;
  * <p>A route whose flag is off yields {@link ApiRequestRateLimiter#UNLIMITED}: no dynamic property is
  * resolved and no limiter is constructed, so the feature stays inert until an operator opts in, and the
  * route layer has no disabled case to special-case.
+ *
+ * <p>What kind of limiter backs a budget is not decided here — that is the
+ * {@link ApiRequestRateLimiterProvider}'s job, so that a deployment can swap the mechanism (per-caller
+ * buckets, say) while this class keeps deciding which routes have budgets at all. Everything above still
+ * holds whatever the provider returns: the flag, the caching, and the one-limiter-per-route guarantee are
+ * applied to it, not delegated.
  */
 @Slf4j
 public class ApiRequestRateLimiterFactory {
 
     private final MasterConfiguration config;
     private final MantisPropertiesLoader propertiesLoader;
+    private final ApiRequestRateLimiterProvider provider;
     private final ConcurrentMap<String, ApiRequestRateLimiter> limiters = new ConcurrentHashMap<>();
 
+    /**
+     * Builds limiters with the node-wide single-bucket mechanism. Equivalent to passing
+     * {@link ApiRequestRateLimiterProvider#GLOBAL}.
+     */
     public ApiRequestRateLimiterFactory(
         MasterConfiguration config, MantisPropertiesLoader propertiesLoader) {
+        this(config, propertiesLoader, ApiRequestRateLimiterProvider.GLOBAL);
+    }
+
+    public ApiRequestRateLimiterFactory(
+        MasterConfiguration config,
+        MantisPropertiesLoader propertiesLoader,
+        ApiRequestRateLimiterProvider provider) {
         this.config = config;
         this.propertiesLoader = propertiesLoader;
+        this.provider = provider;
     }
 
     /**
@@ -80,6 +99,6 @@ public class ApiRequestRateLimiterFactory {
             MasterConfiguration.class,
             defaultPermitsPerSecond,
             propertiesLoader);
-        return new GlobalApiRequestRateLimiter(route, permitsPerSecondDp);
+        return provider.create(route, permitsPerSecondDp, propertiesLoader);
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiterFactory.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiterFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.utils;
+
+import io.mantisrx.common.properties.MantisPropertiesLoader;
+import io.mantisrx.config.dynamic.LongDynamicProperty;
+import io.mantisrx.server.core.utils.ConfigUtils;
+import io.mantisrx.server.master.config.MasterConfiguration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Hands out the rate limiter guarding a route, one accessor per throttled route, building it on first ask
+ * and returning that same instance thereafter.
+ *
+ * <p>A route is one budget. Building it twice would produce two independent limiters — each admitting the
+ * configured rate, so the effective limit is doubled — that both register their shed counter under the
+ * same {@code route} tag. The metrics registry de-duplicates by group id, so the two would report as one
+ * series and the split would be invisible in exactly the state where the numbers matter. Caching here is
+ * what makes that unrepresentable, so the accessors are the only supported way to reach a limiter.
+ *
+ * <p>Each accessor holds the entire binding for its route: the flag that switches the throttle on, the
+ * config method whose {@code @Config} key sizes it, and the label its sheds are tagged with. Throttling
+ * another route means adding an accessor here — deliberately more friction than a config key, because a
+ * new limiter is a new budget somebody has to size and watch.
+ *
+ * <p>A route whose flag is off yields {@link ApiRequestRateLimiter#UNLIMITED}: no dynamic property is
+ * resolved and no limiter is constructed, so the feature stays inert until an operator opts in, and the
+ * route layer has no disabled case to special-case.
+ */
+@Slf4j
+public class ApiRequestRateLimiterFactory {
+
+    private final MasterConfiguration config;
+    private final MantisPropertiesLoader propertiesLoader;
+    private final ConcurrentMap<String, ApiRequestRateLimiter> limiters = new ConcurrentHashMap<>();
+
+    public ApiRequestRateLimiterFactory(
+        MasterConfiguration config, MantisPropertiesLoader propertiesLoader) {
+        this.config = config;
+        this.propertiesLoader = propertiesLoader;
+    }
+
+    /**
+     * @return the limiter shared by the throttled endpoints of the v1 jobs route, or
+     *     {@link ApiRequestRateLimiter#UNLIMITED} while the throttle is switched off
+     */
+    public ApiRequestRateLimiter v1Jobs() {
+        if (!config.isApiV1JobsThrottleEnabled()) {
+            log.info("throttle for route v1Jobs is disabled");
+            return ApiRequestRateLimiter.UNLIMITED;
+        }
+        return limiters.computeIfAbsent("v1Jobs", route -> create(
+            route,
+            // The same accessor twice over: by name so its @Config key can be resolved for overrides, and
+            // called for the value that sizes the limiter until the first override arrives.
+            "getApiV1JobsThrottlePermitsPerSecond",
+            config.getApiV1JobsThrottlePermitsPerSecond()));
+    }
+
+    private ApiRequestRateLimiter create(
+        String route, String permitsPerSecondConfigMethod, long defaultPermitsPerSecond) {
+        final LongDynamicProperty permitsPerSecondDp = ConfigUtils.getDynamicPropertyLong(
+            permitsPerSecondConfigMethod,
+            MasterConfiguration.class,
+            defaultPermitsPerSecond,
+            propertiesLoader);
+        return new GlobalApiRequestRateLimiter(route, permitsPerSecondDp);
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiterProvider.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/ApiRequestRateLimiterProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.utils;
+
+import io.mantisrx.common.properties.MantisPropertiesLoader;
+import io.mantisrx.config.dynamic.LongDynamicProperty;
+
+/**
+ * Builds the {@link ApiRequestRateLimiter} backing one route's budget, so that a deployment can swap the
+ * admission-control <em>mechanism</em> without owning the route map.
+ *
+ * <p>The split is deliberate. {@link ApiRequestRateLimiterFactory} decides which routes get a budget, what
+ * each is called, and that each is built exactly once; this decides only how a bucket behaves once asked
+ * for. A deployment wanting per-caller isolation supplies a provider and inherits every route the factory
+ * already throttles, and a route added to the factory later is covered without that deployment changing
+ * anything. Were this an interface over the factory instead, each new throttled route would break every
+ * implementation of it, and the route-to-budget mapping the factory documents at length would have to be
+ * re-decided downstream.
+ *
+ * <p>Implementations are constructed once per route at startup, not per request, so they may do work a
+ * request path could not afford. What they return is on the request path, however, and must honour
+ * {@link ApiRequestRateLimiter}'s contract: cheap, non-blocking, never throwing.
+ *
+ * <p>Providers are supplied by dependency injection — {@code MasterMain} takes one and passes it down —
+ * so an implementation is free to close over whatever services it needs. {@code propertiesLoader} is
+ * handed to {@link #create} anyway so a provider stays constructible without a container, which the
+ * {@code MasterMain.main()} bootstrap and the tests both rely on.
+ */
+@FunctionalInterface
+public interface ApiRequestRateLimiterProvider {
+
+    /**
+     * The node-wide single-bucket mechanism: what a deployment gets unless it supplies its own. Every
+     * caller draws from one bucket per route, which caps total load but cannot isolate a well-behaved
+     * caller from a noisy one — see {@link GlobalApiRequestRateLimiter}.
+     */
+    ApiRequestRateLimiterProvider GLOBAL =
+        (route, permitsPerSecondDp, propertiesLoader) ->
+            new GlobalApiRequestRateLimiter(route, permitsPerSecondDp);
+
+    /**
+     * @param route names what the returned limiter guards, and is the label its sheds are reported under.
+     *     Unique per budget; the factory guarantees it asks at most once per route.
+     * @param permitsPerSecondDp the route's configured ceiling, re-readable at runtime. An implementation
+     *     that keys per caller should treat this as the ceiling it enforces <em>underneath</em> rather
+     *     than as a per-caller allowance, so that the meaning of the operator-facing config key does not
+     *     change with the mechanism.
+     * @param propertiesLoader for resolving whatever further keys the mechanism needs, so that its own
+     *     knobs can be dynamic in the same way the rate above is.
+     * @return the limiter for this route; never null
+     */
+    ApiRequestRateLimiter create(
+        String route, LongDynamicProperty permitsPerSecondDp, MantisPropertiesLoader propertiesLoader);
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/GlobalApiRequestRateLimiter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/GlobalApiRequestRateLimiter.java
@@ -17,10 +17,6 @@
 package io.mantisrx.master.utils;
 
 import akka.http.javadsl.model.HttpRequest;
-import com.netflix.spectator.api.BasicTag;
-import io.mantisrx.common.metrics.Counter;
-import io.mantisrx.common.metrics.Metrics;
-import io.mantisrx.common.metrics.MetricsRegistry;
 import io.mantisrx.config.dynamic.LongDynamicProperty;
 import io.mantisrx.shaded.com.google.common.util.concurrent.RateLimiter;
 import lombok.extern.slf4j.Slf4j;
@@ -42,20 +38,25 @@ import lombok.extern.slf4j.Slf4j;
  * 302 the caller away first. So the configured rate is in practice the cluster-wide ceiling, not a
  * per-node share of one.
  *
- * <p>Sheds are counted by this class rather than by the route layer, so that the {@code route} tag
- * always names the bucket that actually shed the request instead of whatever the call site claimed.
+ * <p>Nothing here is counted. Sheds are counted by the route layer, which is the only place they can be
+ * counted once the mechanism is a deployment's to choose — see {@link ApiRequestRateLimiterProvider}.
+ *
+ * <p>{@link ApiRequestRateLimiter#getRetryAfter(HttpRequest)} is left at the inherited one second, which is
+ * the honest answer for every rate this limiter can be given: the bucket refills a permit every
+ * {@code 1/rate} seconds and the rate is a whole number of permits per second, so the next permit is always
+ * within a second — and {@code Retry-After} cannot express less than that anyway. Its request parameter is
+ * of no use here for the same reason {@link #tryAcquire(HttpRequest)} discards one. Two caveats. The hint
+ * does not say the permit will be <em>this</em> caller's: the bucket is unkeyed, so every client shed in the
+ * same second gets the same number and they contend again when it elapses, which is why the route layer's
+ * message asks for backoff and jitter on top. And if the rate ever becomes fractional, one second turns into
+ * an underestimate and this needs an override.
  */
 @Slf4j
 public class GlobalApiRequestRateLimiter implements ApiRequestRateLimiter {
 
-    private static final String METRIC_GROUP = "ApiRequestRateLimiter";
-    private static final String THROTTLED_REQUEST_COUNT = "throttledRequestCount";
-    private static final String ROUTE_TAG = "route";
-
     private final String route;
     private final LongDynamicProperty permitsPerSecondDp;
     private final RateLimiter rateLimiter;
-    private final Counter throttledRequestCount;
 
     /**
      * Guards {@link #syncRate()} so concurrent callers don't race on {@code RateLimiter.setRate}.
@@ -65,21 +66,15 @@ public class GlobalApiRequestRateLimiter implements ApiRequestRateLimiter {
     private volatile long currentRate;
 
     /**
-     * @param route names what this bucket guards, and is the {@code route} tag its sheds are counted
-     *     under. Two limiters built with the same label report into the same time series, so give each
-     *     bucket its own label.
+     * @param route names what this bucket guards, for the startup log line and the rate-change one. It is
+     *     not a metric tag — sheds are counted at the route layer under the endpoint that shed them, which
+     *     is finer than this label: one bucket can guard several endpoints.
      */
     public GlobalApiRequestRateLimiter(String route, LongDynamicProperty permitsPerSecondDp) {
         this.route = route;
         this.permitsPerSecondDp = permitsPerSecondDp;
         this.currentRate = permitsPerSecondDp.getValue();
         this.rateLimiter = RateLimiter.create(this.currentRate);
-        final Metrics metrics = MetricsRegistry.getInstance().registerAndGet(
-            new Metrics.Builder()
-                .id(METRIC_GROUP, new BasicTag(ROUTE_TAG, route))
-                .addCounter(THROTTLED_REQUEST_COUNT)
-                .build());
-        this.throttledRequestCount = metrics.getCounter(THROTTLED_REQUEST_COUNT);
         log.info("Created rate limiter for route {} from {} at {} permits/sec",
             route, permitsPerSecondDp, this.currentRate);
     }
@@ -92,11 +87,7 @@ public class GlobalApiRequestRateLimiter implements ApiRequestRateLimiter {
     @Override
     public boolean tryAcquire(HttpRequest request) {
         syncRate();
-        if (rateLimiter.tryAcquire()) {
-            return true;
-        }
-        throttledRequestCount.increment();
-        return false;
+        return rateLimiter.tryAcquire();
     }
 
     /**

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/GlobalApiRequestRateLimiter.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/utils/GlobalApiRequestRateLimiter.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.utils;
+
+import akka.http.javadsl.model.HttpRequest;
+import com.netflix.spectator.api.BasicTag;
+import io.mantisrx.common.metrics.Counter;
+import io.mantisrx.common.metrics.Metrics;
+import io.mantisrx.common.metrics.MetricsRegistry;
+import io.mantisrx.config.dynamic.LongDynamicProperty;
+import io.mantisrx.shaded.com.google.common.util.concurrent.RateLimiter;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * One bucket, drawn from by every client alike, sized by a {@link LongDynamicProperty} so it can be
+ * re-tuned at runtime without a deploy. "Global" refers to the set of clients, not the set of
+ * endpoints: this limiter is unkeyed — {@link #tryAcquire(HttpRequest)} discards the request — so it
+ * cannot tell one caller from another. Which endpoints it covers is decided entirely by where the
+ * instance is wired in, not by anything here.
+ *
+ * <p>This is the simplest useful form of admission control: it caps total load on whatever it guards
+ * and so stops one client from storming it. What it cannot do is isolate a well-behaved caller from a
+ * noisy one — once the bucket is drained, everyone is shed alike. Keying the limit per caller needs a
+ * different {@link ApiRequestRateLimiter} implementation, one holding a bucket per client.
+ *
+ * <p>The bucket is per node, but since every API route sits behind
+ * {@code LeaderRedirectionFilter.redirectIfNotLeader} only the leader ever reaches a limiter — standbys
+ * 302 the caller away first. So the configured rate is in practice the cluster-wide ceiling, not a
+ * per-node share of one.
+ *
+ * <p>Sheds are counted by this class rather than by the route layer, so that the {@code route} tag
+ * always names the bucket that actually shed the request instead of whatever the call site claimed.
+ */
+@Slf4j
+public class GlobalApiRequestRateLimiter implements ApiRequestRateLimiter {
+
+    private static final String METRIC_GROUP = "ApiRequestRateLimiter";
+    private static final String THROTTLED_REQUEST_COUNT = "throttledRequestCount";
+    private static final String ROUTE_TAG = "route";
+
+    private final String route;
+    private final LongDynamicProperty permitsPerSecondDp;
+    private final RateLimiter rateLimiter;
+    private final Counter throttledRequestCount;
+
+    /**
+     * Guards {@link #syncRate()} so concurrent callers don't race on {@code RateLimiter.setRate}.
+     * Reads are unsynchronized: a stale read only costs one redundant {@code setRate} to the same
+     * value.
+     */
+    private volatile long currentRate;
+
+    /**
+     * @param route names what this bucket guards, and is the {@code route} tag its sheds are counted
+     *     under. Two limiters built with the same label report into the same time series, so give each
+     *     bucket its own label.
+     */
+    public GlobalApiRequestRateLimiter(String route, LongDynamicProperty permitsPerSecondDp) {
+        this.route = route;
+        this.permitsPerSecondDp = permitsPerSecondDp;
+        this.currentRate = permitsPerSecondDp.getValue();
+        this.rateLimiter = RateLimiter.create(this.currentRate);
+        final Metrics metrics = MetricsRegistry.getInstance().registerAndGet(
+            new Metrics.Builder()
+                .id(METRIC_GROUP, new BasicTag(ROUTE_TAG, route))
+                .addCounter(THROTTLED_REQUEST_COUNT)
+                .build());
+        this.throttledRequestCount = metrics.getCounter(THROTTLED_REQUEST_COUNT);
+        log.info("Created rate limiter for route {} from {} at {} permits/sec",
+            route, permitsPerSecondDp, this.currentRate);
+    }
+
+    /**
+     * @return true if a permit was available and consumed, false if the caller should be throttled.
+     *     Never blocks. {@code request} is deliberately unused — every caller draws from the same
+     *     bucket regardless of who they are or what they asked for.
+     */
+    @Override
+    public boolean tryAcquire(HttpRequest request) {
+        syncRate();
+        if (rateLimiter.tryAcquire()) {
+            return true;
+        }
+        throttledRequestCount.increment();
+        return false;
+    }
+
+    /**
+     * {@link LongDynamicProperty#getValue()} already self-refreshes on its own interval
+     * ({@code mantis.config.dynamic.refreshSecs}, default 30s), so the rate is re-read lazily on the
+     * calling thread rather than from a dedicated scheduler thread. This runs on every request, so it
+     * relies on {@code getValue()} being safe to call concurrently and on its steady-state path not
+     * touching the underlying properties loader — see {@code DynamicProperty}.
+     */
+    private void syncRate() {
+        long newRate = permitsPerSecondDp.getValue();
+        if (newRate == currentRate) {
+            return;
+        }
+        synchronized (this) {
+            if (newRate == currentRate) {
+                return;
+            }
+            log.info("Setting the rate limiter rate for route {} to {} (was {})", route, newRate, currentRate);
+            rateLimiter.setRate(newRate);
+            currentRate = newRate;
+        }
+    }
+
+    /**
+     * Visible for testing: the rate the underlying bucket is actually set to, read from it rather than
+     * from this class's bookkeeping copy.
+     */
+    double getPermitsPerSecond() {
+        return rateLimiter.getRate();
+    }
+
+    @Override
+    public String toString() {
+        return "GlobalApiRequestRateLimiter(route=" + route + ", permitsPerSecond=" + currentRate + ")";
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -50,6 +50,7 @@ import io.mantisrx.master.resourcecluster.ResourceClustersAkkaImpl;
 import io.mantisrx.master.resourcecluster.ResourceClustersHostManagerActor;
 import io.mantisrx.master.resourcecluster.resourceprovider.ResourceClusterProviderAdapter;
 import io.mantisrx.master.scheduler.JobMessageRouterImpl;
+import io.mantisrx.master.utils.ApiRequestRateLimiterProvider;
 import io.mantisrx.master.zk.ZookeeperLeadershipFactory;
 import io.mantisrx.server.core.BaseService;
 import io.mantisrx.server.core.ILeaderElectorFactory;
@@ -104,10 +105,27 @@ public class MasterMain implements Service {
     private ILeadershipManager leadershipManager;
     private MasterMonitor monitor;
 
+    /**
+     * Throttles API routes with the node-wide single-bucket mechanism. Equivalent to passing
+     * {@link ApiRequestRateLimiterProvider#GLOBAL}.
+     */
     public MasterMain(
         ConfigurationFactory configFactory,
         MantisPropertiesLoader dynamicPropertiesLoader,
         AuditEventSubscriber auditEventSubscriber) {
+        this(configFactory, dynamicPropertiesLoader, auditEventSubscriber, ApiRequestRateLimiterProvider.GLOBAL);
+    }
+
+    /**
+     * @param rateLimiterProvider what kind of limiter backs each throttled route's budget. A deployment
+     *     with something to key on — an authenticated caller identity, say — can supply a per-caller
+     *     mechanism here; which routes have budgets at all is not its call.
+     */
+    public MasterMain(
+        ConfigurationFactory configFactory,
+        MantisPropertiesLoader dynamicPropertiesLoader,
+        AuditEventSubscriber auditEventSubscriber,
+        ApiRequestRateLimiterProvider rateLimiterProvider) {
         String test = "{\"jobId\":\"sine-function-1\",\"status\":{\"jobId\":\"sine-function-1\",\"stageNum\":1,\"workerIndex\":0,\"workerNumber\":2,\"type\":\"HEARTBEAT\",\"message\":\"heartbeat\",\"state\":\"Noop\",\"hostname\":null,\"timestamp\":1525813363585,\"reason\":\"Normal\",\"payloads\":[{\"type\":\"SubscriptionState\",\"data\":\"false\"},{\"type\":\"IncomingDataDrop\",\"data\":\"{\\\"onNextCount\\\":0,\\\"droppedCount\\\":0}\"}]}}";
 
         Metrics metrics = new Metrics.Builder()
@@ -218,7 +236,7 @@ public class MasterMain implements Service {
             mantisServices.addService(leaderFactory.createLeaderElector(config, leadershipManager));
             mantisServices.addService(new MasterApiAkkaService(monitor, leadershipManager.getDescription(), jobClusterManagerActor, statusEventBrokerActor,
                 resourceClusters, resourceClustersHostActor, config.getApiPort(), storageProvider, lifecycleEventPublisher, leadershipManager,
-                dynamicPropertiesLoader));
+                dynamicPropertiesLoader, null, rateLimiterProvider));
 
             if (leaderFactory instanceof LocalLeaderFactory && !config.isLocalMode()) {
                 logger.error("local mode is [ {} ] and leader factory is {} this configuration is unsafe", config.isLocalMode(), leaderFactory.getClass().getSimpleName());

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/MasterMain.java
@@ -217,7 +217,8 @@ public class MasterMain implements Service {
             monitor.start();
             mantisServices.addService(leaderFactory.createLeaderElector(config, leadershipManager));
             mantisServices.addService(new MasterApiAkkaService(monitor, leadershipManager.getDescription(), jobClusterManagerActor, statusEventBrokerActor,
-                resourceClusters, resourceClustersHostActor, config.getApiPort(), storageProvider, lifecycleEventPublisher, leadershipManager));
+                resourceClusters, resourceClustersHostActor, config.getApiPort(), storageProvider, lifecycleEventPublisher, leadershipManager,
+                dynamicPropertiesLoader));
 
             if (leaderFactory instanceof LocalLeaderFactory && !config.isLocalMode()) {
                 logger.error("local mode is [ {} ] and leader factory is {} this configuration is unsafe", config.isLocalMode(), leaderFactory.getClass().getSimpleName());

--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/server/master/config/MasterConfiguration.java
@@ -363,6 +363,22 @@ public interface MasterConfiguration extends CoreConfiguration {
     @Default("5000")
     int getResourceClusterActionsPermitsPerSecond();
 
+    // Whether to rate limit the write endpoints of the v1 jobs route (POST api/v1/jobs,
+    // POST api/v1/jobClusters/{}/jobs and POST api/v1/jobs/actions/quickSubmit), to guard against a
+    // client storming job submission. Off by default: the right ceiling depends on cluster size and
+    // traffic, so operators opt in once they have measured their own submit rate. When off no limiter
+    // is constructed at all.
+    @Config("mantis.master.api.v1.jobs.throttle.enabled")
+    @Default("false")
+    boolean isApiV1JobsThrottleEnabled();
+
+    // Permits per second for the throttle above; ignored unless it is enabled. The default is a
+    // backstop against a runaway client rather than a tuned limit, so override it with a value derived
+    // from the submit rate you actually see. Must be positive.
+    @Config("mantis.master.api.v1.jobs.throttle.permitsPerSecond")
+    @Default("1000")
+    int getApiV1JobsThrottlePermitsPerSecond();
+
     @Config("mantis.scheduler.enable-batch")
     @Default("false")
     boolean isBatchSchedulingEnabled();

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v0/JobRouteTest.java
@@ -65,6 +65,7 @@ import io.mantisrx.master.api.akka.route.v1.JobClustersRoute;
 import io.mantisrx.master.api.akka.route.v1.JobDiscoveryStreamRoute;
 import io.mantisrx.master.api.akka.route.v1.JobStatusStreamRoute;
 import io.mantisrx.master.api.akka.route.v1.JobsRoute;
+import io.mantisrx.master.utils.ApiRequestRateLimiter;
 import io.mantisrx.master.api.akka.route.v1.LastSubmittedJobIdStreamRoute;
 import io.mantisrx.master.events.AuditEventSubscriberLoggingImpl;
 import io.mantisrx.master.events.LifecycleEventPublisher;
@@ -251,7 +252,8 @@ public class JobRouteTest {
                 final JobsRoute v1JobsRoute = new JobsRoute(
                         jobClusterRouteHandler,
                         jobRouteHandler,
-                        system);
+                        system,
+                        ApiRequestRateLimiter.UNLIMITED);
                 final JobArtifactsRoute v1JobArtifactsRoute = new JobArtifactsRoute(jobArtifactRouteHandler);
                 final AdminMasterRoute v1AdminMasterRoute = new AdminMasterRoute(masterDescription);
 

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteTest.java
@@ -62,6 +62,7 @@ import io.mantisrx.master.jobcluster.job.CostsCalculator;
 import io.mantisrx.master.jobcluster.job.JobTestHelper;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.master.scheduler.FakeMantisScheduler;
+import io.mantisrx.master.utils.ApiRequestRateLimiter;
 import io.mantisrx.server.core.JobSchedulingInfo;
 import io.mantisrx.server.core.WorkerAssignments;
 import io.mantisrx.server.core.master.LocalMasterMonitor;
@@ -178,7 +179,8 @@ public class JobsRouteTest extends RouteTestBase {
                 final JobsRoute v1JobsRoute = new JobsRoute(
                         jobClusterRouteHandler,
                         jobRouteHandler,
-                        system);
+                        system,
+                        ApiRequestRateLimiter.UNLIMITED);
 
                 final JobClustersRoute v1JobClusterRoute = new JobClustersRoute(
                         jobClusterRouteHandler, system);

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteThrottleTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteThrottleTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.api.akka.route.v1;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import akka.http.javadsl.model.ContentTypes;
+import akka.http.javadsl.model.HttpEntities;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.testkit.JUnitRouteTest;
+import akka.http.javadsl.testkit.TestRoute;
+import com.netflix.mantis.master.scheduler.TestHelpers;
+import io.mantisrx.master.api.akka.payloads.JobClusterPayloads;
+import io.mantisrx.master.api.akka.route.handlers.JobClusterRouteHandler;
+import io.mantisrx.master.api.akka.route.handlers.JobRouteHandler;
+import io.mantisrx.master.jobcluster.proto.BaseResponse;
+import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
+import io.mantisrx.master.utils.ApiRequestRateLimiter;
+import io.mantisrx.server.master.config.ConfigurationProvider;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Covers the admission control on the v1 job-creation endpoints. All three are wired to the route's
+ * single {@link ApiRequestRateLimiter}, so a storm on any one of them is capped by the same bucket.
+ */
+public class JobsRouteThrottleTest extends JUnitRouteTest {
+
+    private static final String SUBMIT_ENDPOINT = "/api/v1/jobs";
+    private static final String CLUSTER_SUBMIT_ENDPOINT =
+            "/api/v1/jobClusters/" + JobClusterPayloads.CLUSTER_NAME + "/jobs";
+    private static final String QUICK_SUBMIT_ENDPOINT = "/api/v1/jobs/actions/quickSubmit";
+
+    private final JobClusterRouteHandler clusterRouteHandler = mock(JobClusterRouteHandler.class);
+    private final JobRouteHandler jobRouteHandler = mock(JobRouteHandler.class);
+
+    @BeforeClass
+    public static void init() {
+        TestHelpers.setupMasterConfig();
+    }
+
+    private TestRoute routeWith(ApiRequestRateLimiter rateLimiter) {
+        return testRoute(
+                new JobsRoute(clusterRouteHandler, jobRouteHandler, system(), rateLimiter)
+                        .createRoute(route -> route));
+    }
+
+    /** A limiter that sheds everything, i.e. the bucket is permanently empty. */
+    private static ApiRequestRateLimiter denyAll() {
+        return request -> false;
+    }
+
+    private static HttpRequest post(String uri, String payload) {
+        return HttpRequest.POST(uri)
+                .withEntity(HttpEntities.create(ContentTypes.APPLICATION_JSON, payload));
+    }
+
+    @Test
+    public void throttledJobSubmitIsRejectedWithTooManyRequests() {
+        routeWith(denyAll())
+                .run(post(SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+
+        // The point of shedding before unmarshalling: the storm never reaches the cluster actor.
+        verifyNoInteractions(clusterRouteHandler, jobRouteHandler);
+    }
+
+    @Test
+    public void throttledClusterJobSubmitIsRejectedWithTooManyRequests() {
+        routeWith(denyAll())
+                .run(post(CLUSTER_SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+
+        verifyNoInteractions(clusterRouteHandler, jobRouteHandler);
+    }
+
+    @Test
+    public void throttledQuickSubmitIsRejectedWithTooManyRequests() {
+        routeWith(denyAll())
+                .run(post(QUICK_SUBMIT_ENDPOINT, JobClusterPayloads.QUICK_SUBMIT))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+
+        verifyNoInteractions(clusterRouteHandler, jobRouteHandler);
+    }
+
+    @Test
+    public void malformedBodyIsStillThrottled() {
+        // Shedding happens before the entity is parsed, so even a request we would have rejected as a
+        // 400 costs only a rate-limiter check.
+        routeWith(denyAll())
+                .run(post(SUBMIT_ENDPOINT, "not json"))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+    }
+
+    /**
+     * The reads and the per-job actions on this route are deliberately not wrapped: only the creation
+     * path drives a backlog on the shared cluster actor. A limiter that shed everything must therefore
+     * still leave them reachable, or enabling the throttle would take down job monitoring with it.
+     */
+    @Test
+    public void unguardedEndpointsAreNotThrottled() {
+        when(jobRouteHandler.getJobDetails(any()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new JobClusterManagerProto.GetJobDetailsResponse(
+                                1L, BaseResponse.ResponseCode.CLIENT_ERROR_NOT_FOUND, "nope",
+                                Optional.empty())));
+
+        routeWith(denyAll())
+                .run(HttpRequest.GET(SUBMIT_ENDPOINT + "/" + JobClusterPayloads.CLUSTER_NAME + "-1"));
+
+        // Reaching the handler is the assertion: a throttled read would have been answered with a 429
+        // before the handler was ever consulted.
+        verify(jobRouteHandler).getJobDetails(any());
+    }
+
+    @Test
+    public void admittedJobSubmitReachesTheHandler() {
+        when(clusterRouteHandler.submit(any()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new JobClusterManagerProto.SubmitJobResponse(
+                                1L, BaseResponse.ResponseCode.CLIENT_ERROR, "nope", Optional.empty())));
+
+        routeWith(ApiRequestRateLimiter.UNLIMITED)
+                .run(post(CLUSTER_SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT));
+
+        // Reaching the handler at all is the assertion: whatever the handler then answers is the
+        // existing submit behaviour, covered by JobsRouteTest.
+        verify(clusterRouteHandler).submit(any());
+    }
+
+    /**
+     * The throttle is opt-in, so an operator who has not enabled it must see no behaviour change at
+     * all. {@code MasterApiAkkaService} reads this flag to decide whether to build a limiter.
+     */
+    @Test
+    public void throttleIsDisabledByDefault() {
+        assertFalse(ConfigurationProvider.getConfig().isApiV1JobsThrottleEnabled());
+    }
+
+    /**
+     * Guards against the limiter being consulted once when the route tree is built rather than on
+     * every request — a mistake that would leave the endpoint either permanently open or permanently
+     * shut after the first call.
+     */
+    @Test
+    public void limiterIsConsultedOnEveryRequest() {
+        AtomicInteger calls = new AtomicInteger();
+        // Admits the first request, sheds every one after it.
+        TestRoute route = routeWith(request -> calls.getAndIncrement() == 0);
+
+        when(clusterRouteHandler.submit(any()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new JobClusterManagerProto.SubmitJobResponse(
+                                1L, BaseResponse.ResponseCode.CLIENT_ERROR, "nope", Optional.empty())));
+
+        HttpRequest request = post(CLUSTER_SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT);
+
+        route.run(request);
+        route.run(request).assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+        route.run(request).assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+
+        assertEquals(3, calls.get());
+        // Only the first request got through, so the limiter is not being short-circuited either way.
+        verify(clusterRouteHandler, times(1)).submit(any());
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteThrottleTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/JobsRouteThrottleTest.java
@@ -18,6 +18,8 @@ package io.mantisrx.master.api.akka.route.v1;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -28,9 +30,12 @@ import static org.mockito.Mockito.when;
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.HttpEntities;
 import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.MediaTypes;
 import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.model.headers.RetryAfter;
 import akka.http.javadsl.testkit.JUnitRouteTest;
 import akka.http.javadsl.testkit.TestRoute;
+import akka.http.javadsl.testkit.TestRouteResult;
 import com.netflix.mantis.master.scheduler.TestHelpers;
 import io.mantisrx.master.api.akka.payloads.JobClusterPayloads;
 import io.mantisrx.master.api.akka.route.handlers.JobClusterRouteHandler;
@@ -39,6 +44,9 @@ import io.mantisrx.master.jobcluster.proto.BaseResponse;
 import io.mantisrx.master.jobcluster.proto.JobClusterManagerProto;
 import io.mantisrx.master.utils.ApiRequestRateLimiter;
 import io.mantisrx.server.master.config.ConfigurationProvider;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.JsonNode;
+import io.mantisrx.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,6 +56,14 @@ import org.junit.Test;
 /**
  * Covers the admission control on the v1 job-creation endpoints. All three are wired to the route's
  * single {@link ApiRequestRateLimiter}, so a storm on any one of them is capped by the same bucket.
+ *
+ * <p>The shed counters are not asserted on by value, and deliberately so: both metric singletons bind to
+ * whichever registry {@code SpectatorRegistryFactory} holds when they are first touched, that factory
+ * takes a registry once per JVM, and this module runs its whole suite in one JVM with no {@code forkEvery}
+ * — so what a counter reads depends on which test class ran first. An assertion on the value would pass or
+ * fail on test ordering rather than on this code. What is worth guarding does not need one: the endpoint
+ * names are validated against a closed set and an unlisted one throws on the shed path, so the 429
+ * assertions below are what stand between a bad endpoint constant and a 500 during a storm.
  */
 public class JobsRouteThrottleTest extends JUnitRouteTest {
 
@@ -75,6 +91,24 @@ public class JobsRouteThrottleTest extends JUnitRouteTest {
         return request -> false;
     }
 
+    /**
+     * Sheds everything and advertises {@code retryAfter}. A value the route layer could not have invented
+     * on its own, so a passing assertion shows the hint came from the limiter rather than a constant.
+     */
+    private static ApiRequestRateLimiter denyAllRetryingAfter(Duration retryAfter) {
+        return new ApiRequestRateLimiter() {
+            @Override
+            public boolean tryAcquire(HttpRequest request) {
+                return false;
+            }
+
+            @Override
+            public Duration getRetryAfter(HttpRequest request) {
+                return retryAfter;
+            }
+        };
+    }
+
     private static HttpRequest post(String uri, String payload) {
         return HttpRequest.POST(uri)
                 .withEntity(HttpEntities.create(ContentTypes.APPLICATION_JSON, payload));
@@ -88,6 +122,115 @@ public class JobsRouteThrottleTest extends JUnitRouteTest {
 
         // The point of shedding before unmarshalling: the storm never reaches the cluster actor.
         verifyNoInteractions(clusterRouteHandler, jobRouteHandler);
+    }
+
+    /**
+     * A 429 with no {@code Retry-After} leaves a client guessing when to come back, which in practice
+     * means immediately. The header is the machine-readable half of the answer.
+     */
+    @Test
+    public void throttledResponseCarriesRetryAfterFromTheLimiter() {
+        TestRouteResult response = routeWith(denyAllRetryingAfter(Duration.ofSeconds(7)))
+                .run(post(SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+
+        // Asserted via the parsed header rather than the raw string: the point is that clients see a
+        // well-formed Retry-After, and that the value is the limiter's rather than a constant.
+        RetryAfter retryAfter = response.header(RetryAfter.class);
+        assertNotNull("429 must carry a Retry-After header", retryAfter);
+        assertEquals(Optional.of(7L), retryAfter.getDelaySeconds());
+    }
+
+    /**
+     * {@code Retry-After} also admits an HTTP-date, and a sub-second hint would round to 0 — "retry now",
+     * the opposite of shedding. Both are guarded by flooring the header at one second.
+     */
+    @Test
+    public void subSecondRetryAfterIsFlooredToOneSecond() {
+        TestRouteResult response = routeWith(denyAllRetryingAfter(Duration.ofMillis(200)))
+                .run(post(SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+
+        assertEquals(Optional.of(1L), response.header(RetryAfter.class).getDelaySeconds());
+    }
+
+    /**
+     * Truncating 1.4s to 1s sends the caller back before the permit it was waiting for exists, so a hint
+     * that does not land on a whole second rounds up. The cost of being a fraction of a second late is a
+     * fraction of a second; the cost of being early is another shed request.
+     */
+    @Test
+    public void fractionalRetryAfterIsRoundedUp() {
+        TestRouteResult response = routeWith(denyAllRetryingAfter(Duration.ofMillis(1400)))
+                .run(post(SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+
+        assertEquals(Optional.of(2L), response.header(RetryAfter.class).getDelaySeconds());
+    }
+
+    /**
+     * A keyed limiter with a slowly refilling per-caller bucket can compute a hint measured in minutes.
+     * Handing that to a client on a submit path is an outage for them rather than useful advice, so the
+     * header is capped and they come back to a fresh decision instead.
+     */
+    @Test
+    public void implausiblyLongRetryAfterIsCapped() {
+        TestRouteResult response = routeWith(denyAllRetryingAfter(Duration.ofHours(1)))
+                .run(post(SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+
+        assertEquals(Optional.of(60L), response.header(RetryAfter.class).getDelaySeconds());
+    }
+
+    /**
+     * A keyed limiter cannot answer per caller unless it is told who the caller is, and the shed path is
+     * the one place the route layer has to hand it over. This pins that it does: the hint here is derived
+     * from the request, so a route layer that passed anything else could not produce it.
+     */
+    @Test
+    public void retryAfterIsAskedAboutTheRequestBeingShed() {
+        ApiRequestRateLimiter perCaller = new ApiRequestRateLimiter() {
+            @Override
+            public boolean tryAcquire(HttpRequest request) {
+                return false;
+            }
+
+            @Override
+            public Duration getRetryAfter(HttpRequest request) {
+                return Duration.ofSeconds(request.getUri().path().length());
+            }
+        };
+
+        TestRouteResult response = routeWith(perCaller)
+                .run(post(SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS);
+
+        assertEquals(
+                Optional.of((long) SUBMIT_ENDPOINT.length()),
+                response.header(RetryAfter.class).getDelaySeconds());
+    }
+
+    /**
+     * The header tells a client library what to do; the body tells the person reading a curl output why,
+     * in the same JSON envelope as every other error on these routes so nothing needs a special case.
+     */
+    @Test
+    public void throttledResponseBodyExplainsTheShed() throws Exception {
+        String body = routeWith(denyAllRetryingAfter(Duration.ofSeconds(7)))
+                .run(post(SUBMIT_ENDPOINT, JobClusterPayloads.JOB_CLUSTER_SUBMIT))
+                .assertStatusCode(StatusCodes.TOO_MANY_REQUESTS)
+                .assertMediaType(MediaTypes.APPLICATION_JSON)
+                .entityString();
+
+        JsonNode error = new ObjectMapper().readTree(body).get("error");
+        assertNotNull("throttle body must use the standard failure envelope", error);
+        String message = error.asText();
+        // The endpoint, because a bare 429 does not say which of a client's calls was shed; the delay,
+        // because the body is what a human reads; and the backoff advice, because every shed caller is
+        // handed the same number and retrying in lockstep just reproduces the storm.
+        assertTrue("should name the shed endpoint, was: " + message, message.contains(SUBMIT_ENDPOINT));
+        assertTrue("should state the delay, was: " + message, message.contains("7 second(s)"));
+        assertTrue("should ask for jitter, was: " + message, message.contains("jitter"));
     }
 
     @Test

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorReconnectionIntegrationTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/resourcecluster/TaskExecutorReconnectionIntegrationTest.java
@@ -102,6 +102,7 @@ public class TaskExecutorReconnectionIntegrationTest {
     private JobMessageRouter jobMessageRouter;
     private ActorRef resourceClusterActor;
     private ResourceCluster resourceCluster;
+    private TaskExecutorRegistration registration;
     private final MantisPropertiesLoader propertiesLoader =
         new DefaultMantisPropertiesLoader(System.getProperties());
 
@@ -116,13 +117,21 @@ public class TaskExecutorReconnectionIntegrationTest {
         when(gateway.submitTask(any()))
             .thenReturn(CompletableFuture.completedFuture(Ack.getInstance()));
 
-        // Setup required mocks for the MantisJobStore
+        // Setup required mocks for the MantisJobStore. All stubbing has to happen before the actor is
+        // created below: once it is, its preStart and the async disabled-executor load call into this
+        // same mock from other threads, and Mockito's stubbing state is not thread safe. A concurrent
+        // invocation lands on the pending doReturn() and gets stubbed instead of the intended method,
+        // which kills the actor in preStart and leaves later asks to time out.
+        registration = createRegistration(TASK_EXECUTOR_ID);
         doReturn(ImmutableList.of())
             .when(mantisJobStore)
             .loadAllDisableTaskExecutorsRequests(CLUSTER_ID);
         doReturn(ImmutableList.of())
             .when(mantisJobStore)
             .getJobArtifactsToCache(CLUSTER_ID);
+        doReturn(registration)
+            .when(mantisJobStore)
+            .getTaskExecutor(TASK_EXECUTOR_ID);
 
         MasterConfiguration masterConfig = mock(MasterConfiguration.class);
         when(masterConfig.getTimeoutSecondsToReportStart()).thenReturn(1);
@@ -154,6 +163,9 @@ public class TaskExecutorReconnectionIntegrationTest {
                 Duration.ofSeconds(15),
                 CLUSTER_ID,
                 new LongDynamicProperty(propertiesLoader, "resourcecluster.gateway.maxConcurrentRequests.test", 100000L));
+
+        // Round trip through the actor so the test body only starts once preStart has completed.
+        resourceCluster.getRegisteredTaskExecutors().get();
     }
 
     @After
@@ -189,9 +201,6 @@ public class TaskExecutorReconnectionIntegrationTest {
             // Test basic TaskExecutor lifecycle without crash scenarios
             // This ensures the test setup is working correctly
 
-            TaskExecutorRegistration registration = createRegistration(TASK_EXECUTOR_ID);
-            doReturn(registration).when(mantisJobStore).getTaskExecutor(TASK_EXECUTOR_ID);
-
             // Register TaskExecutor
             assertEquals(Ack.getInstance(), resourceCluster.registerTaskExecutor(registration).get());
 
@@ -220,9 +229,6 @@ public class TaskExecutorReconnectionIntegrationTest {
         new TestKit(actorSystem) {{
             // Test scenario where TaskExecutor crashes (like segfault) without sending
             // an explicit disconnection event, but is detected through heartbeat state mismatch
-
-            TaskExecutorRegistration registration = createRegistration(TASK_EXECUTOR_ID);
-            doReturn(registration).when(mantisJobStore).getTaskExecutor(TASK_EXECUTOR_ID);
 
             // Step 1: Register and setup TaskExecutor with a running worker
             assertEquals(Ack.getInstance(), resourceCluster.registerTaskExecutor(registration).get());

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/utils/ApiRequestRateLimiterFactoryTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/utils/ApiRequestRateLimiterFactoryTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import akka.http.javadsl.model.HttpRequest;
+import io.mantisrx.common.properties.MantisPropertiesLoader;
+import io.mantisrx.server.master.config.MasterConfiguration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+
+public class ApiRequestRateLimiterFactoryTest {
+
+    /** The key {@code @Config} puts on the accessor {@link ApiRequestRateLimiterFactory#v1Jobs()} reads. */
+    private static final String PERMITS_PROPERTY = "mantis.master.api.v1.jobs.throttle.permitsPerSecond";
+
+    private static final HttpRequest REQUEST = HttpRequest.POST("/api/v1/jobs");
+
+    /** Records what was looked up, so a test can assert a disabled route resolves no property. */
+    private static class RecordingLoader implements MantisPropertiesLoader {
+        private final Map<String, String> overrides = new HashMap<>();
+        private final Set<String> lookups = new HashSet<>();
+
+        @Override
+        public String getStringValue(String name, String defaultVal) {
+            lookups.add(name);
+            return overrides.getOrDefault(name, defaultVal);
+        }
+    }
+
+    private static MasterConfiguration configWithV1JobsThrottle(boolean enabled, int permitsPerSecond) {
+        MasterConfiguration config = mock(MasterConfiguration.class);
+        when(config.isApiV1JobsThrottleEnabled()).thenReturn(enabled);
+        when(config.getApiV1JobsThrottlePermitsPerSecond()).thenReturn(permitsPerSecond);
+        return config;
+    }
+
+    /**
+     * A route is one budget. Building it twice would hand out two independent limiters — doubling the
+     * effective rate — that report their sheds into a single time series, so the split would not even be
+     * visible. Every other guarantee here rests on this one: the accessor is the identity of the budget.
+     */
+    @Test
+    public void sameRouteYieldsTheSameLimiter() {
+        ApiRequestRateLimiterFactory factory = new ApiRequestRateLimiterFactory(
+            configWithV1JobsThrottle(true, 1000), new RecordingLoader());
+
+        assertSame(
+            factory.v1Jobs(),
+            factory.v1Jobs());
+    }
+
+    /**
+     * The throttle is opt-in, so a route left switched off must build nothing at all: no limiter, and no
+     * dynamic property quietly polling config on the request path.
+     */
+    @Test
+    public void disabledRouteYieldsUnlimitedAndResolvesNoProperty() {
+        RecordingLoader loader = new RecordingLoader();
+        ApiRequestRateLimiterFactory factory =
+            new ApiRequestRateLimiterFactory(configWithV1JobsThrottle(false, 1000), loader);
+
+        assertSame(ApiRequestRateLimiter.UNLIMITED, factory.v1Jobs());
+        assertFalse(loader.lookups.contains(PERMITS_PROPERTY));
+    }
+
+    /**
+     * The static config value sizes the limiter when nothing overrides it. One permit per second means it
+     * is empty immediately after the first request, which is what makes the rate observable without
+     * waiting on a clock.
+     */
+    @Test
+    public void limiterIsSizedFromTheConfiguredRate() {
+        ApiRequestRateLimiterFactory factory = new ApiRequestRateLimiterFactory(
+            configWithV1JobsThrottle(true, 1), new RecordingLoader());
+
+        ApiRequestRateLimiter limiter = factory.v1Jobs();
+
+        assertTrue(limiter.tryAcquire(REQUEST));
+        assertFalse(limiter.tryAcquire(REQUEST));
+    }
+
+    /**
+     * The accessor names a config method, and the property key is resolved by reflecting on that method's
+     * {@code @Config} annotation. This pins that wiring end to end: an override pushed under the
+     * annotated key has to reach the limiter, or re-tuning a limit mid-incident would silently do
+     * nothing. Overriding down to 1 permit is what distinguishes it from the configured 1000.
+     */
+    @Test
+    public void overriddenPropertyReachesTheLimiter() {
+        RecordingLoader loader = new RecordingLoader();
+        loader.overrides.put(PERMITS_PROPERTY, "1");
+        ApiRequestRateLimiterFactory factory =
+            new ApiRequestRateLimiterFactory(configWithV1JobsThrottle(true, 1000), loader);
+
+        ApiRequestRateLimiter limiter = factory.v1Jobs();
+
+        assertTrue(limiter.tryAcquire(REQUEST));
+        assertFalse(limiter.tryAcquire(REQUEST));
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/utils/ApiRequestRateLimiterFactoryTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/utils/ApiRequestRateLimiterFactoryTest.java
@@ -16,6 +16,7 @@
 
 package io.mantisrx.master.utils;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,9 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 
 public class ApiRequestRateLimiterFactoryTest {
@@ -119,5 +123,67 @@ public class ApiRequestRateLimiterFactoryTest {
 
         assertTrue(limiter.tryAcquire(REQUEST));
         assertFalse(limiter.tryAcquire(REQUEST));
+    }
+
+    /**
+     * The mechanism is the provider's to choose, so a deployment that supplies one must get its limiters
+     * back — not a global bucket built behind it. Denying everything is a mechanism no built-in has, which
+     * is what makes the substitution observable rather than merely asserted on identity.
+     */
+    @Test
+    public void substitutedProviderBacksTheRoute() {
+        ApiRequestRateLimiterFactory factory = new ApiRequestRateLimiterFactory(
+            configWithV1JobsThrottle(true, 1000),
+            new RecordingLoader(),
+            (route, permitsPerSecondDp, propertiesLoader) -> request -> false);
+
+        assertFalse(factory.v1Jobs().tryAcquire(REQUEST));
+    }
+
+    /**
+     * The caching this class exists for has to hold whatever the provider returns, not just the built-in:
+     * a provider called twice for one route is two budgets, and a keyed provider's would be two sets of
+     * per-caller buckets that each admit the configured rate. Counting the calls says that directly,
+     * where {@code assertSame} only says the second ask did not build something new.
+     */
+    @Test
+    public void providerIsInvokedOncePerRoute() {
+        AtomicInteger creations = new AtomicInteger();
+        ApiRequestRateLimiterFactory factory = new ApiRequestRateLimiterFactory(
+            configWithV1JobsThrottle(true, 1000),
+            new RecordingLoader(),
+            (route, permitsPerSecondDp, propertiesLoader) -> {
+                creations.incrementAndGet();
+                return request -> true;
+            });
+
+        assertSame(factory.v1Jobs(), factory.v1Jobs());
+        assertEquals(1, creations.get());
+    }
+
+    /**
+     * What the provider is handed is the whole of its input, and a provider that cannot see the route or
+     * its rate cannot size a bucket or tag a metric. The rate arrives as a dynamic property rather than a
+     * number so the provider's limiters can be re-tuned at runtime like the built-in's.
+     */
+    @Test
+    public void providerReceivesTheRouteAndItsConfiguredRate() {
+        RecordingLoader loader = new RecordingLoader();
+        AtomicReference<String> seenRoute = new AtomicReference<>();
+        AtomicLong seenRate = new AtomicLong();
+        ApiRequestRateLimiterFactory factory = new ApiRequestRateLimiterFactory(
+            configWithV1JobsThrottle(true, 1000),
+            loader,
+            (route, permitsPerSecondDp, propertiesLoader) -> {
+                seenRoute.set(route);
+                seenRate.set(permitsPerSecondDp.getValue());
+                assertSame(loader, propertiesLoader);
+                return request -> true;
+            });
+
+        factory.v1Jobs();
+
+        assertEquals("v1Jobs", seenRoute.get());
+        assertEquals(1000L, seenRate.get());
     }
 }

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/utils/GlobalApiRequestRateLimiterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/utils/GlobalApiRequestRateLimiterTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2024 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.mantisrx.master.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import akka.http.javadsl.model.HttpRequest;
+import io.mantisrx.common.properties.MantisPropertiesLoader;
+import io.mantisrx.config.dynamic.LongDynamicProperty;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class GlobalApiRequestRateLimiterTest {
+
+    private static final HttpRequest REQUEST = HttpRequest.POST("/api/v1/jobs");
+    private static final String PROPERTY = "test.permitsPerSecond";
+
+    /** A loader whose value an operator can change mid-test, standing in for a config push. */
+    private static class MutableLoader implements MantisPropertiesLoader {
+        private final Map<String, String> overrides = new HashMap<>();
+
+        void set(String key, String value) {
+            overrides.put(key, value);
+        }
+
+        @Override
+        public String getStringValue(String name, String defaultVal) {
+            return overrides.getOrDefault(name, defaultVal);
+        }
+    }
+
+    /** Lets a test jump past the dynamic property's refresh interval without sleeping through it. */
+    private static class MutableClock extends Clock {
+        private Instant now = Instant.parse("2024-01-01T00:00:00Z");
+
+        void advance(Duration amount) {
+            now = now.plus(amount);
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneId.of("UTC");
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return now;
+        }
+    }
+
+    private static LongDynamicProperty property(
+        MantisPropertiesLoader loader, long defaultValue, Clock clock) {
+        return new LongDynamicProperty(loader, PROPERTY, defaultValue, clock);
+    }
+
+    /**
+     * Guava's bucket starts empty and refills one permit per stable interval, so it does not hand out a
+     * second's worth of permits up front — at one permit per second the very next request has nothing to
+     * draw on. Worth knowing when picking a rate: a burst arriving back-to-back is shed even when it is
+     * far smaller than the per-second limit, so a caller that paces itself gets the full rate while one
+     * that fires everything at once does not. (A bucket left idle for a second does accumulate up to a
+     * second of permits, which is where burst allowance comes from.)
+     *
+     * <p>The rate is 1 rather than something production-sized on purpose: it puts the next permit a full
+     * second away, which is the only spacing this can assert without racing a JIT pause.
+     */
+    @Test
+    public void requestsBeyondTheRateAreShed() {
+        ApiRequestRateLimiter limiter = new GlobalApiRequestRateLimiter(
+            "shed", property(new MutableLoader(), 1L, Clock.systemUTC()));
+
+        assertTrue(limiter.tryAcquire(REQUEST));
+        assertFalse(limiter.tryAcquire(REQUEST));
+    }
+
+    /**
+     * The point of sizing the bucket with a {@link LongDynamicProperty}: an operator who finds the limit
+     * wrong mid-incident can re-tune it by pushing config, with no deploy and no restart. The property
+     * only re-reads itself once per refresh interval, hence the clock jump.
+     */
+    @Test
+    public void rateFollowsTheDynamicProperty() {
+        MutableLoader loader = new MutableLoader();
+        MutableClock clock = new MutableClock();
+        GlobalApiRequestRateLimiter limiter =
+            new GlobalApiRequestRateLimiter("retuned", property(loader, 10_000L, clock));
+
+        assertEquals(10_000d, limiter.getPermitsPerSecond(), 0d);
+
+        loader.set(PROPERTY, "25");
+        clock.advance(Duration.ofSeconds(31));
+        // The re-read is lazy, on the request path: nothing changes until a request arrives.
+        limiter.tryAcquire(REQUEST);
+
+        assertEquals(25d, limiter.getPermitsPerSecond(), 0d);
+    }
+
+    /**
+     * A stale read of the rate must not be re-applied on every subsequent request either — the property
+     * is only re-read once per refresh interval, so between refreshes the rate has to hold steady.
+     */
+    @Test
+    public void rateHoldsSteadyBetweenRefreshes() {
+        MutableLoader loader = new MutableLoader();
+        MutableClock clock = new MutableClock();
+        GlobalApiRequestRateLimiter limiter =
+            new GlobalApiRequestRateLimiter("steady", property(loader, 500L, clock));
+
+        loader.set(PROPERTY, "25");
+        clock.advance(Duration.ofSeconds(5));
+        limiter.tryAcquire(REQUEST);
+
+        assertEquals(500d, limiter.getPermitsPerSecond(), 0d);
+    }
+
+    /**
+     * Two limiters registering under the same {@code route} tag must not fail. The metrics registry
+     * de-duplicates by group id, so this is a no-op there — but if it ever threw instead, it would throw
+     * during startup wiring and take the master down rather than degrade a metric.
+     */
+    @Test
+    public void twoLimitersMayShareARouteLabel() {
+        ApiRequestRateLimiter first = new GlobalApiRequestRateLimiter(
+            "duplicate", property(new MutableLoader(), 1L, Clock.systemUTC()));
+        ApiRequestRateLimiter second = new GlobalApiRequestRateLimiter(
+            "duplicate", property(new MutableLoader(), 1L, Clock.systemUTC()));
+
+        // Each still owns its own bucket; only the counter they report into is shared.
+        assertTrue(first.tryAcquire(REQUEST));
+        assertFalse(first.tryAcquire(REQUEST));
+        assertTrue(second.tryAcquire(REQUEST));
+    }
+
+    /**
+     * The shed path increments a counter looked up at construction time. That path only runs when the
+     * system is already under stress, so an unregistered counter would surface as a 500 exactly when the
+     * throttle was supposed to be protecting the master.
+     */
+    @Test
+    public void sheddingDoesNotThrow() {
+        ApiRequestRateLimiter limiter = new GlobalApiRequestRateLimiter(
+            "counted", property(new MutableLoader(), 1L, Clock.systemUTC()));
+
+        for (int i = 0; i < 10; i++) {
+            limiter.tryAcquire(REQUEST);
+        }
+    }
+}

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/utils/GlobalApiRequestRateLimiterTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/utils/GlobalApiRequestRateLimiterTest.java
@@ -140,9 +140,9 @@ public class GlobalApiRequestRateLimiterTest {
     }
 
     /**
-     * Two limiters registering under the same {@code route} tag must not fail. The metrics registry
-     * de-duplicates by group id, so this is a no-op there — but if it ever threw instead, it would throw
-     * during startup wiring and take the master down rather than degrade a metric.
+     * The route label is a name, not an identity: two limiters sharing one must still be two buckets. The
+     * factory hands out one limiter per route, so this is not how they are built — but if the label ever
+     * became a lookup key, the second route would silently draw down the first route's budget.
      */
     @Test
     public void twoLimitersMayShareARouteLabel() {
@@ -151,24 +151,23 @@ public class GlobalApiRequestRateLimiterTest {
         ApiRequestRateLimiter second = new GlobalApiRequestRateLimiter(
             "duplicate", property(new MutableLoader(), 1L, Clock.systemUTC()));
 
-        // Each still owns its own bucket; only the counter they report into is shared.
         assertTrue(first.tryAcquire(REQUEST));
         assertFalse(first.tryAcquire(REQUEST));
+        // Draining the first left the second untouched.
         assertTrue(second.tryAcquire(REQUEST));
     }
 
     /**
-     * The shed path increments a counter looked up at construction time. That path only runs when the
-     * system is already under stress, so an unregistered counter would surface as a 500 exactly when the
-     * throttle was supposed to be protecting the master.
+     * The {@code Retry-After} a shed caller is handed. One second holds across the whole configurable
+     * range because the rate is a whole number of permits per second, so the next permit is never more
+     * than a second out — this pins that reasoning to the two ends of the range, and would fail if the
+     * rate ever became fractional and made one second an underestimate.
      */
     @Test
-    public void sheddingDoesNotThrow() {
-        ApiRequestRateLimiter limiter = new GlobalApiRequestRateLimiter(
-            "counted", property(new MutableLoader(), 1L, Clock.systemUTC()));
-
-        for (int i = 0; i < 10; i++) {
-            limiter.tryAcquire(REQUEST);
-        }
+    public void retryAfterIsOneSecondAtAnyConfigurableRate() {
+        assertEquals(Duration.ofSeconds(1), new GlobalApiRequestRateLimiter(
+            "fast", property(new MutableLoader(), 10_000L, Clock.systemUTC())).getRetryAfter(REQUEST));
+        assertEquals(Duration.ofSeconds(1), new GlobalApiRequestRateLimiter(
+            "slow", property(new MutableLoader(), 1L, Clock.systemUTC())).getRetryAfter(REQUEST));
     }
 }


### PR DESCRIPTION
### What

Adds an opt-in, per route based bucket rate limit.For jobsRoute, add the rate limit in front of the three v1 job-creation endpoints:

- `POST /api/v1/jobs`
- `POST /api/v1/jobClusters/{cluster}/jobs`
- `POST /api/v1/jobs/actions/quickSubmit`

The rate

### Configuration

| Property | Default | Notes |
| --- | --- | --- |
| `mantis.master.api.v1.submitJob.throttle.enabled` | `false` | Off by default; no limiter is constructed when off |
| `mantis.master.api.v1.submitJob.permitsPerSecond` | `1000` | Re-readable at runtime, no deploy needed |

- Guava RateLimiter, non-blocking tryAcquire(); token-bucket with the usual ~1s of burst accumulation, so a 1000/s limit admits up to a ~1000-request burst after an idle period.
- Shed → HTTP 429, checked in BaseRoute.withThrottle:141 before the entity is unmarshalled — a storm costs a permit check, not a parse plus an actor ask.

Off by default because the right ceiling depends on cluster size and traffic —
operators opt in once they've measured their own submit rate. The rate is backed by a
`LongDynamicProperty`, so it re-reads on the dynamic-property refresh interval
(`mantis.config.dynamic.refreshSecs`, default 30s).

### Metrics

`MasterApiMetrics/throttledRequestCount` gains a `source` tag (`submitJob`,
`resourceCluster`), so an operator can tell which limit is shedding. Previously the
route-level throttle and the resource-cluster gateway's `RequestThrottledException`
both incremented the same untagged counter.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
