### PR TITLE
Remove unused MOA dependency from mantis-runtime-autoscaler-api

### DIFF
--- a/mantis-examples/mantis-examples-sine-function/dependencies.lock
+++ b/mantis-examples/mantis-examples-sine-function/dependencies.lock
@@ -410,17 +410,11 @@
             ],
             "locked": "0.27ea0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-runtime-executor"
-            ],
-            "locked": "2017.06"
-        },
         "org.apache.commons:commons-math3": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-rxcontrol"
             ],
-            "locked": "3.6.1"
+            "locked": "3.5"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -901,17 +895,11 @@
             ],
             "locked": "0.27ea0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-runtime-executor"
-            ],
-            "locked": "2017.06"
-        },
         "org.apache.commons:commons-math3": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-rxcontrol"
             ],
-            "locked": "3.6.1"
+            "locked": "3.5"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [

--- a/mantis-runtime-autoscaler-api/build.gradle
+++ b/mantis-runtime-autoscaler-api/build.gradle
@@ -22,10 +22,6 @@ dependencies {
     api project(":mantis-rxcontrol")
 
     implementation libraries.vavr
-    implementation('nz.ac.waikato.cms.moa:moa:2017.06') {
-        exclude group: 'com.github.spullara.cli-parser', module: 'cli-parser'
-        exclude group: 'org.pentaho.pentaho-commons', module: 'pentaho-package-manager'
-    }
     implementation "com.yahoo.datasketches:sketches-core:0.9.1"
 
     implementation libraries.slf4jApi

--- a/mantis-runtime-autoscaler-api/dependencies.lock
+++ b/mantis-runtime-autoscaler-api/dependencies.lock
@@ -125,9 +125,6 @@
             ],
             "locked": "2.14.0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "locked": "2017.06"
-        },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -377,14 +374,11 @@
             ],
             "locked": "0.27ea0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "locked": "2017.06"
-        },
         "org.apache.commons:commons-math3": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-rxcontrol"
             ],
-            "locked": "3.6.1"
+            "locked": "3.5"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -584,9 +578,6 @@
         },
         "junit:junit-dep": {
             "locked": "4.11"
-        },
-        "nz.ac.waikato.cms.moa:moa": {
-            "locked": "2017.06"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -846,14 +837,11 @@
             ],
             "locked": "0.27ea0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "locked": "2017.06"
-        },
         "org.apache.commons:commons-math3": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-rxcontrol"
             ],
-            "locked": "3.6.1"
+            "locked": "3.5"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [

--- a/mantis-runtime-autoscaler-api/src/main/java/io/mantisrx/server/worker/jobmaster/clutch/ClutchAutoScaler.java
+++ b/mantis-runtime-autoscaler-api/src/main/java/io/mantisrx/server/worker/jobmaster/clutch/ClutchAutoScaler.java
@@ -20,7 +20,6 @@ import static io.mantisrx.runtime.descriptor.StageScalingPolicy.ScalingReason.CP
 import static io.mantisrx.runtime.descriptor.StageScalingPolicy.ScalingReason.JVMMemory;
 import static io.mantisrx.runtime.descriptor.StageScalingPolicy.ScalingReason.Network;
 
-import com.yahoo.labs.samoa.instances.Attribute;
 import io.mantisrx.runtime.descriptor.StageScalingPolicy;
 import io.mantisrx.server.worker.jobmaster.JobAutoScaler;
 import io.mantisrx.server.worker.jobmaster.control.actuators.ClutchMantisStageActuator;
@@ -34,7 +33,6 @@ import io.vavr.Tuple;
 import io.vavr.Tuple3;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
-import moa.core.FastVector;
 import org.slf4j.Logger;
 import rx.Observable;
 
@@ -50,16 +48,6 @@ public class ClutchAutoScaler implements Observable.Transformer<JobAutoScaler.Ev
 
     private static final Logger log = org.slf4j.LoggerFactory.getLogger(ClutchAutoScaler.class);
     private static final String autoscaleLogMessageFormat = "Autoscaling stage %d to %d instances on controller output: cpu/mem/network %f/%f/%f (dampening: %f) and predicted error: %f with dominant resource: %s";
-    private static final FastVector attributes = new FastVector();
-
-    static {
-        attributes.add(new Attribute("cpu"));
-        attributes.add(new Attribute("memory"));
-        attributes.add(new Attribute("network"));
-        attributes.add(new Attribute("minuteofday"));
-        attributes.add(new Attribute("scale"));
-        attributes.add(new Attribute("error"));
-    }
 
     private final JobAutoScaler.StageScaler scaler;
     private final long initialSize;

--- a/mantis-runtime-executor/build.gradle
+++ b/mantis-runtime-executor/build.gradle
@@ -33,10 +33,6 @@ dependencies {
     testImplementation project(":mantis-jm-akka")
     testImplementation "com.yahoo.datasketches:sketches-core:0.9.1"
     testImplementation libraries.vavr
-    testImplementation('nz.ac.waikato.cms.moa:moa:2017.06') {
-        exclude group: 'com.github.spullara.cli-parser', module: 'cli-parser'
-        exclude group: 'org.pentaho.pentaho-commons', module: 'pentaho-package-manager'
-    }
 
     testImplementation libraries.akkaTest
     testImplementation libraries.junit4

--- a/mantis-runtime-executor/dependencies.lock
+++ b/mantis-runtime-executor/dependencies.lock
@@ -129,9 +129,6 @@
             ],
             "locked": "2.13.0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "locked": "2017.06"
-        },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-control-plane-core"
@@ -389,14 +386,11 @@
             ],
             "locked": "0.27ea0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "locked": "2017.06"
