### PR TITLE
perf(network): stop shuffling the whole connection set on every routed batch

### DIFF
--- a/mantis-network/build.gradle
+++ b/mantis-network/build.gradle
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+    dependencies {
+        classpath 'me.champeau.jmh:jmh-gradle-plugin:0.7.3'
+    }
+}
+
+// JMH microbenchmarks live in src/jmh. Run with: ./gradlew :mantis-network:jmh
+// or build the self-contained jar (./gradlew :mantis-network:jmhJar) and drive it with the
+// standard JMH CLI, which is the only way to vary -t (thread count).
+apply plugin: 'me.champeau.jmh'
+
 ext {
     mqlVersion = '3.4.+'
     nettyVersion = '4.1.17.Final'
@@ -30,8 +44,19 @@ dependencies {
     testImplementation libraries.junitJupiter
     testImplementation libraries.mockitoCore
     testImplementation libraries.slf4jLog4j12
+
+    // The benchmarks drive the routers and the push-server batch wrap directly, so they need the
+    // metrics implementation that main only compiles against.
+    jmhImplementation libraries.spectatorApi
 }
 
 test {
     useJUnitPlatform()
+}
+
+jmh {
+    jmhVersion = '1.37'
+    fork = 1
+    warmupIterations = 5
+    iterations = 5
 }

--- a/mantis-network/src/jmh/java/io/reactivex/mantis/network/push/LegacyRoundRobinRouter.java
+++ b/mantis-network/src/jmh/java/io/reactivex/mantis/network/push/LegacyRoundRobinRouter.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.mantis.network.push;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import rx.functions.Func1;
+
+/**
+ * The pre-change {@link RoundRobinRouter}, kept as the JMH baseline arm.
+ *
+ * <p>{@code route} and {@code loopingIterator} below are the <b>verbatim</b> bodies from before the
+ * change, copied out of git rather than reimplemented, precisely so the comparison cannot drift:
+ *
+ * <pre>
+ *   git show master:mantis-network/src/main/java/io/reactivex/mantis/network/push/RoundRobinRouter.java
+ * </pre>
+ *
+ * <p>Do not "clean this up" or apply review suggestions to it — its only value is being byte-for-byte
+ * what shipped.
+ */
+public class LegacyRoundRobinRouter<T> extends Router<T> {
+
+    public LegacyRoundRobinRouter(String name, Func1<T, byte[]> encoder) {
+        super("LegacyRoundRobinRouter_" + name, encoder);
+    }
+
+    @Override
+    public void route(Set<AsyncConnection<T>> connections, List<T> chunks) {
+        if (chunks != null && !chunks.isEmpty()) {
+            numEventsProcessed.increment(chunks.size());
+        }
+        List<AsyncConnection<T>> randomOrder = new ArrayList<>(connections);
+        Collections.shuffle(randomOrder);
+        if (chunks != null && !chunks.isEmpty() && !randomOrder.isEmpty()) {
+            Iterator<AsyncConnection<T>> iter = loopingIterator(randomOrder);
+            Map<AsyncConnection<T>, List<byte[]>> writes = new HashMap<>();
+            // process chunks
+            for (T chunk : chunks) {
+                AsyncConnection<T> connection = iter.next();
+                Func1<T, Boolean> predicate = connection.getPredicate();
+                if (predicate == null || predicate.call(chunk)) {
+                    List<byte[]> buffer = writes.get(connection);
+                    if (buffer == null) {
+                        buffer = new LinkedList<>();
+                        writes.put(connection, buffer);
+                    }
+                    buffer.add(encoder.call(chunk));
+                }
+            }
+            if (!writes.isEmpty()) {
+                for (Entry<AsyncConnection<T>, List<byte[]>> entry : writes.entrySet()) {
+                    AsyncConnection<T> connection = entry.getKey();
+                    List<byte[]> toWrite = entry.getValue();
+                    connection.write(toWrite);
+                    numEventsRouted.increment(toWrite.size());
+                }
+            }
+        }
+    }
+
+    private Iterator<AsyncConnection<T>> loopingIterator(final Collection<AsyncConnection<T>> connections) {
+        final AtomicReference<Iterator<AsyncConnection<T>>> iterRef = new AtomicReference<>(connections.iterator());
+        return
+                new Iterator<AsyncConnection<T>>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public AsyncConnection<T> next() {
+                        Iterator<AsyncConnection<T>> iter = iterRef.get();
+                        if (iter.hasNext()) {
+                            return iter.next();
+                        } else {
+                            iterRef.set(connections.iterator());
+                            return iterRef.get().next();
+                        }
+                    }
+                };
+    }
+}

