### PR TITLE
Avoid copying every push batch into a fresh byte[]

### DIFF
--- a/mantis-network/build.gradle
+++ b/mantis-network/build.gradle
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath 'me.champeau.jmh:jmh-gradle-plugin:0.7.3'
+    }
+}
+
+// JMH microbenchmarks live in src/jmh. Run with: ./gradlew :mantis-network:jmh
+// or build the self-contained jar (./gradlew :mantis-network:jmhJar) and drive it with the
+// standard JMH CLI, which is the only way to vary -t (thread count).
+apply plugin: 'me.champeau.jmh'
+
 ext {
     mqlVersion = '3.4.+'
     nettyVersion = '4.1.17.Final'
@@ -30,8 +44,19 @@ dependencies {
     testImplementation libraries.junitJupiter
     testImplementation libraries.mockitoCore
     testImplementation libraries.slf4jLog4j12
+
+    // The benchmarks drive the routers and the push-server batch wrap directly, so they need the
+    // metrics implementation that main only compiles against.
+    jmhImplementation libraries.spectatorApi
 }
 
 test {
     useJUnitPlatform()
+}
+
+jmh {
+    jmhVersion = '1.37'
+    fork = 1
+    warmupIterations = 5
+    iterations = 5
 }

--- a/mantis-network/src/jmh/java/io/reactivex/mantis/network/push/PushServerBatchWrapBenchmark.java
+++ b/mantis-network/src/jmh/java/io/reactivex/mantis/network/push/PushServerBatchWrapBenchmark.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.mantis.network.push;
+
+import io.netty.buffer.ByteBuf;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Measures assembling one batch for the wire: {@link PushServer#wrapBare}/{@link
+ * PushServer#wrapDelimited} against the two-pass concatenation they replace.
+ *
+ * <p>{@code legacyBareVerbatim} and {@code legacyDelimitedVerbatim} are the <b>verbatim</b>
+ * pre-change bodies, copied out of git rather than reimplemented so the comparison cannot drift:
+ *
+ * <pre>
+ *   git show master:mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
+ * </pre>
+ *
+ * <p>Wrapping does not make bytes disappear, it moves who touches them, so measuring construction
+ * alone would flatter it. Each path therefore has a {@code ...Gathered} arm that also walks the
+ * finished buffer's {@link ByteBuf#nioBuffers() nioBuffers}, which is what the channel does on the
+ * way to a gathering write. The honest claim is the pair of numbers, not the construction one.
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class PushServerBatchWrapBenchmark {
+
+    /**
+     * Events in one 200ms window. 16 is Netty's default {@code maxNumComponents}, the silent
+     * consolidation threshold this change had to opt out of; 1024 is {@code
+     * MAX_WRAPPED_COMPONENTS}, above which the code deliberately falls back to concatenating; 2048
+     * exercises that fallback. The fleet average is tens of events.
+     */
+    @Param({"30", "200"})
+    public int events;
+
+    /** Serialized event size. Mantis events run from a few hundred bytes to several KB. */
+    @Param({"128", "256", "512", "1024", "2048", "4096", "16384"})
+    public int eventBytes;
+
+    private List<List<byte[]>> bufferOfBuffers;
+    private byte[] prefix;
+    private byte[] suffix;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        prefix = "data: ".getBytes();
+        suffix = new byte[]{'\n', '\n'};
+
+        // Shaped like the real thing: the batch arrives as a list of per-drain buffers, not one flat
+        // list. Several small inner lists rather than one big one, which is what the chunkers emit.
+        bufferOfBuffers = new ArrayList<>();
+        List<byte[]> inner = new ArrayList<>();
+        for (int i = 0; i < events; i++) {
+            byte[] event = new byte[eventBytes];
+            event[0] = (byte) i;
+            event[eventBytes - 1] = (byte) i;
+            inner.add(event);
+            if (inner.size() == 8) {
+                bufferOfBuffers.add(inner);
+                inner = new ArrayList<>();
+            }
+        }
+        if (!inner.isEmpty()) {
+            bufferOfBuffers.add(inner);
+        }
+
+        // The whole change is only legitimate if the bytes on the wire are unchanged, so assert that
+        // before measuring rather than trusting it.
+        assertSameBytes(PushServer.wrapBare(bufferOfBuffers, events), legacyBare());
+        assertSameBytes(PushServer.wrapDelimited(bufferOfBuffers, events, prefix, suffix),
+                legacyDelimited());
+    }
+
+    private static void assertSameBytes(ByteBuf actual, byte[] expected) {
+        try {
+            byte[] got = new byte[actual.readableBytes()];
+            actual.getBytes(actual.readerIndex(), got);
+            if (got.length != expected.length) {
+                throw new IllegalStateException(
+                        "length differs: " + got.length + " vs " + expected.length);
+            }
+            for (int i = 0; i < got.length; i++) {
+                if (got[i] != expected[i]) {
+                    throw new IllegalStateException("bytes differ at " + i);
+                }
+            }
+        } finally {
+            actual.release();
+        }
+    }
+
+    /**
+     * The pre-change non-SSE path, verbatim. Do not "clean this up" -- its only value is being
+     * byte-for-byte what shipped.
+     */
+    private byte[] legacyBare() {
+        int totalBytes = 0;
+        for (List<byte[]> buffer : bufferOfBuffers) {
+
+            for (byte[] data : buffer) {
+                totalBytes += (data.length);
+            }
+        }
+        byte[] block = new byte[totalBytes];
+        ByteBuffer blockBuffer = ByteBuffer.wrap(block);
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                blockBuffer.put(data);
+            }
+        }
+        return blockBuffer.array();
+    }
+
+    /** The pre-change uncompressed SSE path, verbatim. Same warning as above. */
+    private byte[] legacyDelimited() {
+        int totalBytes = 0;
+        for (List<byte[]> buffer : bufferOfBuffers) {
+
+            for (byte[] data : buffer) {
+                totalBytes += (data.length + prefix.length + suffix.length);
+            }
+        }
+        byte[] block = new byte[totalBytes];
+        ByteBuffer blockBuffer = ByteBuffer.wrap(block);
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                blockBuffer.put(prefix);
+                blockBuffer.put(data);
+                blockBuffer.put(suffix);
+            }
+        }
+        return blockBuffer.array();
+    }
+
+    /** Stands in for the channel resolving the buffer into an iovec array. */
+    private static int gather(ByteBuf buf) {
+        try {
+            int total = 0;
+            for (ByteBuffer nio : buf.nioBuffers()) {
+                total += nio.remaining();
+            }
+            return total;
+        } finally {
+            buf.release();
+        }
+    }
+
+    @Benchmark
+    public ByteBuf wrapBare() {
+        ByteBuf buf = PushServer.wrapBare(bufferOfBuffers, events);
+        buf.release();
+        return buf;
+    }
+
+    @Benchmark
+    public int wrapBareGathered() {
+        return gather(PushServer.wrapBare(bufferOfBuffers, events));
+    }
+
+    @Benchmark
+    public byte[] legacyBareVerbatim() {
+        return legacyBare();
+    }
+
+    @Benchmark
+    public ByteBuf wrapDelimited() {
+        ByteBuf buf = PushServer.wrapDelimited(bufferOfBuffers, events, prefix, suffix);
+        buf.release();
+        return buf;
+    }
+
+    @Benchmark
+    public int wrapDelimitedGathered() {
+        return gather(PushServer.wrapDelimited(bufferOfBuffers, events, prefix, suffix));
+    }
+
+    @Benchmark
+    public byte[] legacyDelimitedVerbatim() {
+        return legacyDelimited();
+    }
+}

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/LegacyTcpPipelineConfigurator.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/LegacyTcpPipelineConfigurator.java
@@ -17,6 +17,7 @@
 package io.reactivex.mantis.network.push;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -199,18 +200,18 @@ public class LegacyTcpPipelineConfigurator implements PipelineConfigurator<Remot
                               ChannelPromise promise) throws Exception {
 
                 if (ByteBuf.class.isAssignableFrom(msg.getClass())) {
-                    // handle data writes
+                    // handle data writes: prepend the header without copying the payload, which for
+                    // a push batch is on the order of half a megabyte.
                     ByteBuf bytes = (ByteBuf) msg;
-                    ByteBuf buf = ctx.alloc().buffer(bytes.readableBytes());
-                    writeHeader(buf, name);
-                    buf.writeBytes(bytes);
-                    bytes.release();
-                    super.write(ctx, buf, promise);
+                    ByteBuf header = ctx.alloc().buffer(headerSizeHint(name));
+                    writeHeader(header, name);
+                    super.write(ctx, Unpooled.wrappedBuffer(header, bytes), promise);
                 } else if (msg instanceof byte[]) {
                     // handle heart beat writes
-                    ByteBuf buf = ctx.alloc().buffer();
+                    byte[] bytes = (byte[]) msg;
+                    ByteBuf buf = ctx.alloc().buffer(headerSizeHint(name) + bytes.length);
                     writeHeader(buf, name);
-                    buf.writeBytes((byte[]) msg);
+                    buf.writeBytes(bytes);
                     super.write(ctx, buf, promise);
                     super.flush(ctx);
                 } else {
@@ -218,6 +219,15 @@ public class LegacyTcpPipelineConfigurator implements PipelineConfigurator<Remot
                 }
             }
         });
