### PR TITLE
Validate active job pagination parameters

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/api/akka/route/v1/ResourceClustersNonLeaderRedirectRoute.java
@@ -292,13 +292,42 @@ public class ResourceClustersNonLeaderRedirectRoute extends BaseRoute {
         return withFuture(gateway.listActiveClusters());
     }
 
-    private Route getActiveJobOverview(ClusterID clusterID, Optional<String> startingIndex,
+    private Route getActiveJobOverview(
+        ClusterID clusterID,
+        Optional<String> startingIndex,
         Optional<String> pageSize) {
-        CompletableFuture<PagedActiveJobOverview> jobsOverview =
-            gateway.getClusterFor(clusterID).getActiveJobOverview(
-                startingIndex.map(Integer::parseInt),
-                pageSize.map(Integer::parseInt));
-        return withFuture(jobsOverview);
+
+        Optional<Integer> parsedStartingIndex =
+            parseNonNegativeInteger(startingIndex);
+        Optional<Integer> parsedPageSize =
+            parseNonNegativeInteger(pageSize);
+
+        return validate(
+            () -> startingIndex.isEmpty() || parsedStartingIndex.isPresent(),
+            "startingIndex must be a non-negative integer",
+            () -> validate(
+                () -> pageSize.isEmpty() || parsedPageSize.isPresent(),
+                "pageSize must be a non-negative integer",
+                () -> withFuture(
+                    gateway.getClusterFor(clusterID)
+                        .getActiveJobOverview(
+                            parsedStartingIndex,
+                            parsedPageSize))));
+    }
+
+    private Optional<Integer> parseNonNegativeInteger(
+        Optional<String> parameterValue) {
+
+        return parameterValue.flatMap(value -> {
+            try {
+                int parsedValue = Integer.parseInt(value);
+                return parsedValue >= 0
+                    ? Optional.of(parsedValue)
+                    : Optional.empty();
+            } catch (NumberFormatException exception) {
+                return Optional.empty();
+            }
+        });
     }
 
     private Route getResourceOverview(ClusterID clusterID) {

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/api/akka/route/v1/ResourceClusterNonLeaderRedirectRouteTest.java
@@ -82,6 +82,10 @@ import java.util.concurrent.CompletionStage;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.ArgumentMatchers;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import akka.http.javadsl.testkit.TestRouteResult;
 
 public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
     private static final UnitTestResourceProviderAdapter resourceProviderAdapter =
@@ -152,6 +156,7 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
         PagedActiveJobOverview overview1 = new PagedActiveJobOverview(ImmutableList.of(), 0);
         PagedActiveJobOverview overview2 = new PagedActiveJobOverview(ImmutableList.of("test"), 1);
         PagedActiveJobOverview overview3 = new PagedActiveJobOverview(ImmutableList.of("test"), 99);
+        PagedActiveJobOverview zeroPageSizeOverview = new PagedActiveJobOverview(ImmutableList.of("test"), 1);
 
         ResourceCluster resourceCluster = mock(ResourceCluster.class);
         when(resourceCluster.getActiveJobOverview(Optional.empty(), Optional.empty()))
@@ -161,6 +166,10 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
         when(resourceCluster.getActiveJobOverview(Optional.empty(), Optional.of(99)))
             .thenReturn(CompletableFuture.completedFuture(overview3));
         when(resourceClusters.getClusterFor(ClusterID.of("myCluster"))).thenReturn(resourceCluster);
+        when(resourceCluster.getActiveJobOverview(
+            Optional.of(0),
+            Optional.of(0)))
+            .thenReturn(CompletableFuture.completedFuture(zeroPageSizeOverview));
 
         testRouteWithNoopAdapter.run(HttpRequest.GET(
                 "/api/v1/resourceClusters/myCluster/activeJobOverview"))
@@ -176,6 +185,24 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
                 "/api/v1/resourceClusters/myCluster/activeJobOverview?pageSize=99"))
             .assertStatusCode(200)
             .assertEntityAs(Jackson.unmarshaller(PagedActiveJobOverview.class), overview3);