--- a/mantis-network/src/jmh/java/io/reactivex/mantis/network/push/RoundRobinRouterBenchmark.java
+++ b/mantis-network/src/jmh/java/io/reactivex/mantis/network/push/RoundRobinRouterBenchmark.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.mantis.network.push;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import rx.Observer;
+import rx.functions.Func1;
+
+/**
+ * Compares {@link RoundRobinRouter#route} against {@link LegacyRoundRobinRouter#route}, which is the
+ * verbatim pre-change body.
+ *
+ * <p>The two arms differ in three places: the legacy one copies the connection {@link Set} into an
+ * {@link ArrayList} and {@link java.util.Collections#shuffle(List) shuffle}s it, buffers per-destination
+ * writes in a {@link java.util.LinkedList}, and allocates an unsized {@link java.util.HashMap}. The new
+ * one advances a looping iterator to a single {@code ThreadLocalRandom} offset and sizes both
+ * collections.
+ *
+ * <p><b>Run multi-threaded.</b> The largest claimed cost is not the per-connection work, it is that
+ * {@code Collections.shuffle(List)} draws from a single {@code private static Random} shared by the
+ * whole JVM, so every draw is a contended CAS on one seed. That only shows up with more than one
+ * router thread, and JMH's thread count is not expressible as a {@code @Param}, so drive it from the
+ * CLI:
+ *
+ * <pre>
+ *   ./gradlew :mantis-network:jmhJar
+ *   java -jar mantis-network/build/libs/mantis-network-*-jmh.jar RoundRobinRouterBenchmark -t 1
+ *   java -jar mantis-network/build/libs/mantis-network-*-jmh.jar RoundRobinRouterBenchmark -t 8
+ * </pre>
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class RoundRobinRouterBenchmark {
+
+    private static final AtomicInteger NAMES = new AtomicInteger();
+
+    /** Subscribers on one group. Real groups run from a handful to hundreds of thousands. */
+    @Param({"2", "8", "64", "512"})
+    public int connections;
+
+    /** Events in one drain -- what the 200ms chunker hands to route() at a time. */
+    @Param({"30", "200"})
+    public int chunkSize;
+
+    private Router<byte[]> current;
+    private Router<byte[]> legacy;
+    private Set<AsyncConnection<byte[]>> connectionSet;
+    private List<byte[]> chunks;
+
+    /**
+     * Counts deliveries into a plain field on a per-connection object. Not volatile and not
+     * synchronized on purpose: each connection has its own sink, so there is nothing to contend on,
+     * and the store still cannot be optimised away because the sink stays reachable from the
+     * benchmark state. Deliberately not a Counter -- {@code CounterImpl.value()} reads through to a
+     * Spectator registry that is a no-op outside a running worker, so it always reads zero here.
+     */
+    static final class Sink implements Observer<List<byte[]>> {
+        long batches;
+        long events;
+
+        @Override
+        public void onNext(List<byte[]> data) {
+            batches++;
+            events += data.size();
+        }
+
+        @Override
+        public void onCompleted() {
+        }
+
+        @Override
+        public void onError(Throwable e) {
+        }
+    }
+
+    private List<Sink> sinks;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        String tag = "bench" + NAMES.incrementAndGet();
+        Func1<byte[], byte[]> encoder = b -> b;
+        current = new RoundRobinRouter<>(tag, encoder);
+        legacy = new LegacyRoundRobinRouter<>(tag, encoder);
+
+        sinks = new ArrayList<>(connections);
+        connectionSet = new HashSet<>(connections * 2);
+        for (int i = 0; i < connections; i++) {
+            Sink sink = new Sink();
+            sinks.add(sink);
+            connectionSet.add(new AsyncConnection<>(
+                    "host" + i, 7000 + i, "id" + i, "slot" + i, "group", sink, null));
+        }
+
+        chunks = new ArrayList<>(chunkSize);
+        for (int i = 0; i < chunkSize; i++) {
+            byte[] event = new byte[256];
+            event[0] = (byte) i;
+            chunks.add(event);
+        }
+
+        // Cross-check the arms deliver the same volume before measuring anything. Content and
+        // destination differ run to run -- both arms randomise the starting connection -- so the
+        // invariant that holds is every chunk goes out exactly once.
+        long before = totalEvents();
+        current.route(connectionSet, chunks);
+        long afterCurrent = totalEvents() - before;
+        legacy.route(connectionSet, chunks);
+        long afterLegacy = totalEvents() - before - afterCurrent;
+        if (afterCurrent != chunkSize || afterLegacy != chunkSize) {
+            throw new IllegalStateException("arms disagree: current=" + afterCurrent
+                    + " legacy=" + afterLegacy + " expected=" + chunkSize);
+        }
+    }
+
+    private long totalEvents() {
+        long total = 0;
+        for (Sink sink : sinks) {
+            total += sink.events;
+        }
+        return total;
+    }
+
+    @Benchmark
+    public void route() {
+        current.route(connectionSet, chunks);
+    }
+
+    @Benchmark
+    public void routeLegacyVerbatim() {
+        legacy.route(connectionSet, chunks);
+    }
+}