-        },
         "org.apache.commons:commons-math3": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-rxcontrol"
             ],
-            "locked": "3.6.1"
+            "locked": "3.5"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -606,9 +600,6 @@
         },
         "junit:junit-dep": {
             "locked": "4.11"
-        },
-        "nz.ac.waikato.cms.moa:moa": {
-            "locked": "2017.06"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -879,14 +870,11 @@
             ],
             "locked": "0.27ea0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "locked": "2017.06"
-        },
         "org.apache.commons:commons-math3": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-rxcontrol"
             ],
-            "locked": "3.6.1"
+            "locked": "3.5"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [

--- a/mantis-server/mantis-server-agent/dependencies.lock
+++ b/mantis-server/mantis-server-agent/dependencies.lock
@@ -895,17 +895,11 @@
             ],
             "locked": "0.27ea0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-runtime-executor"
-            ],
-            "locked": "2017.06"
-        },
         "org.apache.commons:commons-math3": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-rxcontrol"
             ],
-            "locked": "3.6.1"
+            "locked": "3.5"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [

--- a/mantis-source-jobs/mantis-source-job-publish/dependencies.lock
+++ b/mantis-source-jobs/mantis-source-job-publish/dependencies.lock
@@ -491,17 +491,11 @@
             ],
             "locked": "0.27ea0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-runtime-executor"
-            ],
-            "locked": "2017.06"
-        },
         "org.apache.commons:commons-math3": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-rxcontrol"
             ],
-            "locked": "3.6.1"
+            "locked": "3.5"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [
@@ -1077,17 +1071,11 @@
             ],
             "locked": "0.27ea0"
         },
-        "nz.ac.waikato.cms.moa:moa": {
-            "firstLevelTransitive": [
-                "io.mantisrx:mantis-runtime-executor"
-            ],
-            "locked": "2017.06"
-        },
         "org.apache.commons:commons-math3": {
             "firstLevelTransitive": [
                 "io.mantisrx:mantis-rxcontrol"
             ],
-            "locked": "3.6.1"
+            "locked": "3.5"
         },
         "org.apache.flink:flink-core": {
             "firstLevelTransitive": [


### PR DESCRIPTION
ClutchAutoScaler declared a private static `attributes` FastVector that was populated in a static initializer and then never read. It was the only production use of nz.ac.waikato.cms.moa:moa, a GPL-3.0 library pulled into the runtime classpath of an Apache-2.0 project.

Because the field was initialized in a static block, MOA was a hard class-loading requirement at runtime despite being functionally dead — any classpath in which it was absent would have failed with ExceptionInInitializerError rather than degrading gracefully.

Removes the field, its static initializer, the two imports, and the dependency declarations. The GPL closure this drops is larger than the single coordinate suggests: moa transitively brought in weka-dev, meka (GPL), java-cup, jama, sizeofag and trove4j (LGPL-2.1).

Also removes the `testImplementation` MOA declaration in mantis-runtime-executor, which existed only to satisfy that same static initializer during tests.

Lockfile changes are limited to the two effects of this removal:
  - the 13 `nz.ac.waikato.cms.moa:moa` entries are dropped
  - org.apache.commons:commons-math3 converges 3.6.1 -> 3.5 in 9 configs

The commons-math3 change is a correction, not a regression: 3.5 is the version this project declares (`versions.commons` in build.gradle) and supplies via mantis-rxcontrol. MOA had been silently forcing 3.6.1 onto every downstream consumer. Both APIs in use — DescriptiveStatistics and Precision — are present in 3.5.

Verified: `build` (including `test` and `check`) passes for all five affected modules, and no waikato/weka/meka/sizeofag/trove4j/java-cup artifact remains on any resolved classpath.

