### PR TITLE
Ensure JobClusterActor's logs always contain the clusterName

### DIFF
--- a/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/main/java/io/mantisrx/master/jobcluster/JobClusterActor.java
@@ -167,10 +167,13 @@ import javax.annotation.Nullable;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import rx.Observable;
 import rx.functions.Action1;
 import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
+import scala.PartialFunction;
+import scala.runtime.BoxedUnit;
 
 
 /**
@@ -185,6 +188,8 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
     private static final String BOOKKEEPING_TIMER_KEY = "JOB_CLUSTER_BOOKKEEPING";
     private static final Integer DEFAULT_LIMIT = 100;
     private static final Integer DEFAULT_ACTIVE_JOB_LIMIT = 5000;
+
+    private static final String MDC_KEY_CLUSTER_NAME = "clusterName";
 
     private final Logger logger = LoggerFactory.getLogger(JobClusterActor.class);
 
@@ -671,6 +676,24 @@ public class JobClusterActor extends AbstractActorWithTimers implements IJobClus
 
     MetricGroupId getMetricGroupId(String name) {
         return new MetricGroupId("JobClusterActor", new BasicTag("jobCluster", name));
+    }
+
+    /**
+     * Wraps every message this actor processes so that the cluster name is available via
+     * SLF4J's MDC for the duration of that message's handling. This lets every log line
+     * emitted while handling a message automatically include the cluster name (for logging
+     * backends that render MDC values, e.g. structured/JSON encoders, or a pattern layout
+     * with %X{clusterName}), instead of requiring each of this class's log call sites to pass
+     * `name` explicitly.
+     */
+    @Override
+    public void aroundReceive(PartialFunction<Object, BoxedUnit> receive, Object msg) {
+        MDC.put(MDC_KEY_CLUSTER_NAME, name);
+        try {
+            super.aroundReceive(receive, msg);
+        } finally {
+            MDC.remove(MDC_KEY_CLUSTER_NAME);
+        }
     }
 
     @Override

--- a/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
+++ b/mantis-control-plane/mantis-control-plane-server/src/test/java/io/mantisrx/master/jobcluster/JobClusterAkkaTest.java
@@ -64,8 +64,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import akka.actor.AbstractActor.Receive;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
+import akka.japi.pf.ReceiveBuilder;
+import akka.testkit.TestActorRef;
 import akka.testkit.javadsl.TestKit;
 import com.netflix.mantis.master.scheduler.TestHelpers;
 import com.typesafe.config.Config;
@@ -141,6 +144,7 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -150,6 +154,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
+import org.slf4j.MDC;
 import rx.schedulers.Schedulers;
 import rx.subjects.BehaviorSubject;
 
@@ -329,6 +334,34 @@ public class JobClusterAkkaTest {
     private JobDefinition createJob(String name2) throws InvalidJobException {
 
         return createJob(name2, 0, MantisJobDurationType.Perpetual, null);
+    }
+
+    // LOGGING TESTS ////////////////////////////////////////////////////////////////////////////////
+    @Test
+    public void testAroundReceivePutsClusterNameInMdcDuringMessageHandlingAndClearsItAfter() {
+        String clusterName = "mdcTestCluster";
+        MantisSchedulerFactory schedulerMockFactory = mock(MantisSchedulerFactory.class);
+
+        TestActorRef<JobClusterActor> actorRef = TestActorRef.create(
+            system,
+            props(clusterName, jobStore, schedulerMockFactory, eventPublisher, costsCalculator, 0));
+        JobClusterActor actor = actorRef.underlyingActor();
+
+        // Call aroundReceive directly (bypassing the mailbox/dispatcher) with a receive
+        // handler that captures the MDC value synchronously while "processing" the message,
+        // since MDC is thread-local and reading it from the test thread after the fact
+        // (post message-send) wouldn't observe the value set-and-cleared during handling.
+        AtomicReference<String> observedDuringProcessing = new AtomicReference<>();
+        Receive captureMdcReceive = ReceiveBuilder.create()
+            .matchAny(msg -> observedDuringProcessing.set(MDC.get("clusterName")))
+            .build();
+
+        actor.aroundReceive(captureMdcReceive.onMessage(), "any-test-message");
+
+        assertEquals("MDC should contain the cluster name while the actor is handling a message",
+            clusterName, observedDuringProcessing.get());
+        assertNull("MDC should be cleared once message handling completes",
+            MDC.get("clusterName"));
     }
 
     // CLUSTER CRUD TESTS ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Fixes #385 — log lines emitted from `JobClusterActor` didn't consistently include the cluster name, making it hard to trace a specific cluster's behavior in logs (~256 log call sites in this class, added ad-hoc over time, many without `name`).

**Approach:** rather than manually retrofitting every existing call site (tedious, easy to miss, and doesn't guard against new call sites forgetting it later), this overrides `aroundReceive` — the single method every message this actor processes passes through — to set the cluster name in SLF4J's MDC before delegating to the actual handler, and clear it in a `finally` block afterward. This makes the cluster name automatically available to every log line emitted anywhere during that message's handling, for any logging backend that renders MDC values (structured/JSON encoders, or a pattern layout with `%X{clusterName}`).

Verified `AbstractActorWithTimers.aroundReceive` (via the `Timers` trait) already delegates further up the chain to `AbstractActor.aroundReceive`, so calling `super.aroundReceive(receive, msg)` from the override preserves existing timer bookkeeping — confirmed by inspecting the actual Akka 2.6.15 `akka-actor` jar's bytecode rather than assuming the API shape.

## Test plan
- [x] New test `testAroundReceivePutsClusterNameInMdcDuringMessageHandlingAndClearsItAfter` in `JobClusterAkkaTest`. Since MDC is thread-local, it exercises `aroundReceive` directly via `TestActorRef` (bypassing the mailbox/dispatcher) with a receive handler that captures the MDC value synchronously during "processing," then asserts it matches the cluster name and is cleared afterward.
- [x] `akkaTest` task (this class's actual test task — this project splits `*AkkaTest` classes into a separate Gradle task from `test`): 58 passed (57 pre-existing + 1 new), 0 regressions
- [x] `test` task for the module: 358 passed, 0 regressions
- [x] `compileJava` clean, no new warnings on the modified file (verified against a stashed baseline)