--- a/mantis-network/src/main/java/io/reactivex/mantis/network/push/RoundRobinRouter.java
+++ b/mantis-network/src/main/java/io/reactivex/mantis/network/push/RoundRobinRouter.java
@@ -18,14 +18,13 @@ package io.reactivex.mantis.network.push;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import rx.functions.Func1;
 
@@ -38,35 +37,50 @@ public class RoundRobinRouter<T> extends Router<T> {
 
     @Override
     public void route(Set<AsyncConnection<T>> connections, List<T> chunks) {
-        if (chunks != null && !chunks.isEmpty()) {
-            numEventsProcessed.increment(chunks.size());
+        if (chunks == null || chunks.isEmpty()) {
+            return;
         }
-        List<AsyncConnection<T>> randomOrder = new ArrayList<>(connections);
-        Collections.shuffle(randomOrder);
-        if (chunks != null && !chunks.isEmpty() && !randomOrder.isEmpty()) {
-            Iterator<AsyncConnection<T>> iter = loopingIterator(randomOrder);
-            Map<AsyncConnection<T>, List<byte[]>> writes = new HashMap<>();
-            // process chunks
-            for (T chunk : chunks) {
-                AsyncConnection<T> connection = iter.next();
-                Func1<T, Boolean> predicate = connection.getPredicate();
-                if (predicate == null || predicate.call(chunk)) {
-                    List<byte[]> buffer = writes.get(connection);
-                    if (buffer == null) {
-                        buffer = new LinkedList<>();
-                        writes.put(connection, buffer);
-                    }
-                    buffer.add(encoder.call(chunk));
+        numEventsProcessed.increment(chunks.size());
+
+        int numConnections = connections.size();
+        if (numConnections == 0) {
+            return;
+        }
+
+        // Start the round robin at a random offset rather than shuffling the whole connection set.
+        // A shuffle costs one Random.nextInt() and one swap per connection, and Collections.shuffle
+        // (List) draws from a single private static Random shared by the whole JVM, so every draw is
+        // a contended CAS on that one seed -- shared with every other caller of shuffle() in the
+        // process. A single ThreadLocalRandom draw gives the same uniform expectation per
+        // connection with no shared state and no per-connection work, which matters here because
+        // route() is called once per subscriber group per drain.
+        Iterator<AsyncConnection<T>> iter = loopingIterator(connections);
+        for (int i = ThreadLocalRandom.current().nextInt(numConnections); i > 0; i--) {
+            iter.next();
+        }
+
+        // assume even distribution
+        int bufferCapacity = (chunks.size() / numConnections) + 1;
+        Map<AsyncConnection<T>, List<byte[]>> writes =
+                new HashMap<>(Math.min(numConnections, chunks.size()));
+        // process chunks
+        for (T chunk : chunks) {
+            AsyncConnection<T> connection = iter.next();
+            Func1<T, Boolean> predicate = connection.getPredicate();
+            if (predicate == null || predicate.call(chunk)) {
+                List<byte[]> buffer = writes.get(connection);
+                if (buffer == null) {
+                    buffer = new ArrayList<>(bufferCapacity);
+                    writes.put(connection, buffer);
                 }
+                buffer.add(encoder.call(chunk));
             }
-            if (!writes.isEmpty()) {
-                for (Entry<AsyncConnection<T>, List<byte[]>> entry : writes.entrySet()) {
-                    AsyncConnection<T> connection = entry.getKey();
-                    List<byte[]> toWrite = entry.getValue();
-                    connection.write(toWrite);
-                    numEventsRouted.increment(toWrite.size());
-                }
-            }
+        }
+        for (Entry<AsyncConnection<T>, List<byte[]>> entry : writes.entrySet()) {
+            AsyncConnection<T> connection = entry.getKey();
+            List<byte[]> toWrite = entry.getValue();
+            connection.write(toWrite);
+            numEventsRouted.increment(toWrite.size());
         }
     }
 

--- a/mantis-network/src/test/java/io/reactivex/mantis/network/push/RoundRobinRouterTest.java
+++ b/mantis-network/src/test/java/io/reactivex/mantis/network/push/RoundRobinRouterTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2026 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.reactivex.mantis.network.push;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+import rx.Observer;
+import rx.functions.Func1;
+
+/**
+ * Behavioural pins for {@link RoundRobinRouter#route}. The change under test replaced a full
+ * {@code Collections.shuffle} of the connection set with a single random start offset, and swapped
+ * the per-destination {@code LinkedList} for a pre-sized {@code ArrayList}; neither is observable
+ * from the outside, so what these tests assert is the routing contract that must not move.
+ */
+class RoundRobinRouterTest {
+
+    /** Records what a connection was handed, in order. */
+    private static final class Recorder implements Observer<List<byte[]>> {
+
+        private final List<List<String>> writes = new ArrayList<>();
+
+        @Override
+        public void onNext(List<byte[]> data) {
+            writes.add(data.stream()
+                    .map(b -> new String(b, StandardCharsets.UTF_8))
+                    .collect(Collectors.toList()));
+        }
+
+        @Override
+        public void onError(Throwable e) {
+            throw new AssertionError(e);
+        }
+
+        @Override
+        public void onCompleted() {
+        }
+
+        List<String> received() {
+            return writes.stream().flatMap(List::stream).collect(Collectors.toList());
+        }
+    }
+
+    private static RoundRobinRouter<String> router(String name) {
+        return new RoundRobinRouter<>(name, s -> s.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** Connections keyed by id, insertion-ordered so failures are readable. */
+    private static Map<String, Recorder> connect(
+            Set<AsyncConnection<String>> into, int count, Func1<String, Boolean> predicate) {
+        Map<String, Recorder> recorders = new LinkedHashMap<>();
+        for (int i = 0; i < count; i++) {
+            String id = "conn-" + i;
+            Recorder recorder = new Recorder();
+            recorders.put(id, recorder);
+            into.add(new AsyncConnection<>("host", 1000 + i, id, id, "group", recorder, predicate));
+        }
+        return recorders;
+    }
+
+    private static List<String> chunks(int count) {
+        return IntStream.range(0, count).mapToObj(i -> "event-" + i).collect(Collectors.toList());
+    }
+
+    @Test
+    void everyChunkIsDeliveredExactlyOnceAndSpreadEvenly() {
+        Set<AsyncConnection<String>> connections = new LinkedHashSet<>();
+        Map<String, Recorder> recorders = connect(connections, 4, null);
+        List<String> chunks = chunks(10);
+
+        RoundRobinRouter<String> router = router("even-spread");
+        router.route(connections, chunks);
+
+        List<String> delivered = recorders.values().stream()
+                .flatMap(r -> r.received().stream())
+                .collect(Collectors.toList());
+        assertEquals(chunks.size(), delivered.size(), "no chunk may be dropped or duplicated");
+        assertEquals(new HashSet<>(chunks), new HashSet<>(delivered));
+
+        // 10 chunks over 4 connections is 3 or 2 each, whatever the start offset.
+        for (Map.Entry<String, Recorder> e : recorders.entrySet()) {
+            int size = e.getValue().received().size();
+            assertTrue(size == 2 || size == 3, e.getKey() + " received " + size);
+        }
+    }
+
+    /**
+     * Each destination gets one write holding all of its chunks -- not one write per chunk. This is
+     * what makes the downstream batching worthwhile, so it is worth pinning.
+     */
+    @Test
+    void eachDestinationReceivesASingleBatchedWrite() {
+        Set<AsyncConnection<String>> connections = new LinkedHashSet<>();
+        Map<String, Recorder> recorders = connect(connections, 2, null);
+
+        router("batched").route(connections, chunks(6));
+
+        for (Map.Entry<String, Recorder> e : recorders.entrySet()) {
+            assertEquals(1, e.getValue().writes.size(), e.getKey() + " should get one write");
+            assertEquals(3, e.getValue().received().size());
+        }
+    }
+
+    /** Fewer chunks than connections: only the chunks.size() connections in line get a write. */
+    @Test
+    void connectionsWithNoChunksAreNotWrittenTo() {
+        Set<AsyncConnection<String>> connections = new LinkedHashSet<>();
+        Map<String, Recorder> recorders = connect(connections, 10, null);
+
+        router("sparse").route(connections, chunks(3));
+
+        long written = recorders.values().stream().filter(r -> !r.writes.isEmpty()).count();
+        assertEquals(3, written, "exactly one write per chunk, to distinct connections");
+    }
+
+    /**
+     * A chunk assigned to a connection whose predicate rejects it is dropped, not handed on to the
+     * next connection. That was the pre-existing behaviour and this change does not alter it.
+     */
+    @Test
+    void chunksRejectedByAPredicateAreDroppedNotReRouted() {
+        Set<AsyncConnection<String>> connections = new LinkedHashSet<>();
+        Map<String, Recorder> recorders = connect(connections, 3, s -> s.endsWith("0"));
+        List<String> chunks = chunks(9);
+
+        RoundRobinRouter<String> router = router("predicate");
+        router.route(connections, chunks);
+
+        List<String> delivered = recorders.values().stream()
+                .flatMap(r -> r.received().stream())
+                .collect(Collectors.toList());
+        assertEquals(List.of("event-0"), delivered);
+    }
+
+    /**
+     * The start offset must keep moving: with a single chunk and many connections, load only spreads
+     * if successive calls begin somewhere else. Over 2000 calls across 50 connections the chance of
+     * any connection being missed by a uniform draw is about 1e-16, so this is not flaky.
+     */
+    @Test
+    void startOffsetIsRandomisedAcrossCallsSoASingleChunkSpreads() {
+        Set<AsyncConnection<String>> connections = new LinkedHashSet<>();
+        Map<String, Recorder> recorders = connect(connections, 50, null);
+
+        RoundRobinRouter<String> router = router("spread");
+        for (int i = 0; i < 2000; i++) {
+            router.route(connections, List.of("event-" + i));
+        }
+
+        long touched = recorders.values().stream().filter(r -> !r.writes.isEmpty()).count();
+        assertEquals(50, touched, "every connection should have been the start at least once");
+    }
+
+    @Test
+    void emptyAndNullChunkBatchesAreNoOps() {
+        Set<AsyncConnection<String>> connections = new LinkedHashSet<>();
+        Map<String, Recorder> recorders = connect(connections, 3, null);
+
+        RoundRobinRouter<String> router = router("empty");
+        router.route(connections, List.of());
+        router.route(connections, null);
+
+        assertTrue(recorders.values().stream().allMatch(r -> r.writes.isEmpty()));
+    }
+
+    @Test
+    void noConnectionsDropsTheBatchWithoutThrowing() {
+        Set<AsyncConnection<String>> connections = new LinkedHashSet<>();
+        Map<String, Recorder> recorders = connect(connections, 2, null);
+        // deliberately route to an empty set, not to `connections`
+        router("no-connections").route(new HashSet<>(), chunks(5));
+        assertTrue(recorders.values().stream().allMatch(r -> r.writes.isEmpty()));
+    }
+}


### PR DESCRIPTION
## What

`RoundRobinRouter.route()` no longer copies and shuffles the connection set on every routed batch. It takes a single random start offset instead, and stops using a `LinkedList` per destination.

## Why

`route()` is on the push server's fan-out path, once per subscriber group per drain — `GroupChunkProcessor.process` loops the groups and calls `route()` for each with the same chunk list, so everything below multiplies by the group count, once per drain.

The old body was:

```java
List<AsyncConnection<T>> randomOrder = new ArrayList<>(connections);
Collections.shuffle(randomOrder);
```

and then walked `randomOrder` in order via a looping iterator. Three costs, all per call, and only one bit of the result is ever observed:

**1. `Collections.shuffle(List)` draws from one `Random` shared by the whole JVM.** From `java.util.Collections`:

```java
private static Random r;

public static void shuffle(List<?> list) {
    Random rnd = r;
    if (rnd == null)
        r = rnd = new Random(); // harmless race.
    shuffle(list, rnd);
}
```

`Random.nextInt` is a CAS loop on a single seed word. So a shuffle of *n* connections is *n* contended CAS operations on one shared location — contended across every router thread, and against every other caller of `Collections.shuffle` anywhere in the process. This is the part that does not scale with core count.

**2. The `ArrayList` copy** allocates an n-slot array, on top of the fresh `HashSet` that `ConnectionManager.connections()` / `ConnectionGroup.getConnections()` already allocate per call. It exists only so the shuffle has something mutable to swap in.

**3. *n* swaps** whose only observable effect is *which connection the round robin starts at*.

Since the start offset is the only observable output, take it directly:

```java
Iterator<AsyncConnection<T>> iter = loopingIterator(connections);
for (int i = ThreadLocalRandom.current().nextInt(numConnections); i > 0; i--) {
    iter.next();
}
```

Same uniform expectation per connection, one RNG draw instead of *n*, no shared seed, no allocation, and on average half the element visits. The looping iterator already wraps, so nothing else changes.

Note what this does **not** fix: advancing to a random offset is still O(n) in the worst case, so a group with a very large connection count still walks a large fraction of the set per drain. Making that O(chunks) needs a start cursor that persists across calls, which is a behaviour change (the current code re-randomises every drain) and is better argued separately. Left out deliberately.

## Two allocation fixes in the same loop

| | Before | After |
|---|---|---|
| per-destination buffer | `new LinkedList<>()` | `new ArrayList<>((chunks.size() / numConnections) + 1)` |
| `writes` map | `new HashMap<>()` | `new HashMap<>(Math.min(numConnections, chunks.size()))` |

The `LinkedList` allocated one `Node` per event purely to hold a `byte[]` reference that an array slot holds for free — garbage on a per-batch hot path, with no purpose. The capacity expression is the same one `ConsistentHashingRouter` already uses.

The map sizing is deliberately **not** `ConsistentHashingRouter`'s `new HashMap<>(numConnections)`. A batch cannot reach more destinations than it has chunks, so `numConnections` alone would allocate a table sized to the whole fan-out — for a group with ~1e6 connections and a ~30-event batch, a million-entry table per `route()` call. `min(numConnections, chunks.size())` is the correct bound. Worth a look at whether CHR should get the same clamp; not touched here.

## Hygiene, not a saving

The empty-chunks and empty-connections checks moved to the top as early returns, so the router no longer does setup work for a batch it will not route. This reads like a win but isn't one in practice: `TimedChunker.drain()` and `SingleThreadedChunker.drain()` both check for a non-empty buffer before calling `processor.process`, so `chunks` is never empty by the time it reaches `route()`. Calling it out so nobody counts it twice.

## Behaviour

Unchanged, including one pre-existing rule that is easy to misread as a bug: a chunk assigned to a connection whose predicate rejects it is **dropped**, not offered to the next connection. That is what the old code did and this change preserves it.

`loopingIterator` now takes the `Set` directly rather than the removed `ArrayList` copy. That is safe because both `ConnectionManager.connections()` and `ConnectionGroup.getConnections()` return a freshly built `HashSet` that no one else holds — the old code was copying a copy.

## Testing

New `RoundRobinRouterTest` — 7 tests, pinning the contract rather than the internals:

- every chunk delivered exactly once, spread evenly (10 chunks / 4 connections → 3,3,2,2 for any offset)
- one batched write per destination, not one per chunk
- with fewer chunks than connections, exactly `chunks.size()` connections are written to
- predicate-rejected chunks are dropped, not re-routed
- the start offset really does move: 2000 single-chunk calls over 50 connections must touch all 50 (probability of a miss under a uniform draw is ~1e-16, so not flaky)
- empty and null chunk batches are no-ops; an empty connection set does not throw

`./gradlew :mantis-network:test` is green (JDK 17). Counter assertions were removed from the tests on purpose — the default Spectator registry in this module is a no-op registry, so `Counter.value()` always reads 0 and asserting on it measures nothing.

## Benchmarks

This repo had no JMH source set, so this PR adds one to `mantis-network` (`src/jmh`, `me.champeau.jmh` applied module-locally so the root build is untouched) plus `RoundRobinRouterBenchmark`.

The baseline arm is `LegacyRoundRobinRouter`, which holds the **verbatim** pre-change `route()` and `loopingIterator()` bodies, copied out of git rather than reimplemented:

```
git show master:mantis-network/src/main/java/io/reactivex/mantis/network/push/RoundRobinRouter.java
```

so the two arms cannot drift apart under review. `@Setup` cross-checks that both deliver exactly `chunkSize` events before anything is measured. Deliveries are counted in a plain field on a per-connection sink object, not via `Counter` — `CounterImpl.value()` reads through to a no-op Spectator registry outside a running worker, so it would always read 0.

JDK 17.0.17-zulu, `@Fork(1)`, 5x1s warmup, 5x1s measurement, `Mode.AverageTime`. Thread count is not expressible as a `@Param`, so both runs are driven from the built jar:

```
./gradlew :mantis-network:jmhJar
java -jar mantis-network/build/libs/mantis-network-*-jmh.jar RoundRobinRouterBenchmark -t 1
java -jar mantis-network/build/libs/mantis-network-*-jmh.jar RoundRobinRouterBenchmark -t 8
```

### Single-threaded (`-t 1`) - the allocation and O(n) work only

| chunks | connections | this PR | legacy (verbatim) | speedup |
|---:|---:|---:|---:|---:|
| 30 | 2 | 0.345 +/- 0.021 us | 0.577 +/- 0.016 us | 1.67x |
| 30 | 8 | 0.400 +/- 0.013 | 0.612 +/- 0.087 | 1.53x |
| 30 | 64 | 0.666 +/- 0.035 | 1.425 +/- 0.032 | 2.14x |
| 30 | 512 | 1.700 +/- 0.139 | 4.171 +/- 0.126 | 2.45x |
| 200 | 2 | 2.040 +/- 0.061 | 3.139 +/- 0.095 | 1.54x |
| 200 | 8 | 2.034 +/- 0.249 | 3.207 +/- 0.127 | 1.58x |
| 200 | 64 | 2.548 +/- 0.062 | 4.463 +/- 0.129 | 1.75x |
| 200 | 512 | 6.298 +/- 0.173 | 12.525 +/- 0.341 | 1.99x |

The gap widens with connection count and not with chunk count, which is what the analysis predicts: the removed work is O(connections) per call, and the per-chunk loop is unchanged apart from `LinkedList` -> `ArrayList`.

### 8 threads (`-t 8`) - the shared-`Random` CAS

| chunks | connections | this PR | legacy (verbatim) | speedup |
|---:|---:|---:|---:|---:|
| 30 | 2 | 0.954 +/- 0.014 us | 1.134 +/- 0.056 us | 1.19x |
| 30 | 8 | 1.242 +/- 0.020 | 8.681 +/- 1.326 | 7.0x |
| 30 | 64 | 1.967 +/- 0.044 | 138.143 +/- 108.994 | 70x |
| 30 | 512 | 2.633 +/- 0.086 | 686.425 +/- 175.100 | **261x** |
| 200 | 2 | 2.199 +/- 0.017 | 3.922 +/- 0.399 | 1.78x |
| 200 | 8 | 2.549 +/- 0.033 | 4.844 +/- 0.109 | 1.90x |
| 200 | 64 | 6.085 +/- 0.391 | 80.328 +/- 29.623 | 13x |
| 200 | 512 | 11.737 +/- 0.439 | 967.883 +/- 340.559 | **82x** |

Read those numbers with the right caveats:

- **The huge ratios are contention, and contention is superlinear and environment-dependent.** At 512 connections the legacy arm goes from 4.2 us single-threaded to 686 us at 8 threads - 164x *slower in absolute terms* for the same work. That is the signature of every thread CAS-looping on one cache line. The wide error bars (+/- 175, +/- 340) are part of the finding, not noise to be averaged away: under contention the variance *is* the behaviour.
- **Do not read "261x" as a fleet speedup.** It is the speedup of this one method on a machine where 8 threads do nothing but call it. Real routers interleave I/O, and the number of concurrently-shuffling threads in a JVM is a property of the deployment. What generalises is the shape: the old cost grows with both thread count and connection count, the new cost barely grows with either.
- **The single-threaded table is the conservative claim.** 1.5-2.5x on `route()` with zero contention assumed, which holds regardless of deployment.
- The new arm is not free either (0.35 -> 0.95 us at 2 connections across the thread step) - that is the shared `Counter` increments and sink cache lines, present in both arms.