+
+        testRouteWithNoopAdapter.run(HttpRequest.GET(
+                "/api/v1/resourceClusters/myCluster/activeJobOverview"
+                    + "?startingIndex=0&pageSize=0"))
+            .assertStatusCode(StatusCodes.OK)
+            .assertEntityAs(
+                Jackson.unmarshaller(PagedActiveJobOverview.class),
+                zeroPageSizeOverview);
+    }
+
+    @Test
+    public void testGetActiveJobOverviewRejectsNegativeStartingIndex() {
+        testRouteWithNoopAdapter.run(HttpRequest.GET(
+                "/api/v1/resourceClusters/myCluster/activeJobOverview"
+                    + "?startingIndex=-1&pageSize=9"))
+            .assertStatusCode(StatusCodes.BAD_REQUEST);
+
+        verifyNoInteractions(resourceClusters);
     }
 
     @Test
@@ -400,6 +427,67 @@ public class ResourceClusterNonLeaderRedirectRouteTest extends JUnitRouteTest {
                     .optionalSkuId(createRuleReq1.getOptionalSkuId())
                     .optionalEnvType(createRuleReq1.getOptionalEnvType())
                     .build());
+    }
+
+    @Test
+    public void testGetActiveJobOverviewRejectsInvalidStartingIndex() {
+        assertInvalidActiveJobOverviewQuery(
+            "startingIndex=abc",
+            "startingIndex must be a non-negative integer");
+
+        assertInvalidActiveJobOverviewQuery(
+            "startingIndex=-1",
+            "startingIndex must be a non-negative integer");
+
+        assertInvalidActiveJobOverviewQuery(
+            "startingIndex=2147483648",
+            "startingIndex must be a non-negative integer");
+
+        assertInvalidActiveJobOverviewQuery(
+            "startingIndex=",
+            "startingIndex must be a non-negative integer");
+
+        verifyNoInteractions(resourceClusters);
+    }
+
+    @Test
+    public void testGetActiveJobOverviewRejectsInvalidPageSize() {
+        assertInvalidActiveJobOverviewQuery(
+            "pageSize=abc",
+            "pageSize must be a non-negative integer");
+
+        assertInvalidActiveJobOverviewQuery(
+            "pageSize=-1",
+            "pageSize must be a non-negative integer");
+
+        assertInvalidActiveJobOverviewQuery(
+            "pageSize=2147483648",
+            "pageSize must be a non-negative integer");
+
+        assertInvalidActiveJobOverviewQuery(
+            "pageSize=",
+            "pageSize must be a non-negative integer");
+
+        verifyNoInteractions(resourceClusters);
+    }
+
+    private void assertInvalidActiveJobOverviewQuery(
+        String query,
+        String expectedErrorMessage) {
+
+        TestRouteResult result = testRouteWithNoopAdapter.run(
+            HttpRequest.GET(
+                "/api/v1/resourceClusters/myCluster/activeJobOverview?"
+                    + query));
+
+        result.assertStatusCode(StatusCodes.BAD_REQUEST);
+
+        String responseBody = result.entityString();
+
+        assertTrue(
+            responseBody,
+            responseBody.contains(
+                "\"error\":\"" + expectedErrorMessage + "\""));
     }
 
     final String getResourceClusterEndpoint() {


### PR DESCRIPTION
### Context

The `activeJobOverview` endpoint accepts optional `startingIndex` and `pageSize` query parameters.

Previously, these values were converted directly using `Integer.parseInt`. Invalid values such as negative integers, non-numeric strings, empty values, or values exceeding the integer range could either be passed to the resource-cluster layer or result in an internal server error.

This change validates both pagination parameters before invoking the underlying service.

Invalid values now return `400 Bad Request` with a clear error message:

* `startingIndex must be a non-negative integer`
* `pageSize must be a non-negative integer`

The change also preserves `pageSize=0` as a valid value.

### Changes

* Added validation for `startingIndex` and `pageSize`.
* Rejected negative, non-numeric, empty, and overflowing integer values.
* Added clear client-facing validation messages.
* Added tests covering invalid pagination parameters.
* Added a regression test for a negative `startingIndex`.
* Added coverage confirming that `pageSize=0` remains valid.
* Verified that invalid requests do not reach the resource-cluster layer.

### Checklist

* [ ] `./gradlew build` compiles code correctly
* [x] Added new tests where applicable
* [ ] `./gradlew test` passes all tests
* [ ] Extended README or added javadocs where applicable

README and Javadoc changes are not applicable because this change only validates existing API parameters and does not introduce a new public API.