+    }
+
+    /**
+     * Size hint for the buffer {@link #writeHeader} fills: a version byte, a name-length byte, and
+     * the name itself. Only a hint — the buffer grows if it is wrong — but getting it right avoids a
+     * reallocation on every write.
+     */
+    private static int headerSizeHint(String name) {
+        return 2 + (name == null ? 0 : name.length());
     }
 
     private void writeHeader(ByteBuf buf, String name) {

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/PushServer.java
@@ -28,11 +28,13 @@ import io.mantisrx.common.metrics.Metrics;
 import io.mantisrx.common.metrics.MetricsRegistry;
 import io.mantisrx.common.metrics.spectator.MetricGroupId;
 import io.mantisrx.shaded.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.util.concurrent.GenericFutureListener;
 import io.reactivx.mantis.operators.DisableBackPressureOperator;
 import io.reactivx.mantis.operators.DropOperator;
-import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -335,7 +337,7 @@ public abstract class PushServer<T, R> {
                 .buffer(200, TimeUnit.MILLISECONDS)
                 .flatMap((List<List<byte[]>> bufferOfBuffers) -> {
                         if (bufferOfBuffers != null && !bufferOfBuffers.isEmpty()) {
-                            ByteBuffer blockBuffer = null;
+                            ByteBuf blockBuffer = null;
 
                             int size = 0;
                             for (List<byte[]> buffer : bufferOfBuffers) {
@@ -352,47 +354,16 @@ public abstract class PushServer<T, R> {
                                             ? CompressionUtils.compressAndBase64EncodeBytes(bufferOfBuffers, useSnappy)
                                             : CompressionUtils.compressAndBase64EncodeBytes(bufferOfBuffers, useSnappy, delimiter);
 
-                                        blockBuffer = ByteBuffer.allocate(prefix.length + compressedData.length + nwnw.length);
-                                        blockBuffer.put(prefix);
-                                        blockBuffer.put(compressedData);
-                                        blockBuffer.put(nwnw);
+                                        blockBuffer = wrap(prefix, compressedData, nwnw);
                                     } else {
-                                        int totalBytes = 0;
-                                        for (List<byte[]> buffer : bufferOfBuffers) {
-
-                                            for (byte[] data : buffer) {
-                                                totalBytes += (data.length + prefix.length + nwnw.length);
-                                            }
-                                        }
-                                        byte[] block = new byte[totalBytes];
-                                        blockBuffer = ByteBuffer.wrap(block);
-                                        for (List<byte[]> buffer : bufferOfBuffers) {
-                                            for (byte[] data : buffer) {
-                                                blockBuffer.put(prefix);
-                                                blockBuffer.put(data);
-                                                blockBuffer.put(nwnw);
-                                            }
-                                        }
+                                        blockBuffer = wrapDelimited(bufferOfBuffers, batchSize, prefix, nwnw);
                                     }
                                 } else {
-                                    int totalBytes = 0;
-                                    for (List<byte[]> buffer : bufferOfBuffers) {
-
-                                        for (byte[] data : buffer) {
-                                            totalBytes += (data.length);
-                                        }
-                                    }
-                                    byte[] block = new byte[totalBytes];
-                                    blockBuffer = ByteBuffer.wrap(block);
-                                    for (List<byte[]> buffer : bufferOfBuffers) {
-                                        for (byte[] data : buffer) {
-                                            blockBuffer.put(data);
-                                        }
-                                    }
+                                    blockBuffer = wrapBare(bufferOfBuffers, batchSize);
                                 }
                                 return
                                     writer
-                                        .writeBytesAndFlush(blockBuffer.array())
+                                        .writeBytesAndFlush(blockBuffer)
                                         .retry(writeRetryCount)
                                         .doOnError((Throwable t1) -> failedToWriteBatch(connection, batchSize, legacyDroppedWrites, metaMsgSubject))
                                         .doOnCompleted(() -> {
@@ -415,6 +386,100 @@ public abstract class PushServer<T, R> {
                         return Observable.empty();
                     }
                 );
+    }
+
+    /**
+     * Largest number of components a batch may be written as before it is concatenated instead.
+     *
+     * <p>A gathering write is capped at 1024 iovecs by the JDK, so past that point a composite
+     * buffer stops buying anything: the channel has to make several write syscalls regardless, and
+     * the per-component bookkeeping costs more than the copy it was avoiding. Batches that large are
+     * rare — the fleet average is tens of events per 200ms window — so this is a safety valve, not
+     * the common path.
+     */
+    static final int MAX_WRAPPED_COMPONENTS = 1024;
+
+    /**
+     * Presents {@code parts} as one logical buffer without copying their contents.
+     *
+     * <p>Note the explicit component count: {@link Unpooled#wrappedBuffer(byte[]...)} defaults to a
+     * limit of 16 and silently <em>consolidates</em> — that is, copies everything into one array —
+     * once a composite exceeds it, which would reintroduce exactly the copy this avoids.
+     */
+    static ByteBuf wrap(byte[]... parts) {
+        return Unpooled.wrappedBuffer(Math.max(parts.length, 1), parts);
+    }
+
+    /**
+     * Wraps every event in the batch back to back, as the non-SSE protocol frames them.
+     *
+     * @param events the event count already computed by the caller, used only to size the component
+     *               array; the actual components come from iterating the batch, so a stale count
+     *               cannot produce a short or padded buffer.
+     */
+    static ByteBuf wrapBare(List<List<byte[]>> bufferOfBuffers, int events) {
+        if (events > MAX_WRAPPED_COMPONENTS) {
+            return copyBare(bufferOfBuffers);
+        }
+        List<byte[]> parts = new ArrayList<>(events);
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            parts.addAll(buffer);
+        }
+        return wrap(parts.toArray(new byte[0][]));
+    }
+
+    /** Wraps every event in the batch surrounded by the SSE {@code prefix} and {@code suffix}. */
+    static ByteBuf wrapDelimited(List<List<byte[]>> bufferOfBuffers, int events,
+                                 byte[] prefix, byte[] suffix) {
+        if (events > MAX_WRAPPED_COMPONENTS / 3) {
+            return copyDelimited(bufferOfBuffers, prefix, suffix);
+        }
+        List<byte[]> parts = new ArrayList<>(events * 3);
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                parts.add(prefix);
+                parts.add(data);
+                parts.add(suffix);
+            }
+        }
+        return wrap(parts.toArray(new byte[0][]));
+    }
+
+    /** Concatenating fallback for {@link #wrapBare}; byte-for-byte identical output. */
+    static ByteBuf copyBare(List<List<byte[]>> bufferOfBuffers) {
+        int totalBytes = 0;
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                totalBytes += data.length;
+            }
+        }
+        ByteBuf block = Unpooled.buffer(totalBytes, totalBytes);
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                block.writeBytes(data);
+            }
+        }
+        return block;
+    }
+
+    /** Concatenating fallback for {@link #wrapDelimited}; byte-for-byte identical output. */
+    static ByteBuf copyDelimited(List<List<byte[]>> bufferOfBuffers,
+                                 byte[] prefix, byte[] suffix) {
+        int totalBytes = 0;
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                totalBytes += data.length + prefix.length + suffix.length;
+            }
+        }
+        ByteBuf block = Unpooled.buffer(totalBytes, totalBytes);
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                block.writeBytes(prefix);
+                block.writeBytes(data);
+                block.writeBytes(suffix);
+            }
+        }
+        return block;
     }
 
     protected void failedToWriteBatch(AsyncConnection<T> connection,

--- a/mantis-network/src/test/java/io/reactivex/mantis/network/push/LegacyTcpPipelineConfiguratorTest.java
+++ b/mantis-network/src/test/java/io/reactivex/mantis/network/push/LegacyTcpPipelineConfiguratorTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.mantis.network.push;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the bytes the legacy TCP outbound handler puts on the wire. The handler prepends a
+ * two-or-more byte header to every write; the change under test stopped copying the payload behind
+ * that header, so what matters is that the framing is unchanged.
+ */
+class LegacyTcpPipelineConfiguratorTest {
+
+    private static final byte PROTOCOL_VERSION = 1;
+
+    private static byte[] expectedFrame(String name, byte[] payload) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(PROTOCOL_VERSION);
+        if (name == null || name.isEmpty()) {
+            out.write(0);
+        } else {
+            out.write(name.length());
+            out.write(name.getBytes(), 0, name.getBytes().length);
+        }
+        out.write(payload, 0, payload.length);
+        return out.toByteArray();
+    }
+
+    /** Reads everything the channel has queued outbound, concatenated. */
+    private static byte[] drainOutbound(EmbeddedChannel channel) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteBuf buf;
+        while ((buf = channel.readOutbound()) != null) {
+            byte[] chunk = new byte[buf.readableBytes()];
+            buf.readBytes(chunk);
+            buf.release();
+            out.write(chunk, 0, chunk.length);
+        }
+        return out.toByteArray();
+    }
+
+    private static EmbeddedChannel channelFor(String name) {
+        EmbeddedChannel channel = new EmbeddedChannel();
+        new LegacyTcpPipelineConfigurator(name).configureNewPipeline(channel.pipeline());
+        return channel;
+    }
+
+    /**
+     * The push server now hands the handler a composite buffer rather than a {@code byte[]}. Several
+     * components must come out as one contiguous frame behind a single header.
+     */
+    @Test
+    void compositeByteBufWriteIsFramedOnceAndNotPerComponent() {
+        String name = "TestObservable";
+        byte[] payload = "aaaabbbbcccc".getBytes();
+        ByteBuf composite = Unpooled.wrappedBuffer(3,
+                "aaaa".getBytes(), "bbbb".getBytes(), "cccc".getBytes());
+        assertEquals(3, composite.nioBufferCount(), "test must write a genuine composite");
+
+        EmbeddedChannel channel = channelFor(name);
+        channel.writeOutbound(composite);
+        assertArrayEquals(expectedFrame(name, payload), drainOutbound(channel));
+        assertFalse(channel.finish());
+    }
+
+    @Test
+    void singleByteBufWriteIsFramedIdentically() {
+        String name = "TestObservable";
+        byte[] payload = "0123456789".getBytes();
+
+        EmbeddedChannel channel = channelFor(name);
+        channel.writeOutbound(Unpooled.wrappedBuffer(payload));
+        assertArrayEquals(expectedFrame(name, payload), drainOutbound(channel));
+        assertFalse(channel.finish());
+    }
+
+    /** Heartbeats still arrive as {@code byte[]} and take the other branch. */
+    @Test
+    void byteArrayWriteIsFramedIdentically() {
+        String name = "TestObservable";
+        byte[] payload = "heartbeat".getBytes();
+
+        EmbeddedChannel channel = channelFor(name);
+        channel.writeOutbound(payload);
+        assertArrayEquals(expectedFrame(name, payload), drainOutbound(channel));
+        assertFalse(channel.finish());
+    }
+
+    /** With no observable name the header is version + a zero length byte. */
+    @Test
+    void emptyNameWritesZeroLengthHeader() {
+        byte[] payload = "payload".getBytes();
+
+        for (String name : new String[] {null, ""}) {
+            EmbeddedChannel channel = channelFor(name);
+            channel.writeOutbound(Unpooled.wrappedBuffer(payload));
+            assertArrayEquals(expectedFrame(name, payload), drainOutbound(channel),
+                    "name=" + name);
+            assertFalse(channel.finish());
+        }
+    }
+}

--- a/mantis-network/src/test/java/io/reactivex/mantis/network/push/PushServerBatchWrapTest.java
+++ b/mantis-network/src/test/java/io/reactivex/mantis/network/push/PushServerBatchWrapTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.mantis.network.push;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.buffer.ByteBuf;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The push write path used to concatenate every batch into a fresh {@code byte[totalBytes]} before
+ * handing it to the channel; it now wraps the event arrays in a composite buffer instead. These
+ * tests pin the new path to the old one byte for byte.
+ *
+ * <p>The baselines below ({@code legacyBare}, {@code legacyDelimited}) are the <b>verbatim
+ * pre-change bodies</b> from {@code PushServer.startServer}, so the comparison cannot drift into
+ * testing the new code against a restatement of itself.
+ */
+class PushServerBatchWrapTest {
+
+    private static final byte[] SSE_PREFIX = "data: ".getBytes();
+    private static final byte[] SSE_SUFFIX = "\n\n".getBytes();
+
+    // ----------------------------------------------------------------------------------------
+    // Verbatim pre-change concatenation. Do not tidy this up — its value is that it is what
+    // production wrote before the change.
+    // ----------------------------------------------------------------------------------------
+
+    private static byte[] legacyBare(List<List<byte[]>> bufferOfBuffers) {
+        int totalBytes = 0;
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                totalBytes += (data.length);
+            }
+        }
+        byte[] block = new byte[totalBytes];
+        ByteBuffer blockBuffer = ByteBuffer.wrap(block);
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                blockBuffer.put(data);
+            }
+        }
+        return blockBuffer.array();
+    }
+
+    private static byte[] legacyDelimited(List<List<byte[]>> bufferOfBuffers, byte[] prefix,
+                                          byte[] nwnw) {
+        int totalBytes = 0;
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                totalBytes += (data.length + prefix.length + nwnw.length);
+            }
+        }
+        byte[] block = new byte[totalBytes];
+        ByteBuffer blockBuffer = ByteBuffer.wrap(block);
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            for (byte[] data : buffer) {
+                blockBuffer.put(prefix);
+                blockBuffer.put(data);
+                blockBuffer.put(nwnw);
+            }
+        }
+        return blockBuffer.array();
+    }
+
+    // ----------------------------------------------------------------------------------------
+
+    private static byte[] drain(ByteBuf buf) {
+        byte[] out = new byte[buf.readableBytes()];
+        buf.readBytes(out);
+        buf.release();
+        return out;
+    }
+
+    private static int countEvents(List<List<byte[]>> bufferOfBuffers) {
+        int size = 0;
+        for (List<byte[]> buffer : bufferOfBuffers) {
+            size += buffer.size();
+        }
+        return size;
+    }
+
+    /** Batch shapes worth covering: empty inner lists, empty payloads, one event, many events. */
+    private static List<List<List<byte[]>>> batchShapes() {
+        Random rnd = new Random(20260817L);
+        List<List<List<byte[]>>> shapes = new ArrayList<>();
+
+        shapes.add(Collections.singletonList(Collections.singletonList("one".getBytes())));
+        shapes.add(Collections.singletonList(Collections.<byte[]>emptyList()));
+        shapes.add(Arrays.asList(Collections.<byte[]>emptyList(),
+                Collections.singletonList("after empty".getBytes()),
+                Collections.<byte[]>emptyList()));
+        shapes.add(Collections.singletonList(Arrays.asList(new byte[0], "x".getBytes(), new byte[0])));
+
+        for (int shape = 0; shape < 12; shape++) {
+            List<List<byte[]>> batch = new ArrayList<>();
+            int inner = 1 + rnd.nextInt(6);
+            for (int i = 0; i < inner; i++) {
+                int events = rnd.nextInt(8);
+                List<byte[]> buffer = new ArrayList<>(events);
+                for (int e = 0; e < events; e++) {
+                    byte[] data = new byte[rnd.nextInt(512)];
+                    rnd.nextBytes(data);
+                    buffer.add(data);
+                }
+                batch.add(buffer);
+            }
+            shapes.add(batch);
+        }
+        return shapes;
+    }
+
+    @Test
+    void bareWrapMatchesLegacyConcatenation() {
+        for (List<List<byte[]>> batch : batchShapes()) {
+            assertArrayEquals(legacyBare(batch),
+                    drain(PushServer.wrapBare(batch, countEvents(batch))),
+                    "bare batch of " + countEvents(batch) + " events");
+        }
+    }
+
+    @Test
+    void delimitedWrapMatchesLegacyConcatenation() {
+        for (List<List<byte[]>> batch : batchShapes()) {
+            assertArrayEquals(legacyDelimited(batch, SSE_PREFIX, SSE_SUFFIX),
+                    drain(PushServer.wrapDelimited(batch, countEvents(batch), SSE_PREFIX, SSE_SUFFIX)),
+                    "delimited batch of " + countEvents(batch) + " events");
+        }
+    }
+
+    /** The compressed-SSE branch is a fixed three-part frame. */
+    @Test
+    void compressedFrameWrapMatchesLegacyConcatenation() {
+        byte[] compressed = new byte[977];
+        new Random(7L).nextBytes(compressed);
+
+        ByteBuffer legacy = ByteBuffer.allocate(SSE_PREFIX.length + compressed.length + SSE_SUFFIX.length);
+        legacy.put(SSE_PREFIX);
+        legacy.put(compressed);
+        legacy.put(SSE_SUFFIX);
+
+        assertArrayEquals(legacy.array(), drain(PushServer.wrap(SSE_PREFIX, compressed, SSE_SUFFIX)));
+    }
+
+    /**
+     * Past {@link PushServer#MAX_WRAPPED_COMPONENTS} the wrap falls back to concatenating. The
+     * fallback is the thing most likely to rot unnoticed, since it never runs in the common case,
+     * so it is asserted both to trigger and to produce the same bytes.
+     */
+    @Test
+    void oversizedBatchFallsBackToCopyWithIdenticalBytes() {
+        Random rnd = new Random(99L);
+        List<byte[]> buffer = new ArrayList<>();
+        for (int i = 0; i < PushServer.MAX_WRAPPED_COMPONENTS + 5; i++) {
+            byte[] data = new byte[1 + rnd.nextInt(4)];
+            rnd.nextBytes(data);
+            buffer.add(data);
+        }
+        List<List<byte[]>> batch = Collections.singletonList(buffer);
+        int events = countEvents(batch);
+        assertTrue(events > PushServer.MAX_WRAPPED_COMPONENTS, "test must exercise the fallback");
+
+        ByteBuf wrapped = PushServer.wrapBare(batch, events);
+        assertEquals(1, wrapped.nioBufferCount(), "oversized batch should be a single buffer");
+        assertArrayEquals(legacyBare(batch), drain(wrapped));
+
+        assertArrayEquals(legacyDelimited(batch, SSE_PREFIX, SSE_SUFFIX),
+                drain(PushServer.wrapDelimited(batch, events, SSE_PREFIX, SSE_SUFFIX)));
+    }
+
+    /**
+     * The point of the change: a normal batch is written as N components rather than copied into
+     * one array. Without an explicit component limit {@code Unpooled.wrappedBuffer} silently
+     * consolidates above 16 components, which would make the change a no-op.
+     */
+    @Test
+    void normalBatchIsNotCopiedIntoOneBuffer() {
+        List<byte[]> buffer = new ArrayList<>();
+        for (int i = 0; i < 64; i++) {
+            buffer.add(("event-" + i).getBytes());
+        }
+        List<List<byte[]>> batch = Collections.singletonList(buffer);
+
+        ByteBuf bare = PushServer.wrapBare(batch, 64);
+        assertEquals(64, bare.nioBufferCount());
+        bare.release();
+
+        ByteBuf delimited = PushServer.wrapDelimited(batch, 64, SSE_PREFIX, SSE_SUFFIX);
+        assertEquals(64 * 3, delimited.nioBufferCount());
+        delimited.release();
+    }
+}


### PR DESCRIPTION
## What

The push write path buffers events for 200ms per connection, then concatenated the whole batch into a freshly allocated `byte[totalBytes]` before handing it to the channel. This wraps the event arrays in a composite `ByteBuf` instead, so nothing is copied to make the batch contiguous.

## Why

The concatenation exists only to produce one contiguous array. The channel writes it with a gathering write regardless, so the contiguity buys nothing downstream — the copy is pure overhead. Building the batch also took two passes over `bufferOfBuffers` per connection (one to sum lengths, one to fill).

Replacing the copy with a composite trades an **O(total bytes)** memcpy for **O(component count)** bookkeeping. That is a win exactly when events are large enough that the memcpy dominates the per-component cost — see [Benchmarks](#benchmarks) for where that crossover sits and why the payloads this path carries clear it comfortably. Below the crossover it is a regression, and the PR is honest about that boundary rather than hiding it.

## How

`ChannelWriter` already exposes `writeBytesAndFlush(ByteBuf)`, and `DefaultChannelWriter` performs no copy — both the `byte[]` and `ByteBuf` overloads just call `writeOnChannel(msg)`. So `PushServer` now builds the batch as a composite:

| batch shape | before | after |
|---|---|---|
| non-SSE | `byte[totalBytes]`, all events copied in | `wrapBare` — one component per event |
| SSE, uncompressed | `byte[totalBytes]`, prefix+event+suffix copied in | `wrapDelimited` — three components per event |
| SSE, compressed | `byte[totalBytes]` around the compressed blob | `wrap(prefix, compressed, suffix)` |

Wrapping is safe: each `byte[]` comes from `encoder.call(chunk)`, freshly allocated per chunk and never reused or retained elsewhere.

**`LengthFieldPrepender` and the legacy TCP handler preserve the property.** The prepender adds a separate header buffer and retains the message rather than copying it, so the zero-copy batch survives to the socket. (`JdkZlibEncoder` necessarily copies when compression is enabled — unchanged behaviour, and it makes the wrap a no-op for compressed SSE, which is expected.)

### The legacy TCP handler gains more than the wrap

`LegacyTcpPipelineConfigurator`'s outbound handler has two branches. The `byte[]` one is commented *"handle heart beat writes"* — but until this change **all** legacy TCP data took it, because `PushServer` emitted a `byte[]`. That branch allocated an unsized `ctx.alloc().buffer()` — Netty's 256-byte default — and grew it to the full batch size: roughly **eleven doubling reallocations and two passes over the payload per batch**, on top of `PushServer`'s own concatenation.

Data now takes the `ByteBuf` branch, which prepends the header by wrapping rather than copying, and the comment is accurate for the first time. The heartbeat branch is now pre-sized too.

The explicit `bytes.release()` was dropped from that branch deliberately: `Unpooled.wrappedBuffer(ByteBuf...)` takes ownership of its components' refcounts, so releasing the composite releases the payload.

### Two traps worth flagging for review

1. **`Unpooled.wrappedBuffer(byte[]...)` defaults to `maxNumComponents = 16`** and silently *consolidates* — copies everything into a single array — once the composite exceeds it. A 30-event batch is 30 components bare and ~90 delimited, so using the varargs form without an explicit count would have made this entire change a no-op with no visible symptom. Every call site now passes the count explicitly, and `normalBatchIsNotCopiedIntoOneBuffer` asserts `nioBufferCount()` is 64 / 192 for a 64-event batch so a regression here fails loudly.

2. **`Unpooled.wrappedBuffer` returns `EMPTY_BUFFER` if any array element is null.** A pre-sized `new byte[events][]` would leave trailing nulls if a batch shrank between the counting pass and the fill pass — silent data loss. The helpers build a `List<byte[]>` and call `toArray(new byte[0][])`, which makes the event count a sizing hint only.

### `MAX_WRAPPED_COMPONENTS = 1024`

A gathering write is capped at 1024 iovecs by the JDK, so past that point a composite stops buying anything — the channel makes several write syscalls regardless, and the per-component bookkeeping costs more than the copy it was avoiding. Batches that large fall back to `copyBare`/`copyDelimited`, which produce byte-identical output. Typical batches are tens of events per 200ms window, so this is a safety valve rather than a live path. The benchmark confirms the fallback rows are within noise of legacy — it never makes a large batch materially worse.

## Retry semantics are unchanged

`writeBytesAndFlush` performs the write **eagerly, as a side effect at call time**, and returns only the `flush()` `Observable`. So `.retry(writeRetryCount)` retries the flush, never the write — identically for `byte[]` and `ByteBuf`. Worth noting separately that this makes the retry largely vacuous today; that's pre-existing and not touched here.

## Testing

`./gradlew :mantis-network:test` — green (JDK 17).

**`PushServerBatchWrapTest`** (5 tests) compares the new path against the **verbatim pre-change concatenation bodies**, copied out of `PushServer.startServer` rather than reimplemented, so the comparison cannot drift into testing the new code against a restatement of itself:

- `bareWrapMatchesLegacyConcatenation` / `delimitedWrapMatchesLegacyConcatenation` — byte equality over 16 generated batch shapes (a singleton; an empty inner list; empty-then-nonempty-then-empty; zero-length payloads; 12 random shapes of 1–6 inner lists × 0–7 events × 0–511 byte payloads, fixed seed).
- `compressedFrameWrapMatchesLegacyConcatenation` — the SSE compressed frame.
- `oversizedBatchFallsBackToCopyWithIdenticalBytes` — `MAX_WRAPPED_COMPONENTS + 5` events; asserts the fallback fired (`nioBufferCount() == 1`) *and* byte equality.
- `normalBatchIsNotCopiedIntoOneBuffer` — the 16-component consolidation guard described above.

**`LegacyTcpPipelineConfiguratorTest`** (4 tests) drives the configured pipeline through an `EmbeddedChannel` and asserts the emitted frame is exactly `[PROTOCOL_VERSION, nameLength, ...nameBytes, ...payload]` for a multi-component composite, a single `ByteBuf`, a `byte[]` heartbeat, and the null/empty-name case.

## Benchmarks

This repo had no JMH source set, so this PR adds one to `mantis-network` (`src/jmh`, `me.champeau.jmh` applied module-locally so the root build is untouched) plus `PushServerBatchWrapBenchmark`.

The baseline arm holds the **verbatim** pre-change concatenation body, copied out of the pre-change `PushServer` rather than reimplemented, so the two arms cannot drift apart under review. `@Setup` asserts both arms produce byte-for-byte identical output before anything is measured.

**Wrapping does not make bytes disappear — it moves who touches them.** Measuring construction alone would flatter it, because the channel still has to walk the finished buffer's `nioBuffers()` on the way to a gathering write. So each path has a `...Gathered` arm that also does that walk; the honest number is the `...Gathered` arm, not the construction-only one.

JDK 17.0.17-zulu, `@Fork(1)`, 5×1s warmup, 5×1s measurement, `Mode.AverageTime`, µs/op, `-t 1`:

### Bare (non-SSE), 30 events/batch

| bytes/event | legacy (verbatim) | this PR (+gather) | result |
|---:|---:|---:|:---|
| 128 | 0.195 | 0.562 | 2.9× slower |
| 256 | 0.280 | 0.564 | 2.0× slower |
| 512 | 0.517 | 0.565 | ~even |
| 1024 | 0.907 | 0.573 | 1.6× faster |
| 2048 | 1.586 | 0.568 | 2.8× faster |
| 4096 | 3.371 | 0.567 | 5.9× faster |
| 16384 | 12.597 | 0.568 | **22× faster** |

### Delimited (SSE, uncompressed), 30 events/batch

| bytes/event | legacy (verbatim) | this PR (+gather) | result |
|---:|---:|---:|:---|
| 128 | 0.341 | 1.916 | 5.6× slower |
| 256 | 0.410 | 1.858 | 4.5× slower |
| 512 | 0.621 | 1.920 | 3.1× slower |
| 1024 | 0.907 | 1.810 | 2.0× slower |
| 2048 | 1.913 | 1.966 | ~even |
| 4096 | 3.535 | 1.933 | 1.8× faster |
| 16384 | 12.520 | 1.935 | 6.5× faster |

Read this honestly:

- **The effect changes sign on bytes-per-event, not on event count.** Legacy cost is O(total bytes) — the memcpy — and scales linearly with payload size. The wrap arm is dead flat in payload size (0.56 µs bare from 128 B to 16 KB) because its cost is O(component count). The 200-event rows have the identical shape, just scaled up.
- **Measured crossover: ~575 B/event bare, ~2 KB/event delimited.** Below that the composite bookkeeping and the `nioBuffers()` gather cost more than the copy they replace, and this is a regression. Delimited pays three components per event, so its crossover is higher.
- The `events ≥ 1024` fallback rows (not shown) are within noise of legacy — the safety valve does not make large batches worse.
- These are single-threaded construction numbers with no allocator pressure. The eliminated `byte[totalBytes]` allocation (one per batch per connection) is not modelled here; under real allocation and GC pressure the win at large payloads is a lower bound.

### Where the payloads actually sit

Whether this PR is net-positive depends entirely on real payload size, so I measured it — **from Atlas metrics, not profiling**: per-`mantisJobName`, `tcpServer_..._bytesWritten` (wire bytes/s) ÷ `PushServer_numSuccessfulWrites` (events/s), us-east-1, 6h window:

| representative job | bytes/event |
|---|---:|
| every significant push source | ~5 KB – 22 KB |
| fleet weighted mean | ~10.5 KB |

Every job that moves meaningful push volume sits well above both crossovers, in the region where the bare path wins 3–22× and the delimited path 1.8–6.5×. Caveat: `bytesWritten` is post-framing, post-compression wire bytes, so for compressed SSE the pre-compression payload the wrap actually sees is larger still — but compression also defeats the wrap (the zlib encoder copies), so the relevant jobs for this change are the uncompressed ones.

## Not addressed here

Two adjacent findings from the same measurement pass, deliberately out of scope:

- Push batches that are fully built and then dropped at the writability check (`processedWrites.increment` fires before the check, so that work is performed then discarded). This change makes each such batch cheaper to build but does not stop it being dropped.
- One 200ms `OperatorBufferWithTime` timer per connection, many of them near-idle.

Both are cheaper per batch after this change but neither goes away.
